### PR TITLE
Fix row className in Inferno

### DIFF
--- a/inferno-v0.7.13/src/controller.jsx
+++ b/inferno-v0.7.13/src/controller.jsx
@@ -127,7 +127,7 @@ export class Controller extends Component{
     }
     render () {
         var rows = this.state.store.data.map((d,i) => {
-            var className = d.id === this.state.store.selected ? 'danger':'x';
+            var className = d.id === this.state.store.selected ? 'danger':'';
             return <Row key={d.id} data={d} onClick={this.select} onDelete={this.delete} styleClass={className}></Row>
         });
         return (<div className="container">


### PR DESCRIPTION
Other implementations[1] doesn't have `className="x"`, probably a typo

[1] https://github.com/krausest/js-framework-benchmark/blob/8daa626de88b9a6fa49acfd10060e5f7a44cdf22/react-v15.2.0/src/Main.jsx#L91