### PR TITLE
Improve row selection in Elm 0.18 implementation

### DIFF
--- a/elm-v0.18.0/elm-package.json
+++ b/elm-v0.18.0/elm-package.json
@@ -8,7 +8,6 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/array-extra": "1.0.2 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"

--- a/elm-v0.18.0/src/Main.elm
+++ b/elm-v0.18.0/src/Main.elm
@@ -259,19 +259,7 @@ update msg model =
                 )
 
         UpdateEvery amount ->
-            ( { model
-                | rows =
-                    List.indexedMap
-                        (\index row ->
-                            if (index % 10) == 0 then
-                                { row | label = row.label ++ " !!!" }
-                            else
-                                row
-                        )
-                        model.rows
-              }
-            , Cmd.none
-            )
+            ( { model | rows = List.indexedMap updateRow model.rows }, Cmd.none )
 
         Clear ->
             ( { model | rows = [] }, Cmd.none )
@@ -315,6 +303,14 @@ update msg model =
 
         UpdateSeed seed ->
             ( { model | seed = Just seed }, Cmd.none )
+
+
+updateRow : Int -> Row -> Row
+updateRow index row =
+    if index % 10 == 0 then
+        { row | label = row.label ++ " !!!" }
+    else
+        row
 
 
 select : Int -> Int -> Row -> Row

--- a/elm-v0.18.0/src/Main.elm
+++ b/elm-v0.18.0/src/Main.elm
@@ -1,7 +1,6 @@
 module Main exposing (..)
 
 import Array exposing (Array)
-import Array.Extra
 import Html exposing (Html, Attribute, program, div, a, h1, span, button, table, td, tr, text)
 import Html.Attributes exposing (id, class, classList, attribute, type_, href)
 import Html.Events exposing (onClick)
@@ -312,30 +311,20 @@ update msg model =
             )
 
         Select index ->
-            ( { model
-                | rows =
-                    model.rows
-                        |> List.map
-                            (\row ->
-                                if row.selected == True then
-                                    { row | selected = False }
-                                else
-                                    row
-                            )
-                        |> Array.fromList
-                        |> Array.Extra.update index
-                            (\row ->
-                                { row
-                                    | selected = True
-                                }
-                            )
-                        |> Array.toList
-              }
-            , Cmd.none
-            )
+            ( { model | rows = List.indexedMap (select index) model.rows }, Cmd.none )
 
         UpdateSeed seed ->
             ( { model | seed = Just seed }, Cmd.none )
+
+
+select : Int -> Int -> Row -> Row
+select targetIndex index ({ id, label, selected } as row) =
+    if index == targetIndex then
+        Row id label True
+    else if selected == True then
+        Row id label False
+    else
+        row
 
 
 type alias Model =


### PR DESCRIPTION
## Summary

This change simplifies the `update` logic for selecting items.

## Details

In the previous implementation, the `Select` logic included:

  1. A `List.map` that deselected all rows.
  2. A conversion from `List` to `Array`
  3. An update of that `Array`
  4. A conversion back from `Array` to `List`

This is quite a bizarre choice because everything *can* be done in that initial `List.map`. This PR changes the code slightly to skip steps 2, 3, and 4.

The benefits of this change include:

  - The `elm-community/array-extra` dependency can be removed.
  - Less garbage will be produced by skipping these `Array` conversions.
  - Less computation is necessary to select an item.
  - The resulting code is simpler.

## Expectations

This should improve speed and allocation, but I expect the improvement to be rather small.
 
Again, thank you for your consideration!