### PR TITLE
clamp metrics with delta of < half a frame (~8.3ms)

### DIFF
--- a/webdriver-ts-results/src/Common.tsx
+++ b/webdriver-ts-results/src/Common.tsx
@@ -236,7 +236,7 @@ export class ResultTableData {
             if (result === null) return null;
             else {
                 let mean = this.useMedian ? result.median : result.mean;
-                let factor = clamp ? Math.max(16, mean) / Math.max(16, min) : mean/min;
+                let factor = clamp && (mean - min < 16.667/2) ? 1 : mean/min;
                 let standardDeviation = result.standardDeviation;
 
                 let statisticalResult = undefined;


### PR DESCRIPTION
@krausest 

in general i'm not a huge fan of clamping, but...

the current clamping behavior is heavily biased towards lightweight metrics/workloads (those that finish within 1 frame) rather than those that *differ* by 1 frame or less.

if you look at "select row", almost everyone is at 1.0 because they're < 16ms and the range is 7.5 - 15.0. now look at "partial update". the minimum is 72.0 but everything that can also finish within the same frame (up to 72 + 16.667 = 88.667) is marked with a factor larger than 1.0. a more ridiculius example is "swap rows" with a baseline of 17.0 which is already at least 2 frames, but everything else that will finish within these 2 frames (from 18.0 up to 33.334) is penalized.

what this PR does is make the clamping behavior more logical. the change will clamp any differences smaller than half a frame to 1.0, regardless of the actual workload or absolute timings. it will have the effect of making "swap rows" 1.0 from the baseline of 17.0 to ~25.3. this entire range will certainly be completely transparent to the user since everything here will take 2 frames. as i understand it, clamping is supposed to mask imperceptible differences, and this method does a better and more uniform job of it across all metrics, i think.