### PR TITLE
submit pico-dom-v0.18.0 keyed

### DIFF
--- a/pico-dom-v0.18.0/index.html
+++ b/pico-dom-v0.18.0/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
-    <title>VanillaJS-"keyed"</title>
+    <title>picoDOM-"keyed"</title>
     <link href="/css/currentStyle.css" rel="stylesheet"/>
 </head>
 <body>

--- a/pico-dom-v0.18.0/index.html
+++ b/pico-dom-v0.18.0/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>VanillaJS-"keyed"</title>
+    <link href="/css/currentStyle.css" rel="stylesheet"/>
+</head>
+<body>
+<script src='dist/main.js'></script>
+</body>
+</html>

--- a/pico-dom-v0.18.0/package.json
+++ b/pico-dom-v0.18.0/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "js-framework-benchmark-pico-dom-0.17.0",
+  "version": "0.1.0",
+  "description": "Benchmark for picoDom 0.17.0",
+  "scripts": {
+    "build-dev": "webpack -w -d --entry ./src/main.js --output-filename ./dist/main.js",
+    "build-prod": "webpack -p --entry ./src/main.js --output-filename ./dist/main.js"
+  },
+  "author": "Hugo Villeneuve",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "devDependencies": {},
+  "dependencies": {
+    "pico-dom": "0.18.0"
+  }
+}

--- a/pico-dom-v0.18.0/src/main.js
+++ b/pico-dom-v0.18.0/src/main.js
@@ -1,0 +1,26 @@
+/*eslint indent:0 quotes:0*/
+var el = require('pico-dom').element,
+    menu = require('./menu'),
+    table = require('./table'),
+    Store = require('./store')
+
+var title = 'picoDom-keyed',
+    store = new Store()
+
+el(document.body,
+  el('div#main',
+    el('div.container',
+      el('div.jumbotron',
+        el('div.row',
+          el('div.col-md-6',
+            el('h1', title)
+          ),
+          el('div.col-md-6', menu)
+        )
+      ),
+      table,
+      el('span.preloadicon.glyphicon.glyphicon-remove[aria-hidden]')
+    )
+  )
+)
+menu.update(store)

--- a/pico-dom-v0.18.0/src/menu.js
+++ b/pico-dom-v0.18.0/src/menu.js
@@ -1,0 +1,67 @@
+/*eslint indent:0 quotes:0*/
+var pico = require('pico-dom'),
+    table = require('./table'),
+    time = require('./time')
+
+var el = pico.element,
+    co = pico.component
+
+module.exports = co('div.row', {
+    extra: {
+      store: null,
+      update: function(s) { this.store = s },
+      handleEvent: handleClick,
+      init: function() { this.node.addEventListener('click', this, true) }
+    }
+  }, [
+  el('div.col-sm-6 smallpad',
+    co('button[type=button].btn.btn-primary.btn-block#run', {extra: {key: 'run'}}, 'Create 1,000 rows')
+  ),
+  el('div.col-sm-6 smallpad',
+    co('button[type=button].btn.btn-primary.btn-block#runlots', {extra: {key: 'runLots'}}, 'Create 10,000 rows')
+  ),
+  el('div.col-sm-6 smallpad',
+    co('button[type=button].btn.btn-primary.btn-block#add', {extra: {key: 'add'}}, 'Append 1,000 rows')
+  ),
+  el('div.col-sm-6 smallpad',
+    co('button[type=button].btn.btn-primary.btn-block#update', {extra: {key: 'update'}}, 'Update every 10th row')
+  ),
+  el('div.col-sm-6 smallpad',
+    co('button[type=button].btn.btn-primary.btn-block#clear', {extra: {key: 'clear'}}, 'Clear')
+  ),
+  el('div.col-sm-6 smallpad',
+    co('button[type=button].btn.btn-primary.btn-block#swaprows', {extra: {key: 'swapRows'}}, 'Swap Rows')
+  )
+])
+function handleClick(e) {
+  var target = pico.extra.get(e.target),
+      key = target && target.key,
+      store = this.store
+  if (!key) return
+
+  e.preventDefault()
+  time.start(key)
+  switch (key) {
+    case 'run':
+      store.clear()
+      store.run()
+      break
+    case 'add':
+      store.add()
+      break
+    case 'runLots':
+      store.clear()
+      store.runLots()
+      break
+    case 'update':
+      store.update()
+      break
+    case 'clear':
+      store.clear()
+      break
+    case 'swapRows':
+      if (store.data.length>10) store.swapRows()
+  }
+  table.update(store)
+  time.stop()
+}

--- a/pico-dom-v0.18.0/src/menu.js
+++ b/pico-dom-v0.18.0/src/menu.js
@@ -14,22 +14,22 @@ module.exports = co('div.row', {
       init: function() { this.node.addEventListener('click', this, true) }
     }
   }, [
-  el('div.col-sm-6 smallpad',
+  el('div.col-sm-6.smallpad',
     co('button[type=button].btn.btn-primary.btn-block#run', {extra: {key: 'run'}}, 'Create 1,000 rows')
   ),
-  el('div.col-sm-6 smallpad',
+  el('div.col-sm-6.smallpad',
     co('button[type=button].btn.btn-primary.btn-block#runlots', {extra: {key: 'runLots'}}, 'Create 10,000 rows')
   ),
-  el('div.col-sm-6 smallpad',
+  el('div.col-sm-6.smallpad',
     co('button[type=button].btn.btn-primary.btn-block#add', {extra: {key: 'add'}}, 'Append 1,000 rows')
   ),
-  el('div.col-sm-6 smallpad',
+  el('div.col-sm-6.smallpad',
     co('button[type=button].btn.btn-primary.btn-block#update', {extra: {key: 'update'}}, 'Update every 10th row')
   ),
-  el('div.col-sm-6 smallpad',
+  el('div.col-sm-6.smallpad',
     co('button[type=button].btn.btn-primary.btn-block#clear', {extra: {key: 'clear'}}, 'Clear')
   ),
-  el('div.col-sm-6 smallpad',
+  el('div.col-sm-6.smallpad',
     co('button[type=button].btn.btn-primary.btn-block#swaprows', {extra: {key: 'swapRows'}}, 'Swap Rows')
   )
 ])

--- a/pico-dom-v0.18.0/src/store.js
+++ b/pico-dom-v0.18.0/src/store.js
@@ -1,0 +1,77 @@
+/*eslint indent:0 quotes:0*/
+module.exports = Store
+
+function _random(max) {
+  return Math.round(Math.random()*1000)%max
+}
+
+function Store() {
+  this.data = []
+  this.backup = null
+  this.selected = null
+  this.id = 1
+}
+Store.prototype = {
+  constructor: Store,
+  buildData: function(count) {
+    if (!(count >=0)) count = 1000
+    var adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"]
+    var colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"]
+    var nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"]
+    var data = []
+    for (var i=0; i < count; ++i)
+      data.push({id: this.id++, label: adjectives[_random(adjectives.length)] + " " + colours[_random(colours.length)] + " " + nouns[_random(nouns.length)] })
+    return data
+  },
+  updateData: function(mod) {
+    if (!(mod >=0)) mod = 1000
+    for (var i=0; i<this.data.length; i+=10) {
+      this.data[i].label += ' !!!'
+    }
+  },
+  delete: function(id) {
+    var idx = this.data.findIndex(function(d) { return d.id == id }) //eslint-disable-line eqeqeq
+    this.data = this.data.filter(function(e,i) { return i != idx }) //eslint-disable-line eqeqeq
+    return this
+  },
+  run: function() {
+    this.data = this.buildData()
+    this.selected = null
+  },
+  add: function() {
+    this.data = this.data.concat(this.buildData(1000))
+    this.selected = null
+  },
+  update: function() {
+    this.updateData()
+    this.selected = null
+  },
+  select: function(id) {
+    this.selected = id
+  },
+  hideAll: function() {
+    this.backup = this.data
+    this.data = []
+    this.selected = null
+  },
+  showAll: function() {
+    this.data = this.backup
+    this.backup = null
+    this.selected = null
+  },
+  runLots: function() {
+    this.data = this.buildData(10000)
+    this.selected = null
+  },
+  clear: function() {
+    this.data = []
+    this.selected = null
+  },
+  swapRows: function() {
+    if(this.data.length > 10) {
+      var a = this.data[4]
+      this.data[4] = this.data[9]
+      this.data[9] = a
+    }
+  }
+}

--- a/pico-dom-v0.18.0/src/table.js
+++ b/pico-dom-v0.18.0/src/table.js
@@ -1,0 +1,71 @@
+/*eslint indent:0 quotes:0*/
+var pico = require('pico-dom'),
+    time = require('./time')
+
+var el = pico.element,
+    co = pico.component,
+    list = pico.list,
+    extra = pico.extra
+
+var store = null
+
+var rows = list(co('tr', {
+    extra: { key: -1, update: updateRow, init: function() { this.node.onclick = rowClickHandler } }
+  }, [
+    co('td.col-md-1', {
+      extra: { init: function(v) { this.setText(v && v.id) } }
+    }),
+    co('td.col-md-4',
+      co('a.lbl', {
+        extra: { key: 'select', update: updateLabel }
+      })
+    ),
+    el('td.col-md-1',
+      el('a.remove',
+        co('span.glyphicon.glyphicon-remove.remove[aria-hidden]', {
+          extra: { key: 'delete' }
+        })
+      )
+    ),
+    el('td.col-md-6')
+  ]),
+  'id'
+)
+
+var table = module.exports = co('table.table.table-hover.table-striped.test-data',
+  co('tbody#tbody', {
+    extra: { update: function(str) {
+      store = str
+      this.update = function(s) { rows.update(s.data) } // run-once switcharoo
+      this.update(store)
+  }}},
+  rows)
+)
+
+function updateLabel(v) {
+  this.setText(v.label)
+}
+function updateRow(v) {
+  var className = this.key === store.selected ? "danger" : ""
+  if (this.node.className !== className) this.node.className = className
+  this.updateChildren(v)
+}
+function rowClickHandler(e) {
+  var key = extra.get(this).key,
+      tgt = extra.get(e.target),
+      act = tgt && tgt.key
+  if (!act) return
+
+  e.preventDefault()
+  time.start(act)
+  switch (act) {
+    case 'select':
+      store.select(key)
+      break
+    case 'delete':
+      store.delete(key)
+      break
+  }
+  table.update(store)
+  time.stop()
+}

--- a/pico-dom-v0.18.0/src/time.js
+++ b/pico-dom-v0.18.0/src/time.js
@@ -1,0 +1,20 @@
+/*eslint indent:0, quotes:0, no-console:0*/
+var startTime
+var lastMeasure
+
+module.exports = {
+  start: function startMeasure(name) {
+    startTime = performance.now()
+    lastMeasure = name
+  },
+  stop: function stopMeasure() {
+    var last = lastMeasure
+    if (lastMeasure) {
+      window.setTimeout(function () {
+        lastMeasure = null
+        var stop = performance.now()
+        console.log(last+" took "+(stop-startTime))
+      }, 0)
+    }
+  }
+}

--- a/webdriver-ts/src/common.ts
+++ b/webdriver-ts/src/common.ts
@@ -60,6 +60,7 @@ export let frameworks = [
     f("mithril-v1.0.1", false),
     f("nx-v1.0.0-beta.1.1.0-keyed", false),
     f("nx-v1.0.0-beta.1.1.0-non-keyed", true),
+    f("pico-dom-v0.18.0", false),
     f("plastiq-v1.33.0", false),
     f("polymer-v1.7.0", true, {uri: "polymer-v1.7.0", useShadowRoot: true}),
     f("preact-v7.1.0", false),


### PR DESCRIPTION
Here is a fast minimal lib (2.3 kb gzip) with low memory footprint to facilitate the creation of components and lists of components. On my machine, the memory use and overall slowdown is close to svelte. The overall minimized code is also quite close to the compiled svelte code.

More a library than a framework so I will let you decide if it is relevant here:
* all hyperscript functions (definitely not as sexy as other entries)
* no intermediate structure, all direct dom operations
* top-down updates (updating a node cascades down the whole tree)

This is the *keyed* version, the *non-keyed* can be obtained by deleting the [key here](https://github.com/hville/js-framework-benchmark/blob/master/pico-dom-v0.18.0/src/table.js#L32). I can add the other version if there is any interest.

Thanks for the project. Trying the tests made me realize how much involvement it must require to keep all these tests up to date.