### PR TITLE
Bump http-server to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "command-exists": "^1.0.2",
     "fs-extra": "^0.30.0",
-    "http-server": "^0.9.0",
+    "http-server": "^0.10.0",
     "lodash": "^4.15.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Turns out the `Error: listen EADDRINUSE 0.0.0.0:8080` error I mentioned in #333 is fixed by the new release of `http-server` : https://github.com/indexzero/http-server/issues/215
Of course, #333 is still needed when using anything but port 8080. 