### PR TITLE
Run all circleci node commands in the same shell

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,17 +17,8 @@ jobs:
       - run: |
           source $NVM_DIR/nvm.sh
           nvm install v8.9.1
-          nvm use v8.9.1
-          nvm alias default v8.9.1
-          node -v
-#          nvm uninstall default
-#          curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-#          sudo apt-get install -y nodejs
 
-      - run: npm install
-      - run:
-          name: Start http-server
-          command: npm start
-          background: true
-      - run: npm run build
-      - run: npm run check
+          npm install
+          npm start &
+          npm run build
+          npm run check


### PR DESCRIPTION
Fixes #323.

I don't really like this solution (and avoided it at first) since it makes logs messier and it's harder to see how much time each command took, but having to account for $PATH being reset and resourced is a pain, _especially_ when it's changed by scripts.

