### PR TITLE
Update bower to fix CI

### DIFF
--- a/frameworks/halogen-v2.1.0-non-keyed/package.json
+++ b/frameworks/halogen-v2.1.0-non-keyed/package.json
@@ -21,7 +21,7 @@
         "url": "https://github.com/krausest/js-framework-benchmark.git"
     },
     "devDependencies": {
-        "bower": "1.8.0",
+        "bower": "^1.8.4",
         "pulp": "11.0.0",
         "purescript": "0.11.6",
         "rimraf": "2.5.4"

--- a/frameworks/polymer-v2.0.0-non-keyed/package.json
+++ b/frameworks/polymer-v2.0.0-non-keyed/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "bower": "^1.8.0",
+    "bower": "^1.8.4",
     "polymer-cli": "^1.0.0"
   },
   "dependencies": {}

--- a/frameworks/pux-v11.0.0-non-keyed/package.json
+++ b/frameworks/pux-v11.0.0-non-keyed/package.json
@@ -21,7 +21,7 @@
         "url": "https://github.com/krausest/js-framework-benchmark.git"
     },
     "devDependencies": {
-        "bower": "1.8.0",
+        "bower": "^1.8.4",
         "pulp": "11.0.0",
         "purescript": "0.11.6",
         "react": "15.6.1",

--- a/frameworks/thermite-v4.0.0-non-keyed/package.json
+++ b/frameworks/thermite-v4.0.0-non-keyed/package.json
@@ -21,7 +21,7 @@
         "url": "https://github.com/krausest/js-framework-benchmark.git"
     },
     "devDependencies": {
-        "bower": "1.8.0",
+        "bower": "^1.8.4",
         "pulp": "11.0.0",
         "purescript": "0.11.6",
         "react": "15.6.1",


### PR DESCRIPTION
Bower deprecated and removed their old registry at http://bower.herokuapp.com/ and so now only 1.8.4 will work