### PR TITLE
Add ko-jsx

### DIFF
--- a/knockout-v3.4.2-ko-jsx-keyed/.babelrc
+++ b/knockout-v3.4.2-ko-jsx-keyed/.babelrc
@@ -1,0 +1,3 @@
+{
+    "plugins": [["jsx-dom-expressions", {"noWhitespaceOnly": true}]]
+}

--- a/knockout-v3.4.2-ko-jsx-keyed/index.html
+++ b/knockout-v3.4.2-ko-jsx-keyed/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>Knockout JSX</title>
+    <link href="/css/currentStyle.css" rel="stylesheet"/>
+</head>
+<body>
+<div id='main'></div>
+<script src='dist/main.js'></script>
+</body>
+</html>

--- a/knockout-v3.4.2-ko-jsx-keyed/package.json
+++ b/knockout-v3.4.2-ko-jsx-keyed/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "js-framework-benchmark-ko-jsx",
+  "version": "0.0.1",
+  "main": "index.js",
+  "scripts": {
+    "build-dev": "rollup -c",
+    "build-prod": "rollup -c --environment production"
+  },
+  "author": "Ryan Carniato",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "dependencies": {
+    "knockout": "3.4.2",
+    "ko-jsx": "^0.0.1"
+  },
+  "devDependencies": {
+    "@babel/core": "*",
+    "@babel/plugin-syntax-jsx": "*",
+    "babel-plugin-jsx-dom-expressions": "0.0.11",
+    "rollup": "^0.58.2",
+    "rollup-plugin-babel": "beta",
+    "rollup-plugin-commonjs": "^9.1.3",
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-uglify": "^3.0.0"
+  }
+}

--- a/knockout-v3.4.2-ko-jsx-keyed/rollup.config.js
+++ b/knockout-v3.4.2-ko-jsx-keyed/rollup.config.js
@@ -1,0 +1,27 @@
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import babel from 'rollup-plugin-babel';
+import uglify from 'rollup-plugin-uglify';
+
+const plugins = [
+	babel({
+    exclude: 'node_modules/**'
+  }),
+	resolve({ extensions: ['.js', '.jsx'] }),
+	commonjs({
+		include: 'node_modules/**'
+	})
+];
+
+if (process.env.production) {
+	plugins.push(uglify());
+}
+
+export default {
+	input: 'src/Main.js',
+	output: {
+		file: 'dist/main.js',
+		format: 'iife'
+	},
+	plugins
+};

--- a/knockout-v3.4.2-ko-jsx-keyed/src/Main.js
+++ b/knockout-v3.4.2-ko-jsx-keyed/src/Main.js
@@ -1,0 +1,116 @@
+import ko from 'knockout'
+import r from 'ko-jsx'
+import template from './template'
+
+var startTime;
+var lastMeasure;
+
+var startMeasure = function (name) {
+    startTime = performance.now();
+    lastMeasure = name;
+};
+var stopMeasure = function () {
+    window.setTimeout(function () {
+        var stop = performance.now();
+        console.log(lastMeasure + " took " + (stop - startTime));
+    }, 0);
+};
+
+var HomeViewModel = function () {
+    var self = this;
+    self.id = 1;
+
+    function _random(max) {
+        return Math.round(Math.random() * 1000) % max;
+    }
+
+    function buildData(count) {
+        var adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"];
+        var colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"];
+        var nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+        var data = [];
+        for (var i = 0; i < count; i++) {
+            data.push(new ItemViewModel({
+                id: self.id++,
+                label: adjectives[_random(adjectives.length)] + " " + colours[_random(colours.length)] + " " + nouns[_random(nouns.length)]
+            }));
+        }
+        return data;
+    }
+
+    self.selected = ko.observable(null);
+    self.data = ko.observableArray();
+
+    self.run = function () {
+        startMeasure("run");
+        self.data(buildData(1000));
+        self.selected(null);
+        stopMeasure();
+    };
+
+    self.runLots = function () {
+        startMeasure("runLots");
+        self.data(buildData(10000));
+        self.selected(null);
+        stopMeasure();
+    };
+
+    self.add = function () {
+        startMeasure("add");
+        self.data.push.apply(self.data, buildData(1000));
+        stopMeasure();
+    };
+
+    self.update = function () {
+        startMeasure("update");
+        var tmp = self.data();
+        for (let i = 0; i < tmp.length; i += 10) {
+            tmp[i].label(tmp[i].label() + ' !!!');
+        }
+        stopMeasure();
+    };
+
+    self.clear = function () {
+        startMeasure("clear");
+        self.data.removeAll();
+        self.selected(null);
+        stopMeasure();
+    };
+
+    self.swapRows = function () {
+        startMeasure("swapRows");
+        var tmp = self.data();
+        if (tmp.length > 998) {
+            var a = tmp[1];
+            tmp[1] = tmp[998];
+            tmp[998] = a;
+            self.data(tmp);
+        }
+        stopMeasure();
+    };
+
+    self.select = function (id) {
+        startMeasure("select");
+        self.selected(id);
+        stopMeasure();
+    };
+
+    self.del = function (item) {
+        startMeasure("delete");
+        var tmp = self.data();
+        const idx = tmp.findIndex(d => d.id === item.id);
+        self.data.splice(idx, 1);
+        stopMeasure();
+    };
+};
+
+var ItemViewModel = function (data, parent) {
+    var self = this;
+
+    self.id = data.id;
+    self.label = ko.observable(data.label);
+};
+
+r.root(function () {
+    document.getElementById('main').appendChild(template(new HomeViewModel()))
+});

--- a/knockout-v3.4.2-ko-jsx-keyed/src/template.jsx
+++ b/knockout-v3.4.2-ko-jsx-keyed/src/template.jsx
@@ -1,0 +1,43 @@
+import ko from 'knockout'
+import r from 'ko-jsx'
+
+export default function({data, selected, run, runLots, add, update, clear, swapRows, select, del}) {
+  return (
+    <div class='container'>
+      <div class='jumbotron'><div class='row'>
+        <div class ='col-md-6'><h1>KnockoutJSX-keyed</h1></div>
+        <div class ='col-md-6'><div class ='row'>
+          <div class ='col-sm-6 smallpad'>
+            <button id='run' class='btn btn-primary btn-block' type='button' onClick={run}>Create 1,000 rows</button>
+          </div>
+          <div class='col-sm-6 smallpad'>
+            <button id='runlots' class='btn btn-primary btn-block' type='button' onClick={runLots}>Create 10,000 rows</button>
+          </div>
+          <div class='col-sm-6 smallpad'>
+            <button id='add' class='btn btn-primary btn-block' type='button' onClick={add}>Append 1,000 rows</button>
+          </div>
+          <div class='col-sm-6 smallpad'>
+            <button id='update' class='btn btn-primary btn-block' type='button' onClick={update}>Update every 10th row</button>
+          </div>
+          <div class='col-sm-6 smallpad'>
+            <button id='clear' class='btn btn-primary btn-block' type='button' onClick={clear}>Clear</button>
+          </div>
+          <div class='col-sm-6 smallpad'>
+            <button id='swaprows' class='btn btn-primary btn-block' type='button' onClick={swapRows}>Swap Rows</button>
+          </div>
+        </div></div>
+      </div></div>
+      <table class='table table-hover table-striped test-data'><tbody>{
+        data.map(row =>
+          <tr classList={{danger: row.id === selected()}}>
+            <td class='col-md-1'>{row.id}</td>
+            <td class='col-md-4'><a onClick={select.bind(this, row.id)}>{row.label}</a></td>
+            <td class='col-md-1'><a onClick={del.bind(this, row)}><span class='delete glyphicon glyphicon-remove' /></a></td>
+            <td class='col-md-6'/>
+          </tr>
+        )
+      }</tbody></table>
+      <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
+    </div>
+  )
+}

--- a/webdriver-ts/src/common.ts
+++ b/webdriver-ts/src/common.ts
@@ -86,6 +86,7 @@ export let frameworks = [
     f("inferno-v4.0.6-non-keyed", false),
     f("ivi-v0.9.1-keyed", true),
     f("knockout-v3.4.1-keyed", true),
+    f("knockout-v3.4.2-ko-jsx-keyed", true),
     f("lit-html-v0.9.0-keyed", true),
     f("lit-html-v0.9.0-non-keyed", false),
     f("maik-h-v2.5.2-keyed", true),


### PR DESCRIPTION
[https://github.com/ryansolid/ko-jsx](https://github.com/ryansolid/ko-jsx)

An alternate renderer for KnockoutJS that uses precompiled JSX to real DOM nodes with performance in mind. I hope will consider adding it to the benchmark suite.

Thanks.