### PR TITLE
Fix issue 294 - Update to "swap rows" implementation

### DIFF
--- a/halogen-v2.1.0-non-keyed/src/Main.purs
+++ b/halogen-v2.1.0-non-keyed/src/Main.purs
@@ -185,8 +185,8 @@ swapRows arr index1 index2 = do
   rowB <- arr !! index2
 
   let diff = index2 - index1
-  arrA <- updateAt index1 rowB { rid = rowB.rid - diff } arr
-  arrB <- updateAt index2 rowA { rid = rowA.rid + diff } arrA
+  arrA <- updateAt index1 rowB arr
+  arrB <- updateAt index2 rowA arrA
 
   pure arrB
 

--- a/pux-v11.0.0-non-keyed/src/Main.purs
+++ b/pux-v11.0.0-non-keyed/src/Main.purs
@@ -231,8 +231,8 @@ swapRows arr index1 index2 = do
   rowB <- arr !! index2
 
   let diff = index2 - index1
-  arrA <- updateAt index1 rowB { rid = rowB.rid - diff } arr
-  arrB <- updateAt index2 rowA { rid = rowA.rid + diff } arrA
+  arrA <- updateAt index1 rowB arr
+  arrB <- updateAt index2 rowA arrA
 
   pure arrB
 

--- a/thermite-v4.0.0-non-keyed/src/Main.purs
+++ b/thermite-v4.0.0-non-keyed/src/Main.purs
@@ -268,8 +268,8 @@ swapRows arr index1 index2 = do
   rowB <- arr A.!! index2
 
   let diff = index2 - index1
-  arrA <- A.updateAt index1 rowB { rid = rowB.rid - diff } arr
-  arrB <- A.updateAt index2 rowA { rid = rowA.rid + diff } arrA
+  arrA <- A.updateAt index1 rowB arr
+  arrB <- A.updateAt index2 rowA arrA
 
   pure arrB
 


### PR DESCRIPTION
Hi @krausest,

This is a small fix. I had misunderstood the implementation and preserved row IDs after being swapped; this change no longer does that.

This fixes:
https://github.com/krausest/js-framework-benchmark/issues/294

I did not uncomment the `common.ts` file so the frameworks are still disabled in this PR.