### PR TITLE
Add common optimization to elm-v0.18.0

### DIFF
--- a/elm-v0.18.0/src/Main.elm
+++ b/elm-v0.18.0/src/Main.elm
@@ -6,6 +6,7 @@ import Html exposing (Html, Attribute, program, div, a, h1, span, button, table,
 import Html.Attributes exposing (id, class, classList, attribute, type_, href)
 import Html.Events exposing (onClick)
 import Html.Keyed
+import Html.Lazy
 import String
 import Random.Pcg exposing (Seed, Generator)
 
@@ -115,10 +116,14 @@ btnPrimaryBlock ( buttonId, labelText, msg ) =
         ]
 
 
-rowView : Int -> Row -> ( String, Html Msg )
-rowView index { id, label, selected } =
-    ( toString id
-    , tr
+viewKeyedRow : Int -> Row -> ( String, Html Msg )
+viewKeyedRow index row =
+  ( toString row.id, Html.Lazy.lazy2 viewRow index row )
+
+
+viewRow : Int -> Row -> Html Msg
+viewRow index { id, label, selected } =
+    tr
         [ classList [ ( "danger", selected ) ] ]
         [ td [ class "col-md-1" ] [ text (toString id) ]
         , td
@@ -144,7 +149,6 @@ rowView index { id, label, selected } =
             ]
         , td [ class "col-md-6" ] []
         ]
-    )
 
 
 view : Model -> Html Msg
@@ -170,7 +174,7 @@ view model =
             [ class "table table-hover table-striped test-data" ]
             [ tbody
                 []
-                (List.indexedMap rowView model.rows)
+                (List.indexedMap viewKeyedRow model.rows)
             ]
         , span
             [ class "preloadicon glyphicon glyphicon-remove"


### PR DESCRIPTION
## Summary

This change adds the equivalent of React's `shouldComponentUpdate` for the Elm implementation.

## Justification

**First**, I noticed that this optimization was permitted in the following React implementations:

  - [react-v15.5.4-keyed](https://github.com/krausest/js-framework-benchmark/blob/master/react-v15.5.4-keyed/src/Row.jsx#L15-L17)
  - [react-v15.5.4-redux-v3.6.0](https://github.com/krausest/js-framework-benchmark/blob/master/react-v15.5.4-redux-v3.6.0/src/controller.jsx#L60-L62)
  - [react-lite-v0.15.30](https://github.com/krausest/js-framework-benchmark/blob/master/react-lite-v0.15.30/src/Row.jsx#L15-L17)

There are probably others that use similar techniques, but I am not familiar with all of these projects.

**Second**, this technique is very commonly used in Elm applications. The overall technique is described in [our docs](http://package.elm-lang.org/packages/elm-lang/html/2.0.0/Html-Lazy), and it is *the* optimization tool for Elm programs. For example, it is used [here](https://github.com/evancz/elm-todomvc/blob/master/Todo.elm#L300-L306) in our TodoMVC implementation, filling roughly the same role as React's `shouldComponentUpdate`.


## Expectations

I am not certain how to get all these benchmarks set up, but I would expect this to (1) reduce the memory footprint and (2) increase speed. For example, when rows are swapped, rather than allocating and diffing the entire `tr` virtual DOM, we will just compare the `row` value itself. This should result in faster updates and less garbage generated.

Thank you for your consideration!