### PR TITLE
add domvm-v2.0.0-beta

### DIFF
--- a/domvm-v2.0.0-beta/index.html
+++ b/domvm-v2.0.0-beta/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>domvm v2.0.0-beta</title>
+  <link href="../css/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet"/>
+  <link href="../css/main.css" rel="stylesheet"/>
+</head>
+<body>
+  <script src='node_modules/domvm/dist/nano/domvm.nano.min.js'></script>
+  <script src='src/store.js'></script>
+  <script src='src/main.js'></script>
+</body>
+</html>

--- a/domvm-v2.0.0-beta/package.json
+++ b/domvm-v2.0.0-beta/package.json
@@ -3,6 +3,6 @@
   "version": "2.0.0-beta",
   "description": "Benchmark for Domvm framework",
   "dependencies": {
-    "domvm": "git://github.com/leeoniya/domvm.git#58fd6d1afd2cadbbd5e098a2e3c655a8b9bf9b51"
+    "domvm": "git://github.com/leeoniya/domvm.git#d8bf362a9f693c321286a07f4d6704a4971f4284"
   }
 }

--- a/domvm-v2.0.0-beta/package.json
+++ b/domvm-v2.0.0-beta/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "js-framework-benchmark-domvm",
+  "version": "2.0.0-beta",
+  "description": "Benchmark for Domvm framework",
+  "dependencies": {
+    "domvm": "git://github.com/leeoniya/domvm.git#58fd6d1afd2cadbbd5e098a2e3c655a8b9bf9b51"
+  }
+}

--- a/domvm-v2.0.0-beta/src/main.js
+++ b/domvm-v2.0.0-beta/src/main.js
@@ -1,0 +1,116 @@
+'use strict';
+
+var startTime;
+var lastMeasure;
+var startMeasure = function(name) {
+	startTime = performance.now();
+	lastMeasure = name;
+}
+var stopMeasure = function() {
+	var last = lastMeasure;
+	if (lastMeasure) {
+		window.setTimeout(function () {
+			lastMeasure = null;
+			var stop = performance.now();
+			var duration = 0;
+			console.log(last+" took "+(stop-startTime));
+		}, 0);
+	}
+}
+
+var h  = (tag, arg1, arg2) => domvm.defineElement(tag, arg1, arg2, domvm.FAST_REMOVE | domvm.FIXED_BODY),
+	h2 = (tag, arg1, arg2) => domvm.defineElement(tag, arg1, arg2, domvm.FAST_REMOVE);
+
+let wrapMeasure = (store, name) => e => {
+	startMeasure(name);
+	store[name]();
+	vm.redraw();
+	stopMeasure(name);
+};
+
+let store = new Store();
+
+let vm = domvm.createView(View, store).mount(document.body);
+
+function View(vm, store) {
+	let run			= wrapMeasure(store, "run");
+	let runLots		= wrapMeasure(store, "runLots");
+	let add			= wrapMeasure(store, "add");
+	let update		= wrapMeasure(store, "update");
+	let clear		= wrapMeasure(store, "clear");
+	let swapRows	= wrapMeasure(store, "swapRows");
+
+	let select = (e, node) => {
+		startMeasure("select");
+		store.select(node.data);
+		vm.redraw(true);		// sync redraw
+		stopMeasure("select");
+		return false;
+	};
+
+	let remove = (e, node) => {
+		startMeasure("delete");
+		store.delete(node.data == null ? node.parent.data : node.data);
+		vm.redraw(true);
+		stopMeasure("delete");
+		return false;
+	};
+
+	// delegated handler
+	let tableClick = {
+		".remove, .remove *": remove,
+		".lbl": select,
+	};
+
+	return _ =>
+	h("#main", [
+		h(".container", [
+			h(".jumbotron", [
+				h(".row", [
+					h(".col-md-6", [
+						h("h1", "domvm v2.0.0-beta")
+					]),
+					h(".col-md-6", [
+						h(".row", [
+							h(".col-sm-6.smallpad", [
+								h("button.btn.btn-primary.btn-block#run", {type: "button", onclick: run}, "Create 1,000 rows")
+							]),
+							h(".col-sm-6.smallpad", [
+								h("button.btn.btn-primary.btn-block#runlots", {type: "button", onclick: runLots}, "Create 10,000 rows")
+							]),
+							h(".col-sm-6.smallpad", [
+								h("button.btn.btn-primary.btn-block#add", {type: "button", onclick: add}, "Append 1,000 rows")
+							]),
+							h(".col-sm-6.smallpad", [
+								h("button.btn.btn-primary.btn-block#update", {type: "button", onclick: update}, "Update every 10th row")
+							]),
+							h(".col-sm-6.smallpad", [
+								h("button.btn.btn-primary.btn-block#clear", {type: "button", onclick: clear}, "Clear")
+							]),
+							h(".col-sm-6.smallpad", [
+								h("button.btn.btn-primary.btn-block#swaprows", {type: "button", onclick: swapRows}, "Swap Rows")
+							])
+						])
+					])
+				])
+			]),
+			h("table.table.table-hover.table-striped.test-data", {onclick: tableClick}, [
+				h2("tbody", store.data.map(item =>
+					h("tr", {class: item.id === store.selected ? 'danger' : null}, [
+						h("td.col-md-1", item.id),
+						h("td.col-md-4", [
+							h("a.lbl", {_data: item.id}, item.label)
+						]),
+						h("td.col-md-1", [
+							h("a.remove", {_data: item.id}, [
+								h("span.glyphicon.glyphicon-remove", {"aria-hidden": true})
+							])
+						]),
+						h("td.col-md-6")
+					])
+				))
+			]),
+			h("span.preloadicon.glyphicon.glyphicon-remove", {"aria-hidden": true})
+		])
+	])
+}

--- a/domvm-v2.0.0-beta/src/main.js
+++ b/domvm-v2.0.0-beta/src/main.js
@@ -103,14 +103,14 @@ function View(vm, store) {
 						]),
 						h("td.col-md-1", [
 							h("a.remove", {_data: item.id}, [
-								h("span.glyphicon.glyphicon-remove", {"aria-hidden": true})
+								h("span.glyphicon.glyphicon-remove", {"aria-hidden": ""})
 							])
 						]),
 						h("td.col-md-6")
 					])
 				))
 			]),
-			h("span.preloadicon.glyphicon.glyphicon-remove", {"aria-hidden": true})
+			h("span.preloadicon.glyphicon.glyphicon-remove", {"aria-hidden": ""})
 		])
 	])
 }

--- a/domvm-v2.0.0-beta/src/main.js
+++ b/domvm-v2.0.0-beta/src/main.js
@@ -21,24 +21,24 @@ var stopMeasure = function() {
 var h  = (tag, arg1, arg2) => domvm.defineElement(tag, arg1, arg2, domvm.FAST_REMOVE | domvm.FIXED_BODY),
 	h2 = (tag, arg1, arg2) => domvm.defineElement(tag, arg1, arg2, domvm.FAST_REMOVE);
 
-let wrapMeasure = (store, name) => e => {
-	startMeasure(name);
-	store[name]();
-	vm.redraw();
-	stopMeasure(name);
-};
-
 let store = new Store();
 
 let vm = domvm.createView(View, store).mount(document.body);
 
 function View(vm, store) {
-	let run			= wrapMeasure(store, "run");
-	let runLots		= wrapMeasure(store, "runLots");
-	let add			= wrapMeasure(store, "add");
-	let update		= wrapMeasure(store, "update");
-	let clear		= wrapMeasure(store, "clear");
-	let swapRows	= wrapMeasure(store, "swapRows");
+	let wrapMeasure = name => e => {
+		startMeasure(name);
+		store[name]();
+		vm.redraw(true);
+		stopMeasure(name);
+	};
+
+	let run			= wrapMeasure("run");
+	let runLots		= wrapMeasure("runLots");
+	let add			= wrapMeasure("add");
+	let update		= wrapMeasure("update");
+	let clear		= wrapMeasure("clear");
+	let swapRows	= wrapMeasure("swapRows");
 
 	let select = (e, node) => {
 		startMeasure("select");

--- a/domvm-v2.0.0-beta/src/store.js
+++ b/domvm-v2.0.0-beta/src/store.js
@@ -1,0 +1,88 @@
+'use strict';
+
+function _random(max) {
+	return Math.round(Math.random()*1000)%max;
+}
+
+function Store() {
+	this.data = [];
+	this.backup = null;
+	this.selected = null;
+	this.id = 1;
+}
+
+Store.prototype = {
+	constructor: Store,
+
+	buildData: function(count) {
+		count = count || 1000;
+
+		var adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"];
+		var colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"];
+		var nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+		var data = [];
+		for (var i = 0; i < count; i++)
+			data.push({id: this.id++, label: adjectives[_random(adjectives.length)] + " " + colours[_random(colours.length)] + " " + nouns[_random(nouns.length)] });
+		return data;
+	},
+
+	updateData: function(mod) {
+		mod = mod || 10;
+
+		for (let i=0;i<this.data.length;i+=10) {
+			this.data[i].label += ' !!!';
+		//	this.data[i] = Object.assign({}, this.data[i], {label: this.data[i].label +' !!!'});
+		}
+	},
+
+	delete: function(id) {
+		const idx = this.data.findIndex(d => d.id==id);
+		this.data = this.data.filter((e,i) => i!=idx);
+		return this;
+	},
+
+	run: function() {
+		this.data = this.buildData();
+		this.selected = null;
+	},
+
+	add: function() {
+		this.data = this.data.concat(this.buildData(1000));
+	},
+
+	update: function() {
+		this.updateData();
+	},
+
+	select: function(id) {
+		this.selected = id;
+	},
+
+	hideAll: function() {
+		this.backup = this.data;
+		this.data = [];
+	},
+
+	showAll: function() {
+		this.data = this.backup;
+		this.backup = null;
+	},
+
+	runLots: function() {
+		this.data = this.buildData(10000);
+		this.selected = null;
+	},
+
+	clear: function() {
+		this.data = [];
+		this.selected = null;
+	},
+
+	swapRows: function() {
+		if(this.data.length > 10) {
+			var a = this.data[4];
+			this.data[4] = this.data[9];
+			this.data[9] = a;
+		}
+	},
+};


### PR DESCRIPTION
@krausest 

Since you test in Chrome, there's no need to transpile this impl down to ES5.

A simple `npm install` will also pull down `domvm`'s pre-built & minified ES5/umd bundles (in `/dist`), which are used directly by `index.html`. Rather than publishing to npm, i've set the `package.json` dependency to point directly to the git repo & commit. This should make updates easier with less collateral noise.

The perf should be improved over https://github.com/krausest/js-framework-benchmark/pull/70

Thanks!