### PR TITLE
print timings to browser console (inferno-v4.0.6-keyed)

### DIFF
--- a/inferno-v4.0.6-keyed/src/controller.jsx
+++ b/inferno-v4.0.6-keyed/src/controller.jsx
@@ -73,55 +73,84 @@ export class Controller extends Component {
     this.runLots = this.runLots.bind(this);
     this.clear = this.clear.bind(this);
     this.swapRows = this.swapRows.bind(this);
-    this.start = 0;
+    this.startTime = null;
+    this.lastMeasure = "";
+  }
+
+  startMeasure(name) {
+    this.startTime = performance.now();
+    this.lastMeasure = name;
+  };
+
+  stopMeasure() {
+    window.setTimeout(() => {
+      let stop = performance.now();
+      console.log(this.lastMeasure+" took "+(stop-this.startTime));
+    }, 0);
   }
 
   run() {
+    this.startMeasure("run");
     event.stopPropagation();
     this.state.store.run();
     this.setState({ store: this.state.store });
+    this.stopMeasure();
   }
 
   add() {
+    this.startMeasure("add");
     event.stopPropagation();
     this.state.store.add();
     this.setState({ store: this.state.store });
+    this.stopMeasure();
   }
 
   update() {
+    this.startMeasure("update");
     event.stopPropagation();
     this.state.store.update();
     this.setState({ store: this.state.store });
+    this.stopMeasure();
   }
 
   select(id, event) {
+    this.startMeasure("select");
     event.stopPropagation();
     this.state.store.select(id);
     this.setState({ store: this.state.store });
+    this.stopMeasure();
   }
 
   delete(id, event) {
+    this.startMeasure("delete");
     event.stopPropagation();
     this.state.store.delete(id);
     this.setState({ store: this.state.store });
+    this.stopMeasure();
   }
 
   runLots() {
+    this.startMeasure("runLots");
     event.stopPropagation();
     this.state.store.runLots();
     this.setState({ store: this.state.store });
+    this.stopMeasure();
   }
 
   clear(event) {
+    this.startMeasure("clear");
     event.stopPropagation();
     this.state.store.clear();
     this.setState({ store: this.state.store });
+    this.stopMeasure();
   }
 
   swapRows() {
+    this.startMeasure("swapRows");
     event.stopPropagation();
     this.state.store.swapRows();
     this.setState({ store: this.state.store });
+    this.stopMeasure();
   }
 
   render() {


### PR DESCRIPTION
Going through the readme I noticed in [section 3](https://github.com/arlimus/js-framework-benchmark\#3-building-and-running-a-single-framework) that the inferno-v4.0.6-keyed results didnt print to the browsers console. Added them.

![screenshot from 2018-03-17 11-10-32](https://user-images.githubusercontent.com/1307529/37558637-e567d4f6-29d3-11e8-9ca6-7ff166390d7b.png)

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>