### PR TITLE
use lighthouse to calculate metrics from CPU benchmark

### DIFF
--- a/webdriver-ts/package.json
+++ b/webdriver-ts/package.json
@@ -28,8 +28,10 @@
   },
   "dependencies": {
     "chromedriver": "2.33.2",
+    "columnify": "^1.5.4",
     "dot": "1.1.2",
     "jstat": "1.7.1",
+    "lighthouse": "^2.6.0",
     "lodash": "4.17.4",
     "ramda": "^0.25.0",
     "selenium-webdriver": "3.6.0",

--- a/webdriver-ts/src/lighthouseConfig.ts
+++ b/webdriver-ts/src/lighthouseConfig.ts
@@ -1,0 +1,42 @@
+export const lhConfig = {
+  artifacts: {
+    traces: {},
+    devtoolsLogs: {}
+  },
+
+  audits: [
+    "speed-index-metric",
+    "estimated-input-latency",
+    "first-meaningful-paint",
+    "time-to-first-byte",
+    "first-interactive",
+    "consistently-interactive",
+    "user-timings",
+    "critical-request-chains",
+    "byte-efficiency/total-byte-weight",
+    "screenshot-thumbnails",
+    "mainthread-work-breakdown",
+    "bootup-time"
+  ],
+
+  categories: {
+    performance: {
+      name: "Performance",
+      description: "These encapsulate your app's current performance and opportunities to improve it.",
+      audits: [
+        {id: "first-meaningful-paint", weight: 5},
+        {id: "first-interactive", weight: 5},
+        {id: "consistently-interactive", weight: 5},
+        {id: "speed-index-metric", weight: 1},
+        {id: "estimated-input-latency", weight: 1},
+        {id: "time-to-first-byte", weight: 0},
+        {id: "total-byte-weight", weight: 0},
+        {id: "critical-request-chains", weight: 0},
+        {id: "user-timings", weight: 0},
+        {id: "bootup-time", weight: 0},
+        {id: "screenshot-thumbnails", weight: 0},
+        {id: "mainthread-work-breakdown", weight: 0}
+      ]
+    }
+  }
+};


### PR DESCRIPTION
Thanks to your ping in https://github.com/krausest/js-framework-benchmark/issues/316#issuecomment-348297110 I spent some time on this so we could get a TTI metric calculated for you. Basically I'm just using Lighthouse to [process the perfLog](https://github.com/GoogleChrome/lighthouse/blob/master/docs/readme.md#lighthouse-as-trace-processor).

![image](https://user-images.githubusercontent.com/39191/33500775-e994af88-d68e-11e7-8615-32b7c405db52.png)

I wasn't sure where this belongs between the CPU/MEM/Startup benchmarks, so I stuffed it into CPU. But the nice part here is that the only instrumentation changes are flipping on `enableNetwork`/`enablePage` and recording a few additional trace categories.



For now, I'm just logging the results to the console, though I'm sure you probably want to redirect the values somewhere more useful. 

As for the metrics themselves (and how they apply to this benchmark):

* **first contentful paint** - will be affected by render blocking resources, so the size and number of them. 
   - Probably not terribly useful
* **first meaningful paint** - the paint following the most significant layout during load. 
   - If the initial painting of the DOM is key, then it's useful. But I can imagine it might catch some of the DOM changes that the benchmark triggers.. in which case I don't think it'd be a good signal.
* **onload** - it's normal onload. 
   - seems like its basically[ your durationJS](https://github.com/krausest/js-framework-benchmark/issues/316#issuecomment-347670958)
* **first interactive** - an optimistic TTI - the first moment the main thread stays idle for a little bit.
* **consistently interactive** - a pessimistic TTI - when the CPU and network are both definitely very idle. (no more CPU tasks over 50ms)
* **script bootup time** - the total ms required to parse/compile/evaluate all the page's scripts.
* **main thread work cost** - total amount of time spent doing work on the main thread. includes style/layout/etc. 
   - seems useful for this application, for sure.
* **estimated input latency** - kind of represents how slammed the main thread was. higher numbers are bad. 
   - it's tuned for normal pageloads, so i'm not sure how good a signal it is for here.
* **total byte weight** - network transfer cost (post-compression) of all the resources loaded into the page.

hope this is helpful!!