### PR TITLE
surplus: bump dep versions; optimize keyed impl some

### DIFF
--- a/surplus-v0.4.0/package.json
+++ b/surplus-v0.4.0/package.json
@@ -23,13 +23,13 @@
   },
   "dependencies": {
     "s-js": "^0.4.0",
-    "s-array": "^0.4.0",
+    "s-array": "^0.4.2",
     "surplus": "^0.4.0"
   },
   "devDependencies": {
     "ts-loader": "0.8.2",
     "typescript": "2.2.1",
-    "surplus-loader": "^0.4.0",
+    "surplus-loader": "^0.4.2",
     "webpack": "2.2.1"
   }
 }

--- a/surplus-v0.4.0/src/controller.ts
+++ b/surplus-v0.4.0/src/controller.ts
@@ -20,9 +20,9 @@ var stopMeasure = function() {
 
 export class App {
     constructor(public store : Store) { }
-    run() {
+    run(clear : boolean) {
         startMeasure("run");
-        this.store.run();
+        this.store.run(clear);
         stopMeasure();
     }
     add() {
@@ -45,9 +45,9 @@ export class App {
         this.store.delete(idx);
         stopMeasure();
     }
-    runLots() {
+    runLots(clear : boolean) {
         startMeasure("runLots");
-        this.store.runLots();
+        this.store.runLots(clear);
         stopMeasure();
     }
     clear() {

--- a/surplus-v0.4.0/src/store.ts
+++ b/surplus-v0.4.0/src/store.ts
@@ -38,7 +38,8 @@ export class Store {
         const idx = (this.data() as any).findIndex((d : Row) => d.id == id);
         this.data.splice(idx, 1);
     }
-    run() {
+    run(clear : boolean) {
+        if (clear) this.data([]);
         S.freeze(() => {
             this.data(this.buildData());
             this.selected(undefined);
@@ -53,7 +54,8 @@ export class Store {
     select(id : number) {
         this.selected(id);
     }
-    runLots() {
+    runLots(clear : boolean) {
+        if (clear) this.data([]);
         S.freeze(() => {
             this.data(this.buildData(10000));
             this.selected(undefined);

--- a/surplus-v0.4.0/src/view.tsx
+++ b/surplus-v0.4.0/src/view.tsx
@@ -18,10 +18,10 @@ export let AppView = (app : App) =>
                     <div className="col-md-6">
                         <div className="row">
                             <div className="col-sm-6 smallpad">
-                                <button type="button" className="btn btn-primary btn-block" id="run" onClick={e => app.run()}>Create 1,000 rows</button>
+                                <button type="button" className="btn btn-primary btn-block" id="run" onClick={e => app.run(!USE_NON_KEYED_TBODY)}>Create 1,000 rows</button>
                             </div>
                             <div className="col-sm-6 smallpad">
-                                <button type="button" className="btn btn-primary btn-block" id="runlots" onClick={e => app.runLots()}>Create 10,000 rows</button>
+                                <button type="button" className="btn btn-primary btn-block" id="runlots" onClick={e => app.runLots(!USE_NON_KEYED_TBODY)}>Create 10,000 rows</button>
                             </div>
                             <div className="col-sm-6 smallpad">
                                 <button type="button" className="btn btn-primary btn-block" id="add" onClick={e => app.add()}>Append 1,000 rows</button>
@@ -49,19 +49,24 @@ export let AppView = (app : App) =>
         while (el.tagName !== 'TR') el = el.parentElement!; 
         return +el.childNodes[0].textContent!; 
     },
-    TBodyKeyed = (app : App) =>
-        <tbody>
-            {app.store.data.mapSample(row =>
-                <tr className={row.id === app.store.selected() ? 'danger' : ''}>
-                    <td className="col-md-1" innerText={row.id}></td>
-                    <td className="col-md-4">
-                        <a innerText={row.label()}></a>
-                    </td>
-                    <td className="col-md-1"><a><span className="glyphicon glyphicon-remove delete"></span></a></td>
-                    <td className="col-md-6"></td>
-                </tr>
-            )}
-        </tbody>,
+    TBodyKeyed = (app : App) => {
+        let trs = app.store.data.mapSample(row =>
+            <tr>
+                <td className="col-md-1" innerText={row.id}></td>
+                <td className="col-md-4">
+                    <a innerText={row.label()}></a>
+                </td>
+                <td className="col-md-1"><a><span className="glyphicon glyphicon-remove delete"></span></a></td>
+                <td className="col-md-6"></td>
+            </tr>);
+
+        S.on(app.store.selected, () => {
+            let sel = app.store.selected(), data = app.store.data();
+            trs().forEach((tr, i) => tr.className = data[i].id === sel ? 'danger' : '');
+        });
+        
+        return <tbody>{trs}</tbody>;
+    },
     TBodyNonKeyed = (app : App) => {
         var tbody = <tbody></tbody>,
             trs = [] as RowTr[];

--- a/surplus-v0.4.0/webpack.config.js
+++ b/surplus-v0.4.0/webpack.config.js
@@ -12,6 +12,5 @@ module.exports = {
 		rules: [
 			{ test: /\.tsx?$/, loader: 'surplus-loader!ts-loader' },
 		]
-	},
-	externals: [ { '@types/react' : 'this'} ]
+	}
 };


### PR DESCRIPTION
A couple tweaks to the surplus version

1) bump dependencies to latest versions.  This was mostly to bring in a bugfix in s-array, but I bumped the others while I was there.

2) a few performance tweaks to the keyed implementation:

    - when replacing rows, do a clear first, to take advantage of fast path for removing nodes

    - use a single computation to set selected row, avoiding creating N computations for N rows (better matches cardinality of state)

With these changes, here are the timings I get for the top four keyed and unkeyed versions.  Curious to see how it comes out for you on your machine this go around.

<img width="337" alt="screen shot 2017-03-28 at 11 25 44 pm" src="https://cloud.githubusercontent.com/assets/1620206/24437529/85cab53e-140f-11e7-879e-86b8cc1c40b1.png">
<img width="347" alt="screen shot 2017-03-28 at 11 26 28 pm" src="https://cloud.githubusercontent.com/assets/1620206/24437553/ab88c658-140f-11e7-9034-f35fa5fcac4f.png">
 
Thanks!