### PR TITLE
fix benchmark numbering and naming

### DIFF
--- a/webdriver-ts/src/benchmarks.ts
+++ b/webdriver-ts/src/benchmarks.ts
@@ -342,7 +342,7 @@ const benchCreateClear5Memory = new class extends Benchmark {
 }
 
 const benchStartupConsistentlyInteractive: StartupBenchmarkResult = {
-    id: "30_startup-ci",
+    id: "31_startup-ci",
     label: "consistently interactive",
     description: "a pessimistic TTI - when the CPU and network are both definitely very idle. (no more CPU tasks over 50ms)",
     type: BenchmarkType.STARTUP,
@@ -350,7 +350,7 @@ const benchStartupConsistentlyInteractive: StartupBenchmarkResult = {
 }
 
 const benchStartupBootup: StartupBenchmarkResult = {
-    id: "30_startup-bt",
+    id: "32_startup-bt",
     label: "script bootup time",
     description: "the total ms required to parse/compile/evaluate all the page's scripts",
     type: BenchmarkType.STARTUP,
@@ -358,7 +358,7 @@ const benchStartupBootup: StartupBenchmarkResult = {
 }
 
 const benchStartupMainThreadWorkCost: StartupBenchmarkResult = {
-    id: "30_startup-mainthreadcost",
+    id: "33_startup-mainthreadcost",
     label: "main thread work cost",
     description: "total amount of time spent doing work on the main thread. includes style/layout/etc.",
     type: BenchmarkType.STARTUP,
@@ -366,7 +366,7 @@ const benchStartupMainThreadWorkCost: StartupBenchmarkResult = {
 }
 
 const benchStartupTotalBytes: StartupBenchmarkResult = {
-    id: "30_startup-totalbytes",
+    id: "34_startup-totalbytes",
     label: "total byte weight",
     description: "network transfer cost (post-compression) of all the resources loaded into the page.",
     type: BenchmarkType.STARTUP,

--- a/webdriver-ts/src/common.ts
+++ b/webdriver-ts/src/common.ts
@@ -1,5 +1,5 @@
 export interface JSONResult {
-    framework: string, benchmark: string, type: string, min: number,
+    framework: string, keyed: boolean, benchmark: string, type: string, min: number,
         max: number, mean: number, geometricMean: number,
         standardDeviation: number, median: number, values: Array<number>
 }

--- a/webdriver-ts/src/forkedBenchmarkRunner.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunner.ts
@@ -263,7 +263,7 @@ function buildDriver(benchmarkOptions: BenchmarkOptions) {
     options = options.setLoggingPrefs(logPref);
 
     options = options.setPerfLoggingPrefs(<any>{
-        enableNetwork: true, enablePage: true, 
+        enableNetwork: true, enablePage: true,
         traceCategories: lighthouse.traceCategories.join(", ")
     });
 
@@ -288,7 +288,7 @@ async function forceGC(framework: FrameworkData, driver: WebDriver): Promise<any
 }
 
 async function snapMemorySize(driver: WebDriver): Promise<number> {
-	let heapSnapshot: any = await driver.executeScript(":takeHeapSnapshot");
+    let heapSnapshot: any = await driver.executeScript(":takeHeapSnapshot");
     let node_fields: any = heapSnapshot.snapshot.meta.node_fields;
     let nodes: any = heapSnapshot.nodes;
 
@@ -336,6 +336,13 @@ interface Result<T> {
 function writeResult<T>(res: Result<T>, dir: string) {
     let benchmark = res.benchmark;
     let framework = res.framework.name;
+    let type = null;
+
+    switch (benchmark.type) {
+        case BenchmarkType.CPU: type = "cpu"; break;
+        case BenchmarkType.MEM: type = "memory"; break;
+        case BenchmarkType.STARTUP: type = "startup"; break;
+    }
 
     for (let resultKind of benchmark.resultKinds()) {
         let data = benchmark.extractResult(res.results, resultKind);
@@ -344,7 +351,7 @@ function writeResult<T>(res: Result<T>, dir: string) {
         let result: JSONResult = {
             "framework": framework,
             "benchmark": resultKind.id,
-            "type": benchmark.type === BenchmarkType.CPU ? "cpu" : "memory",
+            "type": type,
             "min": s.min(),
             "max": s.max(),
             "mean": s.mean(),
@@ -476,12 +483,11 @@ process.on('message', (msg) => {
             process.send(errorsAndWarnings);
             process.exit(0);
         }).catch(err => {
-            console.log("error running benchmark", err);            
+            console.log("error running benchmark", err);
             process.exit(1);
         });
     } catch (err) {
-        console.log("error running benchmark", err);            
+        console.log("error running benchmark", err);
         process.exit(1);
-    }    
+    }
   });
-  

--- a/webdriver-ts/src/forkedBenchmarkRunner.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunner.ts
@@ -336,6 +336,7 @@ interface Result<T> {
 function writeResult<T>(res: Result<T>, dir: string) {
     let benchmark = res.benchmark;
     let framework = res.framework.name;
+    let keyed = res.framework.keyed;
     let type = null;
 
     switch (benchmark.type) {
@@ -350,6 +351,7 @@ function writeResult<T>(res: Result<T>, dir: string) {
         console.log(`result ${fileName(res.framework, resultKind)} min ${s.min()} max ${s.max()} mean ${s.mean()} median ${s.median()} stddev ${s.stdev()}`);
         let result: JSONResult = {
             "framework": framework,
+            "keyed": keyed,
             "benchmark": resultKind.id,
             "type": type,
             "min": s.min(),


### PR DESCRIPTION
supersedes #410 (split into a dedicated banch)

i'm working on an alternate results builder that's faster and doesn't require dependencies of 110MB and 13,000 files.

i noticed that the generated json results files did not conform to the same naming conventions, which makes the classification code more hairy. looks like this was an omission when merging/adjusting the Lighthouse metrics.