### PR TITLE
Allow supplying a custom port to benchmark runner

### DIFF
--- a/webdriver-ts/src/benchmarkRunner.ts
+++ b/webdriver-ts/src/benchmarkRunner.ts
@@ -362,7 +362,7 @@ async function runMemOrCPUBenchmark(framework: FrameworkData, benchmark: Benchma
             for (let i = 0; i<config.REPEAT_RUN; i++) {
             try {
                 setUseShadowRoot(framework.useShadowRoot);
-                await driver.get(`http://localhost:8080/${framework.uri}/`);
+                await driver.get(`http://localhost:` + args.port + `/${framework.uri}/`);
                 await driver.executeScript("console.timeStamp('initBenchmark')");
                 await initBenchmark(driver, benchmark, framework);
                 await driver.executeScript("console.timeStamp('runBenchmark')");
@@ -450,6 +450,7 @@ let args = yargs(process.argv)
 .default('check','false')
 .default('exitOnError','false')
 .default('count', config.REPEAT_RUN)
+.default('port', config.PORT)
 .string('chromeBinary')
 .string('chromeDriver')
 .boolean('headless')
@@ -460,6 +461,7 @@ console.log(args);
 let runBenchmarks = args.benchmark && args.benchmark.length>0 ? args.benchmark : [""];
 let runFrameworks = args.framework && args.framework.length>0 ? args.framework : [""];
 let count = Number(args.count);
+let port = Number(args.port);
 
 config.REPEAT_RUN = count;
 

--- a/webdriver-ts/src/common.ts
+++ b/webdriver-ts/src/common.ts
@@ -5,6 +5,7 @@ export interface JSONResult {
 }
 
 export let config = {
+    PORT: 8080,
     REPEAT_RUN: 10,
     DROP_WORST_RUN: 0,
     WARMUP_COUNT: 5,


### PR DESCRIPTION
Currently, if port 8080 is occupied, one of at least two things happen
- NixOS (possibly any Linux):   http-server will try 8081, 8082 and so on but the benchmark runner won't find it.
- MacOS: http-server will fail with `Error: listen EADDRINUSE 0.0.0.0:8080`

If one passes a custom port with `npm run start -- -p`, then it's also not found.