### PR TITLE
add react-easy-state

### DIFF
--- a/react-v15.5.4-easy-state-v1.0.3/.babelrc
+++ b/react-v15.5.4-easy-state-v1.0.3/.babelrc
@@ -1,0 +1,4 @@
+{
+    presets: [ "stage-0", "react" ],
+    plugins: [ "transform-decorators-legacy", "external-helpers" ]
+}

--- a/react-v15.5.4-easy-state-v1.0.3/index.html
+++ b/react-v15.5.4-easy-state-v1.0.3/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>React v15.5.4 + React Easy State 1.0.3</title>
+  <link href="/css/currentStyle.css" rel="stylesheet"/>
+</head>
+<body>
+  <div id='main'></div>
+  <script src='dist/main.js'></script>
+</body>
+</html>

--- a/react-v15.5.4-easy-state-v1.0.3/package.json
+++ b/react-v15.5.4-easy-state-v1.0.3/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "js-framework-benchmark-react-easy-state",
+  "version": "1.0.0",
+  "description": "React Easy State demo",
+  "main": "src/Main.jsx",
+  "scripts": {
+    "build-prod": "rollup -c rollup.config.prod.js",
+    "build-dev": "rollup -w -c rollup.config.dev.js"
+  },
+  "keywords": [
+    "react",
+    "rollup"
+  ],
+  "author": "Stefan Krause",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "devDependencies": {
+    "babel-core": "6.24.1",
+    "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-transform-decorators-legacy": "1.3.4",
+    "babel-preset-react": "6.24.1",
+    "babel-preset-stage-0": "6.24.1",
+    "babili": "0.1.2",
+    "rollup": "0.41.6",
+    "rollup-plugin-babel": "2.7.1",
+    "rollup-plugin-babili": "3.0.0",
+    "rollup-plugin-commonjs": "8.0.2",
+    "rollup-plugin-node-resolve": "3.0.0",
+    "rollup-plugin-replace": "1.1.1",
+    "rollup-watch": "3.2.2",
+    "webpack": "2.5.1"
+  },
+  "dependencies": {
+    "react-easy-state": "1.0.3",
+    "react": "15.5.4",
+    "react-dom": "15.5.4"
+  }
+}

--- a/react-v15.5.4-easy-state-v1.0.3/rollup.config.dev.js
+++ b/react-v15.5.4-easy-state-v1.0.3/rollup.config.dev.js
@@ -1,0 +1,20 @@
+import commonjs from 'rollup-plugin-commonjs'
+import resolve from 'rollup-plugin-node-resolve'
+import babel from 'rollup-plugin-babel'
+import replace from 'rollup-plugin-replace'
+
+export default {
+  entry: 'src/Main.jsx',
+  format: 'iife',
+  moduleName: 'reactEasyState',
+  dest: 'dist/main.js',
+  sourceMap: 'inline',
+  plugins: [
+    resolve({ jsnext: true, main: true, extensions: [ '.js', '.json', '.jsx' ] }),
+    commonjs({
+      namedExports: { 'node_modules/react/react.js': ['Component'] }
+    }),
+    babel({ exclude: 'node_modules/**' }),
+    replace({ 'process.env.NODE_ENV': JSON.stringify('development') })
+  ]
+}

--- a/react-v15.5.4-easy-state-v1.0.3/rollup.config.prod.js
+++ b/react-v15.5.4-easy-state-v1.0.3/rollup.config.prod.js
@@ -1,0 +1,21 @@
+import commonjs from 'rollup-plugin-commonjs'
+import resolve from 'rollup-plugin-node-resolve'
+import babel from 'rollup-plugin-babel'
+import babili from 'rollup-plugin-babili'
+import replace from 'rollup-plugin-replace'
+
+export default {
+  entry: 'src/Main.jsx',
+  format: 'iife',
+  moduleName: 'reactEasyState',
+  dest: 'dist/main.js',
+  plugins: [
+    resolve({ jsnext: true, main: true, extensions: [ '.js', '.json', '.jsx' ] }),
+    commonjs({
+      namedExports: { 'node_modules/react/react.js': ['Component'] }
+    }),
+    babel({ exclude: 'node_modules/**' }),
+    babili({ comments: false }),
+    replace({ 'process.env.NODE_ENV': JSON.stringify('production') })
+  ]
+}

--- a/react-v15.5.4-easy-state-v1.0.3/src/Main.jsx
+++ b/react-v15.5.4-easy-state-v1.0.3/src/Main.jsx
@@ -1,0 +1,137 @@
+import React, { Component } from 'react'
+import ReactDOM from 'react-dom'
+import easyState from 'react-easy-state'
+import Row from './Row'
+import randomSentence from './randomSentence'
+import {startMeasure, stopMeasure} from './logPerf'
+
+let idCounter = 1
+
+@easyState
+class Main extends Component {
+  constructor (props) {
+    super(props)
+    this.state = { rows: [] }
+  }
+
+  componentDidUpdate() {
+    stopMeasure()
+  }
+
+  componentDidMount() {
+    stopMeasure()
+  }
+
+  buildRows (numOfRows) {
+    const { state } = this
+    for (let i = 0; i < numOfRows; i++) {
+      state.rows.push({ id: idCounter++, label: randomSentence() })
+    }
+  }
+
+  run () {
+    startMeasure('run')
+    const { state } = this
+    state.rows = []
+    state.selected = undefined
+    this.buildRows(1000)
+  }
+
+  add () {
+    startMeasure('add')
+    this.buildRows(1000)
+  }
+
+  update () {
+    startMeasure('update')
+    const { rows } = this.state
+    for (let i = 0; i < rows.length; i += 10) {
+      rows[i].label += ' !!!'
+    }
+  }
+
+  select (row) {
+    startMeasure('select')
+    const { state } = this
+    state.selected = row
+  }
+
+  delete (row) {
+    startMeasure('delete')
+    const { rows } = this.state
+    rows.splice(rows.indexOf(row), 1)
+  }
+
+  runLots () {
+    startMeasure('runLots')
+    const { state } = this
+    state.rows = []
+    state.selected = undefined
+    this.buildRows(10000)
+  }
+
+  clear() {
+    startMeasure('clear')
+    const { state } = this
+    state.rows = []
+    state.selected = undefined
+  }
+
+  swapRows() {
+    startMeasure('swapRows')
+    const { rows } = this.state
+    if (rows.length > 10) {
+      const temp = rows[4]
+      rows[4] = rows[9]
+      rows[9] = temp
+    }
+  }
+
+  render() {
+    const { rows, selected } = this.state
+
+    return (
+      <div className="container">
+        <div className="jumbotron">
+          <div className="row">
+            <div className="col-md-6">
+              <h1>React v15.5.4 + Easy State 1.0.3</h1>
+            </div>
+            <div className="col-md-6">
+              <div className="row">
+                <div className="col-sm-6 smallpad">
+                  <button type="button" className="btn btn-primary btn-block" id="run" onClick={this.run}>Create 1,000 rows</button>
+                </div>
+                <div className="col-sm-6 smallpad">
+                  <button type="button" className="btn btn-primary btn-block" id="runlots" onClick={this.runLots}>Create 10,000 rows</button>
+                </div>
+                <div className="col-sm-6 smallpad">
+                  <button type="button" className="btn btn-primary btn-block" id="add" onClick={this.add}>Append 1,000 rows</button>
+                </div>
+                <div className="col-sm-6 smallpad">
+                  <button type="button" className="btn btn-primary btn-block" id="update" onClick={this.update}>Update every 10th row</button>
+                </div>
+                <div className="col-sm-6 smallpad">
+                  <button type="button" className="btn btn-primary btn-block" id="clear" onClick={this.clear}>Clear</button>
+                </div>
+                <div className="col-sm-6 smallpad">
+                  <button type="button" className="btn btn-primary btn-block" id="swaprows" onClick={this.swapRows}>Swap Rows</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <table className="table table-hover table-striped test-data">
+          <tbody>
+            {rows.map(row =>
+              <Row onClick={this.select} onDelete={this.delete}
+                key={row.id} row={row} styleClass={row === selected ? 'danger' : ''}></Row>)}
+          </tbody>
+        </table>
+        <span className="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
+      </div>
+    )
+  }
+}
+
+ReactDOM.render(<Main/>, document.getElementById('main'))

--- a/react-v15.5.4-easy-state-v1.0.3/src/Row.jsx
+++ b/react-v15.5.4-easy-state-v1.0.3/src/Row.jsx
@@ -1,0 +1,30 @@
+import React, { Component } from 'react'
+import easyState from 'react-easy-state'
+
+@easyState
+export default class Row extends Component {
+	onDelete () {
+		const { row, onDelete } = this.props
+		onDelete(row)
+	}
+
+	onClick () {
+		const { row, onClick } = this.props
+		onClick(row)
+	}
+
+	render() {
+		const { row, styleClass } = this.props
+
+		return (
+			<tr className={styleClass}>
+				<td className="col-md-1">{row.id}</td>
+				<td className="col-md-4">
+					<a onClick={this.onClick}>{row.label}</a>
+				</td>
+				<td className="col-md-1"><a onClick={this.onDelete}><span className="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td>
+				<td className="col-md-6"></td>
+			</tr>
+		)
+	}
+}

--- a/react-v15.5.4-easy-state-v1.0.3/src/logPerf.js
+++ b/react-v15.5.4-easy-state-v1.0.3/src/logPerf.js
@@ -1,0 +1,18 @@
+let startTime
+let lastMeasure
+
+export function startMeasure (name) {
+  startTime = performance.now()
+  lastMeasure = name
+}
+
+export function stopMeasure () {
+  let last = lastMeasure
+  if (lastMeasure) {
+    window.setTimeout(() => {
+      lastMeasure = null
+      let stop = performance.now()
+      console.log(last + " took " + (stop - startTime))
+    })
+  }
+}

--- a/react-v15.5.4-easy-state-v1.0.3/src/randomSentence.js
+++ b/react-v15.5.4-easy-state-v1.0.3/src/randomSentence.js
@@ -1,0 +1,11 @@
+const adjectives = ['pretty', 'large', 'big', 'small', 'tall', 'short', 'long', 'handsome', 'plain', 'quaint', 'clean', 'elegant', 'easy', 'angry', 'crazy', 'helpful', 'mushy', 'odd', 'unsightly', 'adorable', 'important', 'inexpensive', 'cheap', 'expensive', 'fancy'];
+const colours = ['red', 'yellow', 'blue', 'green', 'pink', 'brown', 'purple', 'brown', 'white', 'black', 'orange'];
+const nouns = ['table', 'chair', 'house', 'bbq', 'desk', 'car', 'pony', 'cookie', 'sandwich', 'burger', 'pizza', 'mouse', 'keyboard'];
+
+export default function randomSentence () {
+  return `${adjectives[random(adjectives.length)]} ${colours[random(colours.length)]} ${nouns[random(nouns.length)]}`
+}
+
+function random (max) {
+  return Math.round(Math.random() * 1000) % max
+}

--- a/webdriver-ts/src/common.ts
+++ b/webdriver-ts/src/common.ts
@@ -71,6 +71,7 @@ export let frameworks = [
     f("react-lite-v0.15.30", false),
     f("react-v15.5.4-keyed", false),
     f("react-v15.5.4-non-keyed", true),
+    f("react-v15.5.4-easy-state-v1.0.3", false),
     f("react-v15.5.4-mobX-v3.1.9", false),
     f("react-v15.5.4-redux-v3.6.0", false),
     f("riot-v3.5.0", true),


### PR DESCRIPTION
Add [React Easy State](https://github.com/solkimicreb/react-easy-state)

Easy State is a small package that aims to improve React's own state management instead of delegating it to external libraries - like Redux or MobX. To achieve this, it does two things:

- It replaces React's state and `setState` with plain native JavaScript.
- It autobinds component methods.

On my machine the benchmark scores at around Redux (slightly better). I think that the rollup build is responsible for the faster startup time. I would gladly refactor the other React examples to use ES6 syntax and rollup if the other authors agree (:
