### PR TITLE
bump domvm version for non-keyed impl

### DIFF
--- a/domvm-v2.0.3-non-keyed/package.json
+++ b/domvm-v2.0.3-non-keyed/package.json
@@ -13,6 +13,6 @@
     "rollup-plugin-uglify": "*"
   },
   "dependencies": {
-    "domvm": "git://github.com/leeoniya/domvm.git#146afeb1d5897bf49ca6872887572dc530e41b36"
+    "domvm": "git://github.com/leeoniya/domvm.git#8ab7a791f43d4b0632af15a8e39ad8c199c2fd9a"
   }
 }


### PR DESCRIPTION
@krausest would be cool if the whole table was regenerated with a "reboot" [1] and Chrome 57.

It may be worth adding a warmup cycle at the beginning of the bench to ensure the laptop's CPU is thermally throttled equally for all libs rather than giving those starting with "a" an advantage. I've also found 32-bit versions of Chrome to perform faster, allocate a lot less mem and be more stable on my machine.

[1] https://github.com/krausest/js-framework-benchmark/pull/145#issuecomment-287638169