### PR TITLE
close before quit to avoid zombie instances on windows

### DIFF
--- a/webdriver-ts/src/benchmarkRunner.ts
+++ b/webdriver-ts/src/benchmarkRunner.ts
@@ -377,10 +377,12 @@ async function runMemOrCPUBenchmark(framework: FrameworkData, benchmark: Benchma
         let results = benchmark.type === BenchmarkType.CPU ? await computeResultsCPU(driver) : await computeResultsMEM(driver);
         await writeResult({framework: framework, results: results, benchmark: benchmark}, dir);
         console.log("QUIT");
+        await driver.close();
         await driver.quit();
     } catch (e) {
         console.log("ERROR:", e);
         console.log("QUIT");
+        await driver.close();
         await driver.quit();
         if (config.EXIT_ON_ERROR) { throw "Benchmarking failed"}
     }
@@ -408,6 +410,7 @@ async function runStartupBenchmark(framework: FrameworkData, benchmark: Benchmar
                 await registerError(driver, framework, benchmark, e);
                 throw e;
             } finally {
+                await driver.close();
                 await driver.quit();
             }
         }


### PR DESCRIPTION
See #378. It seems that chrome driver doesn't kill off all sub-processes on windows if you call `quit` when there are still open windows. The result being that after a few benchmarks are run, the system starts bogging down terribly. This seems to work on my machine, but there is a comment in #378 suggesting that it may not cover all of the corners 100%.