### PR TITLE
Fix reagent build in windows

### DIFF
--- a/reagent-v0.8-keyed/package.json
+++ b/reagent-v0.8-keyed/package.json
@@ -1,10 +1,11 @@
 {
   "private": true,
   "scripts": {
-    "build-dev": "LEIN_VERSION=2.8.1 lein cljsbuild auto",
-    "build-prod": "LEIN_VERSION=2.8.1 lein cljsbuild once prod"
+    "build-dev" : "cross-env LEIN_VERSION=2.8.1 lein self-install && lein cljsbuild auto",
+    "build-prod": "cross-env LEIN_VERSION=2.8.1 lein self-install && lein cljsbuild once prod"
   },
   "dependencies": {
-    "lein-bin": "0.1.0"
+    "cross-env": "5.1.4",
+    "lein-bin" : "0.1.0"
   }
 }


### PR DESCRIPTION
Fixes #377 
Looks like leiningen needs an [explicit installation](https://github.com/technomancy/leiningen#windows) step on windows.
Only tested via [appveyor](https://ci.appveyor.com/project/alexteves13469/js-framework-benchmark/build/1.0.22) thus far, which unfortunately timeouts while running the benchmarks, so I haven't opened a PR for that.