### PR TITLE
delete the repetitive babel-core and babel-loader

### DIFF
--- a/react-v15.4.0/package.json
+++ b/react-v15.4.0/package.json
@@ -23,12 +23,10 @@
     "babel-loader": "6.2.8",
     "babel-preset-es2015": "6.18.0",
     "babel-preset-react": "6.16.0",
-    "webpack": "1.13.3"
+    "webpack": "1.13.3",
+    "jsx-loader": "0.13.2"
   },
   "dependencies": {
-    "babel-core": "6.3.15",
-    "babel-loader": "6.2.0",
-    "jsx-loader": "0.13.2",
     "react": "15.4.0",
     "react-dom": "15.4.0"
   }


### PR DESCRIPTION
reduce the node_modules size from 436M to 61M