### PR TITLE
add missing aria-hidden="true" attributes to surplus

### DIFF
--- a/surplus-v0.4.0-keyed/src/view.tsx
+++ b/surplus-v0.4.0-keyed/src/view.tsx
@@ -40,7 +40,7 @@ export let AppView = (app : App) =>
                 onClick = {(e : any) => e.target.matches('.delete') ? app.delete(rowId(e)) : app.select(rowId(e))}>
                 { TBody(app) }
             </table>
-            <span className="preloadicon glyphicon glyphicon-remove"></span>
+            <span className="preloadicon glyphicon glyphicon-remove" {...(el : HTMLSpanElement) => el.setAttribute("aria-hidden", "true")}></span>
         </div>,
     rowId = ({target: el} : {target : HTMLElement}) => { 
         while (el.tagName !== 'TR') el = el.parentElement!; 
@@ -48,15 +48,19 @@ export let AppView = (app : App) =>
     },
     TBody = (app : App) => {
         const index = {} as { [id : number] : HTMLTableRowElement | undefined},
-            trs = mapSample(app.store.data, row =>
-                <tr ref={index[row.id]!}>
-                    <td className="col-md-1" innerText={row.id}></td>
-                    <td className="col-md-4">
-                        <a innerText={row.label()}></a>
-                    </td>
-                    <td className="col-md-1"><a><span className="glyphicon glyphicon-remove delete"></span></a></td>
-                    <td className="col-md-6"></td>
-                </tr>,
+            trs = mapSample(app.store.data, row => {
+                let span : HTMLSpanElement = null!, 
+                    tr = <tr ref={index[row.id]!}>
+                            <td className="col-md-1" innerText={row.id}></td>
+                            <td className="col-md-4">
+                                <a innerText={row.label()}></a>
+                            </td>
+                            <td className="col-md-1"><a><span ref={span} className="glyphicon glyphicon-remove delete"></span></a></td>
+                            <td className="col-md-6"></td>
+                        </tr>;
+                    span.setAttribute("aria-hidden", "true");
+                    return tr;
+                },
                 row => index[row.id] = undefined);
 
         S.on(app.store.selected, (tr? : HTMLTableRowElement) => {

--- a/surplus-v0.4.0-non-keyed/src/view.tsx
+++ b/surplus-v0.4.0-non-keyed/src/view.tsx
@@ -42,7 +42,7 @@ export let AppView = (app : App) =>
                 onClick = {(e : any) => e.target.matches('.delete') ? app.delete(rowId(e)) : app.select(rowId(e))}>
                 { TBody(app) }
             </table>
-            <span className="preloadicon glyphicon glyphicon-remove"></span>
+            <span className="preloadicon glyphicon glyphicon-remove" {...(el : HTMLSpanElement) => el.setAttribute("aria-hidden", "true")}></span>
         </div>,
     rowId = ({target: el} : {target : HTMLElement}) => { 
         while (el.tagName !== 'TR') el = el.parentElement!; 
@@ -66,15 +66,17 @@ export let AppView = (app : App) =>
 
             for (let i = 0; i < rows.length; i++) {
                 var row = rows[i],
+                    span : HTMLSpanElement = null!,
                     tr : RowTr | undefined = i < trs.length ? trs[i] : tbody.appendChild(
                         (<tr ref={tr}>
                             <td ref={tr!._id} className="col-md-1"></td>
                             <td className="col-md-4">
                                 <a ref={tr!._label} className="select"></a>
                             </td>
-                            <td className="col-md-1"><a className="delete"><span className="glyphicon glyphicon-remove delete"></span></a></td>
+                            <td className="col-md-1"><a className="delete"><span ref={span} className="glyphicon glyphicon-remove delete"></span></a></td>
                             <td className="col-md-6"></td>
-                        </tr> as RowTr,
+                         </tr> as RowTr,
+                        span.setAttribute("aria-hidden", "true"),
                         trs.push(tr!),
                         tr!));
 


### PR DESCRIPTION
@localvoid noticed (#213) that I mistakenly didn't include the aria-hidden="true" attributes in the surplus implementation.  He's right, they should be there, so this adds them.  It does it in a somewhat artless way.  Once I finish my rewrite of the surplus compiler I'll repost a cleaner fix.