### PR TITLE
convert domvm-keyed impl to use subviews w/sCU

### DIFF
--- a/domvm-v2.0.3-keyed/package.json
+++ b/domvm-v2.0.3-keyed/package.json
@@ -13,6 +13,6 @@
     "rollup-plugin-uglify": "*"
   },
   "dependencies": {
-    "domvm": "git://github.com/leeoniya/domvm.git#146afeb1d5897bf49ca6872887572dc530e41b36"
+    "domvm": "git://github.com/leeoniya/domvm.git#8ab7a791f43d4b0632af15a8e39ad8c199c2fd9a"
   }
 }


### PR DESCRIPTION
this restructures the keyed impl a bit to use subviews w/sCU instead of a monolithic template with `FIXED_BODY` vnode flags. this adds a bit of overhead to the initial creates, but speeds up everything else by reducing the number of vnodes that must be recreated/diffed for each action.