### PR TITLE
simpler surplus-v0.5.0-non-keyed implementation

### DIFF
--- a/surplus-v0.5.0-non-keyed/package.json
+++ b/surplus-v0.5.0-non-keyed/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "s-js": "^0.4.7",
-    "s-array": "^0.4.8",
+    "s-array": "^0.4.9",
     "surplus": "^0.5.0-beta3"
   },
   "devDependencies": {

--- a/surplus-v0.5.0-non-keyed/src/view.tsx
+++ b/surplus-v0.5.0-non-keyed/src/view.tsx
@@ -1,88 +1,65 @@
 import * as Surplus from 'surplus'; Surplus;
 import S from 's-js';
-import { mapSample } from 's-array';
+import { mapSequentially } from 's-array';
 import { Store } from './store';
 
 export const 
-    AppView = (store : Store) => {
-        var view = 
-            <div className="container">
-                <div className="jumbotron">
-                    <div className="row">
-                        <div className="col-md-6">
-                            <h1>Surplus v0.5.0</h1>
-                        </div>
-                        <div className="col-md-6">
-                            <div className="row">
-                                <div className="col-sm-6 smallpad">
-                                    <button type="button" className="btn btn-primary btn-block" id="run" onClick={e => store.run()}>Create 1,000 rows</button>
-                                </div>
-                                <div className="col-sm-6 smallpad">
-                                    <button type="button" className="btn btn-primary btn-block" id="runlots" onClick={e => store.runLots()}>Create 10,000 rows</button>
-                                </div>
-                                <div className="col-sm-6 smallpad">
-                                    <button type="button" className="btn btn-primary btn-block" id="add" onClick={e => store.add()}>Append 1,000 rows</button>
-                                </div>
-                                <div className="col-sm-6 smallpad">
-                                    <button type="button" className="btn btn-primary btn-block" id="update" onClick={e => store.update()}>Update every 10th row</button>
-                                </div>
-                                <div className="col-sm-6 smallpad">
-                                    <button type="button" className="btn btn-primary btn-block" id="clear" onClick={e => store.clear()}>Clear</button>
-                                </div>
-                                <div className="col-sm-6 smallpad">
-                                    <button type="button" className="btn btn-primary btn-block" id="swaprows" onClick={e => store.swapRows()}>Swap Rows</button>
-                                </div>
+    AppView = (store : Store) => 
+        <div className="container">
+            <div className="jumbotron">
+                <div className="row">
+                    <div className="col-md-6">
+                        <h1>Surplus v0.5.0</h1>
+                    </div>
+                    <div className="col-md-6">
+                        <div className="row">
+                            <div className="col-sm-6 smallpad">
+                                <button type="button" className="btn btn-primary btn-block" id="run" onClick={e => store.run()}>Create 1,000 rows</button>
+                            </div>
+                            <div className="col-sm-6 smallpad">
+                                <button type="button" className="btn btn-primary btn-block" id="runlots" onClick={e => store.runLots()}>Create 10,000 rows</button>
+                            </div>
+                            <div className="col-sm-6 smallpad">
+                                <button type="button" className="btn btn-primary btn-block" id="add" onClick={e => store.add()}>Append 1,000 rows</button>
+                            </div>
+                            <div className="col-sm-6 smallpad">
+                                <button type="button" className="btn btn-primary btn-block" id="update" onClick={e => store.update()}>Update every 10th row</button>
+                            </div>
+                            <div className="col-sm-6 smallpad">
+                                <button type="button" className="btn btn-primary btn-block" id="clear" onClick={e => store.clear()}>Clear</button>
+                            </div>
+                            <div className="col-sm-6 smallpad">
+                                <button type="button" className="btn btn-primary btn-block" id="swaprows" onClick={e => store.swapRows()}>Swap Rows</button>
                             </div>
                         </div>
                     </div>
                 </div>
-                <table className="table table-hover table-striped test-data">
-                    <tbody ref={tbody} onClick = {(e : any) => e.target.matches('.delete') ? store.delete(rowId(e)) : store.select(rowId(e))} />
-                </table>
-                <span className="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
-            </div>,
-        // use a computation to keep tbody content in sync with data
-        tbody : any, // set by ref above
-        trs = [] as any[], // cached set of trs in tbody
-        data = clearAfterAnimationRequest(store.data); // 
-
-        S(() => {
-            let rows = data(),
-                selectedId = store.selected();
-
-            // remove excess rows, taking advantage of fast clear if they're all gone
-            if (rows.length === 0 && trs.length > 0) {
-                tbody.textContent = '';
-                trs = [];
-            } else for (let i = trs.length - 1; i >= rows.length; i--) { 
-                tbody.removeChild(trs[i]); 
-                trs.pop();
-            }
-
-            // update retained rows
-            for (let i = 0; i < rows.length; i++) {
-                var row = rows[i],
-                    // fetch or create new tr
-                    tr : any = i < trs.length ? trs[i] : tbody.appendChild(
-                        <tr ref={tr = trs[i]}>
+            </div>
+            <table className="table table-hover table-striped test-data">
+                <tbody onClick={(e : any) => e.target.matches('.delete') ? store.delete(rowId(e)) : store.select(rowId(e))}>
+                    {// use mapSequentially to preserve node order
+                     clearAfterAnimationRequest(mapSequentially(store.data, (row, tr : any) => {
+                        // create a tr if needed, assigning it to `tr` and caching internal nodes via refs
+                        tr || <tr ref={tr}>
                             <td ref={tr._id} className="col-md-1"></td>
                             <td className="col-md-4">
                                 <a ref={tr._label}></a>
                             </td>
                             <td className="col-md-1"><a><span className="glyphicon glyphicon-remove delete" aria-hidden="true"></span></a></td>
                             <td className="col-md-6"></td>
-                        </tr>
-                    );
+                        </tr>;
+                        
+                        // update tr, comparing against values cached on it to see if necessary
+                        tr.className = row.id === store.selected() ? 'danger' : '';
+                        if (tr._row_id !== row.id) tr._id.innerText = (tr._row_id = row.id) + '';
+                        if (tr._row_label !== row.label) tr._label.innerText = tr._row_label = row.label;
 
-                // update tr, comparing against values cached on it to see if necessary
-                tr.className = row.id === selectedId ? 'danger' : '';
-                if (tr._row_id !== row.id) tr._id.innerText = (tr._row_id = row.id) + '';
-                if (tr._row_label !== row.label) tr._label.innerText = tr._row_label = row.label;
-            }
-        });
-
-        return view;
-    },
+                        return tr;
+                    }))}
+                </tbody>
+            </table>
+            <span className="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
+        </div>,
     rowId = (e : any) => +e.target.closest('tr').firstChild.textContent,
     // For not well understood reasons, Chrome runs DOM clear operations a good bit faster when they're
     // deferred until after an animation frame.  So we buffer the row signal in a data signal and delay


### PR DESCRIPTION
Hi Stefan --
This is a much simpler non-keyed implementation than the last PR.  The last one essentially hand-rolled its own 30-line reconciler for the table rows, which was fast, and kind of cool that you can do it (since surplus is real DOM), but also kind of crazy.  This uses a (new) standard function mapSequentially plus the default reconciler, cutting about 25 lines from the code.  The old one came in 1-2% off of vanillajs, this one is more like 3-4%.

All my own apps use keyed-style rendering, so honestly, I hadn't even thought about this implementation until it came time to submit.  Surplus 0.5 was pretty much all aimed at improvements to keyed implementations.

Best
-- Adam

<img width="283" alt="screen shot 2017-11-14 at 5 22 27 pm" src="https://user-images.githubusercontent.com/1620206/32808258-6eadf724-c960-11e7-9292-2cf8a82075b5.png">
