### PR TITLE
Disable GPU when running in headless mode for now

### DIFF
--- a/webdriver-ts/src/benchmarkRunner.ts
+++ b/webdriver-ts/src/benchmarkRunner.ts
@@ -229,8 +229,10 @@ function buildDriver() {
     // options = options.setChromeBinaryPath("/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome");
     // options = options.setChromeBinaryPath("/Applications/Chromium.app/Contents/MacOS/Chromium");
     // options = options.setChromeBinaryPath("/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary");
-    if(args.headless)
+    if(args.headless) {
 	options = options.addArguments("--headless");
+	options = options.addArguments("--disable-gpu");
+    }
     options = options.addArguments("--js-flags=--expose-gc");
     options = options.addArguments("--disable-infobars");
     options = options.addArguments("--disable-background-networking");


### PR DESCRIPTION
Recommended in https://developers.google.com/web/updates/2017/04/headless-chrome
Appears to be required when running under nixos