### PR TITLE
Remove hardcoded port number

### DIFF
--- a/webdriver-ts/src/benchmarkRunner.ts
+++ b/webdriver-ts/src/benchmarkRunner.ts
@@ -287,7 +287,7 @@ async function snapMemorySize(driver: WebDriver): Promise<number> {
 }
 
 async function runBenchmark(driver: WebDriver, benchmark: Benchmark, framework: FrameworkData) : Promise<any> {
-    await benchmark.run(driver, framework);
+    await benchmark.run(driver, framework, port);
     if (config.LOG_PROGRESS) console.log("after run ",benchmark.id, benchmark.type, framework.name);
     if (benchmark.type === BenchmarkType.MEM) {
         await forceGC(framework, driver);
@@ -302,7 +302,7 @@ async function afterBenchmark(driver: WebDriver, benchmark: Benchmark, framework
 }
 
 async function initBenchmark(driver: WebDriver, benchmark: Benchmark, framework: FrameworkData): Promise<any> {
-    await benchmark.init(driver, framework)
+    await benchmark.init(driver, framework, port)
     if (config.LOG_PROGRESS) console.log("after initialized ",benchmark.id, benchmark.type, framework.name);
     if (benchmark.type === BenchmarkType.MEM) {
         await forceGC(framework, driver);

--- a/webdriver-ts/src/benchmarks.ts
+++ b/webdriver-ts/src/benchmarks.ts
@@ -24,8 +24,8 @@ export abstract class Benchmark {
         this.label = benchmarkInfo.label;
         this.description = benchmarkInfo.description;
     }
-    abstract init(driver: WebDriver, framework: FrameworkData): Promise<any>;
-    abstract run(driver: WebDriver, framework: FrameworkData): Promise<any>;
+    abstract init(driver: WebDriver, framework: FrameworkData, port: number): Promise<any>;
+    abstract run(driver: WebDriver, framework: FrameworkData, port: number): Promise<any>;
     after(driver: WebDriver, framework: FrameworkData): Promise<any> { return null; }
     // Good fit for a single result creating Benchmark
     resultKinds(): Array<BenchmarkInfo> { return [this.benchmarkInfo]; }
@@ -380,9 +380,9 @@ class BenchStartup extends Benchmark {
             type: BenchmarkType.STARTUP,
         })
     }
-    async init(driver: WebDriver) { await driver.get(`http://localhost:8080/`); }
-    async run(driver: WebDriver, framework: FrameworkData) {
-        await driver.get(`http://localhost:8080/${framework.uri}/`);
+    async init(driver: WebDriver, framework: FrameworkData, port: number) { await driver.get(`http://localhost:` + port + `/`); }
+    async run(driver: WebDriver, framework: FrameworkData, port: number) {
+        await driver.get(`http://localhost:` + port + `/${framework.uri}/`);
         await testElementLocatedById(driver, "run", SHORT_TIMEOUT);
         return driver.sleep(config.STARTUP_SLEEP_DURATION);
     }

--- a/webdriver-ts/src/nonKeyed.ts
+++ b/webdriver-ts/src/nonKeyed.ts
@@ -108,7 +108,7 @@ function isNonKeyedSwapRow(result: any): boolean {
     return true;
 }
 
-async function runBench(frameworkNames: string[]) {
+async function runBench(frameworkNames: string[], port: number) {
     let runFrameworks = frameworks.filter(f => frameworkNames.some(name => f.name.indexOf(name)>-1));
     console.log("Frameworks that will be checked", runFrameworks.map(f => f.name));
 
@@ -120,7 +120,7 @@ async function runBench(frameworkNames: string[]) {
         try {
             let framework = runFrameworks[i];
             setUseShadowRoot(framework.useShadowRoot);
-            await driver.get(`http://localhost:8080/${framework.uri}/`);
+            await driver.get(`http://localhost:` + port + `/${framework.uri}/`);
             await testElementLocatedById(driver, "add");
             await clickElementById(driver,'run');
             await testTextContains(driver,'//tbody/tr[1000]/td[1]','1000');
@@ -164,13 +164,15 @@ let args = yargs(process.argv)
 .usage("$0 [--framework Framework1,Framework2,...]")
 .help('help')
 .default('check','false')
+.default('port', config.PORT)
 .array("framework").array("benchmark").argv;
 
 let runFrameworks = args.framework && args.framework.length>0 ? args.framework : [""];
+let port = Number(args.port);
 
 if (args.help) {
     yargs.showHelp();
 } else {
-    runBench(runFrameworks);
+    runBench(runFrameworks, port);
 }
 


### PR DESCRIPTION
#333 didn't replace all hardcoded mentions to port 8080, which caused benchmark `30_startup` and the `nonKeyed` script to fail when using other ports.
