### PR TITLE
Fix filename in reflex-dom's package.json

### DIFF
--- a/reflex-dom-v0.4-keyed/package.json
+++ b/reflex-dom-v0.4-keyed/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "install": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to clone reflex-dom\\'s benchmark and build system use: && echo npm run install-force",
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",
-    "install-force": "./clone-reflex.sh",
+    "install-force": "./install.sh",
     "build-prod-force": "./build.sh"
   },
   "repository": {


### PR DESCRIPTION
Installing reflex-dom from `package.json` currently fails - guess I messed up when commiting https://github.com/krausest/js-framework-benchmark/commit/34ce2b0a8d5ccd46580cdbaf3a83a5859406dc43.
Should I add `npm run install-force` & `npm run build-prod-force` to CI ?