### PR TITLE
Fix brittle benchmark implementation in Simulacra.js

### DIFF
--- a/simulacra-v2.1.1-non-keyed/src/main.js
+++ b/simulacra-v2.1.1-non-keyed/src/main.js
@@ -29,20 +29,21 @@ var binding = [ '#main', {
     isSelected: function (node, value) {
       node.className = value ? 'danger' : ''
     }
-  }, bindEvents({
-    click: function (event, path) {
-      if (event.target.tagName === 'SPAN') {
-        bench('delete', function () {
-          var id = event.target.parentNode.parentNode
-            .parentNode.childNodes[1].textContent
+  }, function (node) {
+    bindEvents({
+      click: function (event, path) {
+        if (event.target.tagName === 'SPAN') {
+          bench('delete', function () {
+            var id = node.querySelector('td:nth-of-type(1)').textContent
 
-          path.root.rows.splice(path.root.rows.findIndex(function (obj) {
-            return obj.id === id
-          }), 1)
-        })
+            path.root.rows.splice(path.root.rows.findIndex(function (obj) {
+              return obj.id === id
+            }), 1)
+          })
+        }
       }
-    }
-  }) ]
+    }).apply(null, arguments)
+  } ]
 } ]
 
 var methods = {


### PR DESCRIPTION
I had previously implemented the remove benchmark using a positional index in the DOM, which was evidently flaky and unreliable. This fixes that by using a CSS selector.

Closes https://github.com/krausest/js-framework-benchmark/issues/216