### PR TITLE
new results-ui

### DIFF
--- a/results-ui/package.json
+++ b/results-ui/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "results-ui",
+  "version": "1.0.0",
+  "description": "js-framework-benchmark results ui",
+  "main": "index.js",
+  "scripts": {
+    "build-prod": "node ./src/build.js"
+  },
+  "keywords": [],
+  "author": "Leon Sorokin",
+  "license": "MIT",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "devDependencies": {
+    "domvm": "git://github.com/domvm/domvm.git#3.4.3",
+    "rollup": "*",
+    "rollup-plugin-buble": "*",
+    "rollup-plugin-uglify": "*"
+  },
+  "dependencies": {}
+}

--- a/results-ui/src/build.js
+++ b/results-ui/src/build.js
@@ -1,0 +1,95 @@
+const fs = require('fs');
+const rollup = require('rollup');
+const buble = require('rollup-plugin-buble');
+const uglify = require('rollup-plugin-uglify').uglify;
+const path = require("path");
+
+const start = +new Date();
+
+const RESULTS_PATH = path.resolve(__dirname + '/../../webdriver-ts/results');
+
+function encodeBench(obj) {
+	return [
+		obj.benchmark.substr(0,2),
+		+obj.min.toFixed(2),
+		+obj.max.toFixed(2),
+		+obj.mean.toFixed(2),
+		+obj.median.toFixed(2),
+		+obj.geometricMean.toFixed(2),
+		+obj.standardDeviation.toFixed(2),
+		obj.values.map(v => +v.toFixed(2)),
+	];
+}
+
+let libs = {
+	keyed: {},
+	unkeyed: {},
+};
+
+// grab result files, group by framework, bench types and encode benches into arrays
+fs.readdirSync(RESULTS_PATH).filter(file => file.endsWith('.json')).forEach(file => {
+	var r = JSON.parse(fs.readFileSync(RESULTS_PATH + "/" + file, 'utf-8'));
+	var implGroup = r.keyed ? libs.keyed : libs.unkeyed;
+	var libName = r.framework;
+
+	if (implGroup[libName] == null) {
+		implGroup[libName] = {
+			name: libName,
+			bench: {
+				cpu: [],
+				memory: [],
+				startup: [],
+			},
+		};
+	}
+
+	implGroup[libName].bench[r.type].push(encodeBench(r));
+});
+
+// convert to arrays and sort
+Object.keys(libs).forEach(implType => {
+	libs[implType] = Object.values(libs[implType]).sort((a, b) => a.name.localeCompare(b.name));
+});
+
+fs.writeFileSync(path.resolve(__dirname + '/data.js'), 'export default ' + JSON.stringify(libs), 'utf-8');
+
+async function build() {
+	const bundle = await rollup.rollup({
+		input: __dirname + "/ui.js",
+		plugins: [
+			buble(),
+			uglify(),
+		],
+	});
+
+	const { code, map } = await bundle.generate({
+		format: "iife",
+	});
+
+	const html = [
+		'<!doctype html>',
+		'<html class="no-js" lang="">',
+		'<head>',
+		'<meta charset="utf-8">',
+		'<meta http-equiv="x-ua-compatible" content="ie=edge">',
+		'<title>Interactive Results</title>',
+		'<meta name="description" content="">',
+		'<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">',
+		'<style>',
+		fs.readFileSync(__dirname + '/style.css', 'utf-8'),
+		'</style>',
+		'</head>',
+		'<body>',
+		'<script>',
+		code.trim(),
+		'</script>',
+		'</body>',
+		'</html>',
+	].join("\n");
+
+	fs.writeFileSync(__dirname + "/../table.html", html, 'utf-8');
+
+	console.log("Built in " + (+new Date() - start) + "ms, (" + (html.length / 1024).toFixed(1) + "KB)");
+}
+
+build();

--- a/results-ui/src/build.js
+++ b/results-ui/src/build.js
@@ -11,13 +11,13 @@ const RESULTS_PATH = path.resolve(__dirname + '/../../webdriver-ts/results');
 function encodeBench(obj) {
 	return [
 		obj.benchmark.substr(0,2),
-		+obj.min.toFixed(2),
-		+obj.max.toFixed(2),
+	//	+obj.min.toFixed(2),
+	//	+obj.max.toFixed(2),
 		+obj.mean.toFixed(2),
-		+obj.median.toFixed(2),
-		+obj.geometricMean.toFixed(2),
+	//	+obj.median.toFixed(2),
+	//	+obj.geometricMean.toFixed(2),
 		+obj.standardDeviation.toFixed(2),
-		obj.values.map(v => +v.toFixed(2)),
+	//	obj.values.map(v => +v.toFixed(2)),
 	];
 }
 

--- a/results-ui/src/style.css
+++ b/results-ui/src/style.css
@@ -1,0 +1,136 @@
+/*!
+ * Bootstrap Reboot v4.1.2 (https://getbootstrap.com/)
+ * Copyright 2011-2018 The Bootstrap Authors
+ * Copyright 2011-2018 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md)
+ */*,::after,::before{box-sizing:border-box}html{font-family:sans-serif;line-height:1.15;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;-ms-overflow-style:scrollbar;-webkit-tap-highlight-color:transparent}@-ms-viewport{width:device-width}article,aside,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";font-size:1rem;font-weight:400;line-height:1.5;color:#212529;text-align:left;background-color:#fff}[tabindex="-1"]:focus{outline:0!important}hr{box-sizing:content-box;height:0;overflow:visible}h1,h2,h3,h4,h5,h6{margin-top:0;margin-bottom:.5rem}p{margin-top:0;margin-bottom:1rem}abbr[data-original-title],abbr[title]{text-decoration:underline;-webkit-text-decoration:underline dotted;text-decoration:underline dotted;cursor:help;border-bottom:0}address{margin-bottom:1rem;font-style:normal;line-height:inherit}dl,ol,ul{margin-top:0;margin-bottom:1rem}ol ol,ol ul,ul ol,ul ul{margin-bottom:0}dt{font-weight:700}dd{margin-bottom:.5rem;margin-left:0}blockquote{margin:0 0 1rem}dfn{font-style:italic}b,strong{font-weight:bolder}small{font-size:80%}sub,sup{position:relative;font-size:75%;line-height:0;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}a{color:#007bff;text-decoration:none;background-color:transparent;-webkit-text-decoration-skip:objects}a:hover{color:#0056b3;text-decoration:underline}a:not([href]):not([tabindex]){color:inherit;text-decoration:none}a:not([href]):not([tabindex]):focus,a:not([href]):not([tabindex]):hover{color:inherit;text-decoration:none}a:not([href]):not([tabindex]):focus{outline:0}code,kbd,pre,samp{font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:1em}pre{margin-top:0;margin-bottom:1rem;overflow:auto;-ms-overflow-style:scrollbar}figure{margin:0 0 1rem}img{vertical-align:middle;border-style:none}svg:not(:root){overflow:hidden;vertical-align:middle}table{border-collapse:collapse}caption{padding-top:.75rem;padding-bottom:.75rem;color:#6c757d;text-align:left;caption-side:bottom}th{text-align:inherit}label{display:inline-block;margin-bottom:.5rem}button{border-radius:0}button:focus{outline:1px dotted;outline:5px auto -webkit-focus-ring-color}button,input,optgroup,select,textarea{margin:0;font-family:inherit;font-size:inherit;line-height:inherit}button,input{overflow:visible}button,select{text-transform:none}[type=reset],[type=submit],button,html [type=button]{-webkit-appearance:button}[type=button]::-moz-focus-inner,[type=reset]::-moz-focus-inner,[type=submit]::-moz-focus-inner,button::-moz-focus-inner{padding:0;border-style:none}input[type=checkbox],input[type=radio]{box-sizing:border-box;padding:0}input[type=date],input[type=datetime-local],input[type=month],input[type=time]{-webkit-appearance:listbox}textarea{overflow:auto;resize:vertical}fieldset{min-width:0;padding:0;margin:0;border:0}legend{display:block;width:100%;max-width:100%;padding:0;margin-bottom:.5rem;font-size:1.5rem;line-height:inherit;color:inherit;white-space:normal}progress{vertical-align:baseline}[type=number]::-webkit-inner-spin-button,[type=number]::-webkit-outer-spin-button{height:auto}[type=search]{outline-offset:-2px;-webkit-appearance:none}[type=search]::-webkit-search-cancel-button,[type=search]::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{font:inherit;-webkit-appearance:button}output{display:inline-block}summary{display:list-item;cursor:pointer}template{display:none}[hidden]{display:none!important}
+
+body {
+	font-size: 10px;
+	font-family: Helvetica Neue,Helvetica,Arial,sans-serif;
+    line-height: 1.42857143;
+    color: #333;
+}
+
+a {
+	color: #337ab7;
+	text-decoration: none;
+}
+
+table {
+	table-layout: fixed;
+}
+
+td,
+th {
+	min-width: 60px;
+	max-width: 60px;
+	height: 45px;
+	text-align: center;
+	padding: 3px;
+	border: 1px solid #ddd;
+	word-wrap: break-word;
+}
+
+h1 {
+	font-size: 32px;
+	margin-top: 32px;
+	background: #ddd;
+}
+
+h4 {
+	background: #ddd;
+	padding: 3px 7px;
+}
+
+input {
+	margin-right: 5px;
+}
+
+label {
+	display: block;
+}
+
+label > * {
+	vertical-align: middle;
+}
+
+.value,
+.stddev {
+	display: inline-block;
+}
+
+.stddev {
+	font-size: 8px;
+}
+
+.toggle_all {
+	float: right;
+}
+
+.stddev::before {
+	content: "\B1 ";
+	font-size: 8px;
+	padding-right: 2px;
+	padding-left: 2px;
+}
+
+.factor {
+	font-size: 8px;
+}
+
+.factor::before {
+	content: "(";
+}
+
+.factor::after {
+	content: ")";
+}
+
+.group {
+	display: inline-block;
+	vertical-align: top;
+	padding: 5px;
+}
+
+#frameworks,
+#benchmarks {
+	display: inline-block;
+	vertical-align: top;
+}
+
+#frameworks label {
+	display: inline-block;
+	width: 200px;
+}
+
+#frameworks .group {
+	width: 650px;
+}
+
+.benchname {
+	min-width: 100px;
+}
+
+caption {
+	font-size: 32px;
+	caption-side: top;
+}
+
+.c00 {background: #63BF7C}
+.c01 {background: #76C47D}
+.c02 {background: #8ACA7E}
+.c03 {background: #9DCF7F}
+.c04 {background: #B1D580}
+.c05 {background: #C4DA81}
+.c06 {background: #D8E082}
+.c07 {background: #EBE583}
+.c08 {background: #FFEB84}
+.c09 {background: #FED880}
+.c10 {background: #FDC57D}
+.c11 {background: #FCB379}
+.c12 {background: #FBA076}
+.c13 {background: #FA8E72}
+.c14 {background: #F97B6F}
+.c15 {background: #F9696C}

--- a/results-ui/src/ui.js
+++ b/results-ui/src/ui.js
@@ -1,0 +1,382 @@
+import results from './data';
+import {
+	defineElement as el,
+	defineView as vw,
+	createView as cv,
+} from '../node_modules/domvm/dist/pico/domvm.pico.es.js';
+
+// https://github.com/darkskyapp/string-hash/blob/master/index.js
+function hash(str) {
+  var hash = 5381,
+      i    = str.length;
+
+  while(i) {
+    hash = (hash * 33) ^ str.charCodeAt(--i);
+  }
+
+  /* JavaScript does bitwise operations (like XOR, above) on 32-bit signed
+   * integers. Since we want the results to be always positive, convert the
+   * signed int to an unsigned by doing an unsigned bitshift. */
+  return hash >>> 0;
+}
+
+function decodeBench(arr) {
+	return {
+	    name: arr[0],
+	    min: arr[1],
+	    max: arr[2],
+	    mean: arr[3],
+	    median: arr[4],
+	    geoMean: arr[5],
+	    stdDev: arr[6],
+	    values: arr[7],
+
+	    factor: 0,
+	};
+}
+
+function inflateBenches(lib) {
+	lib.factors = {
+		cpu: 0,
+		memory: 0,
+		startup: 0,
+	};
+
+	Object.keys(lib.factors).forEach(type => {
+		var obj = {};
+		lib.bench[type].map(b => obj[b[0]] = decodeBench(b));
+		lib.bench[type] = obj;
+	});
+}
+
+const benchDescr = {
+	'01': '1k create',
+	'02': '1k replace',
+	'03': '10k update 1k',
+	'04': '1k select 1',
+	'05': '1k swap 2',
+	'06': '1k remove 1',
+	'07': '10k create',
+	'08': '10k append 1k',
+	'09': '10k clear',
+	'21': 'loaded',
+	'22': '1k create (5x)',
+	'23': '1k update 100 (5x)',
+	'24': '1k replace (5x)',			// default sort for memory?
+	'25': '1k clear (5x)',
+	'31': 'script bootup time',
+	'32': 'consistently interactive',
+	'33': 'main thread work cost',		// default sort for startup?
+	'34': 'total byte weight',
+};
+
+function benchStruct(val) {
+	return {
+		cpu: {
+			'01': val,
+			'02': val,
+			'03': val,
+			'04': val,
+			'05': val,
+			'06': val,
+			'07': val,
+			'08': val,
+			'09': val,
+		},
+		memory: {
+			'21': val,
+			'22': val,
+			'23': val,
+			'24': val,
+			'25': val,
+		},
+		startup: {
+			'31': val,
+			'32': val,
+			'33': val,
+			'34': val,
+		},
+	};
+}
+
+const colorSteps = [
+	1.000, 1.125, 1.250, 1.375,
+	1.500, 1.625, 1.750, 1.875,
+	2.000, 2.250, 2.500, 2.750,
+	3.000, 3.250, 3.500, 4.000,
+];
+
+function colorClass(factor) {
+	const last = colorSteps.length - 1;
+
+	for (var i = 0; i < colorSteps.length; i++) {
+		if (i == last || factor < colorSteps[i+1])
+			break;
+	}
+
+	return "c" + (i < 10 ? "0" : "") + i;
+}
+
+function frameworkEnabled(type, name) {
+	return STORE.enabled.frameworks[type][name];
+}
+
+function benchEnabled(type, name) {
+	return STORE.enabled.benchmarks[type][name];
+}
+
+function eachEnabledLib(cb) {
+	Object.keys(STORE.results).forEach(implType => {
+		results[implType].forEach(lib => {
+			if (frameworkEnabled(implType, lib.name))
+				cb(implType, lib);
+		});
+	});
+}
+
+function eachEnabledBench(lib, cb) {
+	Object.keys(lib.bench).forEach(benchType => {
+		Object.keys(lib.bench[benchType]).forEach(num => {
+			if (benchEnabled(benchType, num))
+				cb(benchType, lib.bench[benchType][num]);
+		});
+	});
+}
+
+function anyEnabled(what, type) {
+	var all = STORE.enabled[what][type];
+
+	for (var name in all) {
+		if (all[name])
+			return true;
+	}
+
+	return false;
+}
+
+function clampMin(val, min) {
+	return Math.max(val, min);
+}
+
+function setFactors() {
+	var mins = {
+		keyed: benchStruct(1e10),
+		unkeyed: benchStruct(1e10),
+	};
+
+	// calc minimums
+	eachEnabledLib((implType, lib) => {
+		eachEnabledBench(lib, (benchType, res) => {
+			var typeMins = mins[implType][benchType];
+			typeMins[res.name] = clampMin(Math.min(typeMins[res.name], res[STORE.metric]), STORE.clamp[benchType]);
+		});
+	});
+
+	// set factors
+	eachEnabledLib((implType, lib) => {
+		eachEnabledBench(lib, (benchType, res) => {
+			var typeMins = mins[implType][benchType];
+			res.factor = clampMin(res[STORE.metric], STORE.clamp[benchType]) / typeMins[res.name];
+		});
+	});
+
+	eachEnabledLib((implType, lib) => {
+		for (var benchType in lib.bench) {
+			lib.factors[benchType] = 0;
+
+			var i = 0;
+			for (var num in lib.bench[benchType]) {
+				if (benchEnabled(benchType, num)) {
+					i++;
+					lib.factors[benchType] += lib.bench[benchType][num].factor;
+				}
+			}
+			lib.factors[benchType] /= i;
+		}
+	});
+}
+
+// TODO: must reset if needed row is disabled
+function sortBy(metric, sortDir) {
+	STORE.sortDir = sortDir;
+	STORE.sortBy = metric;
+
+	var typeNum = metric.split(".");
+
+	// cpu, memory, startup
+	var benchType = typeNum[0];
+	var num = typeNum[1];
+
+	if (benchType == "name")
+		var cmp = (a, b) => STORE.sortDir * a.name.localeCompare(b.name);
+	else if (num == null)
+		var cmp = (a, b) => STORE.sortDir * (a.factors[benchType] - b.factors[benchType]);
+	else
+		var cmp = (a, b) => STORE.sortDir * (a.bench[benchType][num][STORE.metric] - b.bench[benchType][num][STORE.metric]);
+
+	STORE.results.keyed.sort(cmp);
+	STORE.results.unkeyed.sort(cmp);
+
+	VIEW && VIEW.redraw();
+
+	return false;
+}
+
+function nextSortDir(metric) {
+	if (STORE.sortBy == metric)
+		return STORE.sortDir * -1;
+	else
+		return 1;
+}
+
+function render(implType, benchType, aggr) {
+	if (!anyEnabled("benchmarks", benchType))
+		return null;
+
+	return el("table", [
+		el("caption", benchType),
+		el("tr", [
+			el("th", {class: "benchname"}, [
+				el("a", {href: "#", onclick: [sortBy, "name", nextSortDir("name")]}, "Name"),
+			]),
+			STORE.results[implType].map(lib =>
+				frameworkEnabled(implType, lib.name) && el("th", lib.name)
+			)
+		]),
+		Object.keys(benchStruct()[benchType]).map(num =>
+			benchEnabled(benchType, num) && el("tr", [
+				el("th", {class: "benchname"}, [
+					el("a", {href: "#", onclick: [sortBy, benchType + "." + num, nextSortDir(benchType + "." + num)]}, benchDescr[num]),
+				]),
+				STORE.results[implType].map(lib =>
+					frameworkEnabled(implType, lib.name) && el("td", {class: colorClass(lib.bench[benchType][num].factor)}, [
+						el("div", {class: "value"}, lib.bench[benchType][num][STORE.metric].toFixed(1)),
+						el("div", {class: "stddev"}, lib.bench[benchType][num].stdDev.toFixed(1)),
+						el("div", {class: "factor"}, lib.bench[benchType][num].factor.toFixed(1)),
+					])
+				)
+			])
+		),
+		aggr && el("tr", [
+			el("th", [
+				el("a", {href: "#", onclick: [sortBy, benchType, nextSortDir(benchType)]}, "slowdown"),
+			]),
+			STORE.results[implType].map(lib =>
+				frameworkEnabled(implType, lib.name) && el("th", {class: colorClass(lib.factors[benchType])}, lib.factors[benchType].toFixed(2))
+			)
+		]),
+	]);
+}
+
+// TODO?: DRY
+function toggle(what, type, num) {
+	var isEnabled = STORE.enabled[what][type][num] = !STORE.enabled[what][type][num];
+
+	setFactors();
+
+	if (what == "benchmarks" && !isEnabled && STORE.sortBy == type + "." + num)
+		sortBy("cpu", 1);
+	else
+		sortBy(STORE.sortBy, STORE.sortDir);
+
+	VIEW.redraw();
+
+	return false;
+}
+
+function setAll(what, type, val) {
+	var all = STORE.enabled[what][type];
+
+	for (var name in all)
+		all[name] = val;
+
+	setFactors();
+	sortBy(STORE.sortBy, STORE.sortDir);
+
+	VIEW.redraw();
+
+	return false;
+}
+
+function selectorTpl(what, fmtName) {
+	var struct = STORE.enabled[what];
+
+	return el("div", {id: what}, Object.keys(struct).map(type => [
+		el("div", {class: "group"}, [
+			el("h4", [
+				type,
+				el("div", {class: "toggle_all"}, [
+					el("a", {href: "#", onclick: [setAll, what, type, true]}, "All"),
+					" / ",
+					el("a", {href: "#", onclick: [setAll, what, type, false]}, "None"),
+				])
+			]),
+			Object.keys(struct[type]).map(key =>
+				el("label", [
+					el("input", {
+						type: "checkbox",
+						checked: STORE.enabled[what][type][key],
+						onchange: [toggle, what, type, key]
+					}),
+					el("strong", fmtName(key)),
+				])
+			)
+		])
+	]));
+}
+
+function tablesTpl(implType) {
+	if (!anyEnabled("frameworks", implType))
+		return null;
+
+	return el("div", {id: implType}, [
+		el("h1", implType),
+		render(implType, "cpu", true),
+		render(implType, "memory", false),
+		render(implType, "startup", false),
+	]);
+}
+
+const AppView = {
+	render() {
+		return el("div", {id: "results"}, [
+			selectorTpl("benchmarks", name => benchDescr[name]),
+			selectorTpl("frameworks", name => name),
+			tablesTpl("keyed"),
+			tablesTpl("unkeyed"),
+		]);
+	}
+};
+
+const STORE = {
+	metric: "mean",
+	enabled: {
+		benchmarks: benchStruct(true),
+		frameworks: {
+			keyed: {},
+			unkeyed: {},
+		},
+	},
+	clamp: {
+		cpu: 16.66666,
+		memory: 0,
+		startup: 0,
+	},
+	sortBy: null,
+	sortDir: null,
+	results: results,
+};
+
+Object.keys(results).forEach(implType => {
+	results[implType].forEach(lib => {
+		inflateBenches(lib);
+		// todo: use this hash in url to show only specific libs (e.g. #libs=abcd,3745)
+		lib.hash = hash(lib.name).toString(16).substr(0, 4);
+		STORE.enabled.frameworks[implType][lib.name] = true;
+	});
+});
+
+setFactors();
+sortBy("cpu", 1);
+
+const VIEW = cv(AppView).mount(document.body);

--- a/results-ui/src/ui.js
+++ b/results-ui/src/ui.js
@@ -23,13 +23,13 @@ function hash(str) {
 function decodeBench(arr) {
 	return {
 	    name: arr[0],
-	    min: arr[1],
-	    max: arr[2],
-	    mean: arr[3],
-	    median: arr[4],
-	    geoMean: arr[5],
-	    stdDev: arr[6],
-	    values: arr[7],
+//	    min: arr[1],
+//	    max: arr[2],
+	    mean: arr[1],
+//	    median: arr[4],
+//	    geoMean: arr[5],
+	    stdDev: arr[2],
+//	    values: arr[3],
 
 	    factor: 0,
 	};

--- a/webdriver-ts/src/benchmarks.ts
+++ b/webdriver-ts/src/benchmarks.ts
@@ -342,7 +342,7 @@ const benchCreateClear5Memory = new class extends Benchmark {
 }
 
 const benchStartupConsistentlyInteractive: StartupBenchmarkResult = {
-    id: "30_startup-ci",
+    id: "31_startup-ci",
     label: "consistently interactive",
     description: "a pessimistic TTI - when the CPU and network are both definitely very idle. (no more CPU tasks over 50ms)",
     type: BenchmarkType.STARTUP,
@@ -350,7 +350,7 @@ const benchStartupConsistentlyInteractive: StartupBenchmarkResult = {
 }
 
 const benchStartupBootup: StartupBenchmarkResult = {
-    id: "30_startup-bt",
+    id: "32_startup-bt",
     label: "script bootup time",
     description: "the total ms required to parse/compile/evaluate all the page's scripts",
     type: BenchmarkType.STARTUP,
@@ -358,7 +358,7 @@ const benchStartupBootup: StartupBenchmarkResult = {
 }
 
 const benchStartupMainThreadWorkCost: StartupBenchmarkResult = {
-    id: "30_startup-mainthreadcost",
+    id: "33_startup-mainthreadcost",
     label: "main thread work cost",
     description: "total amount of time spent doing work on the main thread. includes style/layout/etc.",
     type: BenchmarkType.STARTUP,
@@ -366,7 +366,7 @@ const benchStartupMainThreadWorkCost: StartupBenchmarkResult = {
 }
 
 const benchStartupTotalBytes: StartupBenchmarkResult = {
-    id: "30_startup-totalbytes",
+    id: "34_startup-totalbytes",
     label: "total byte weight",
     description: "network transfer cost (post-compression) of all the resources loaded into the page.",
     type: BenchmarkType.STARTUP,

--- a/webdriver-ts/src/common.ts
+++ b/webdriver-ts/src/common.ts
@@ -1,5 +1,5 @@
 export interface JSONResult {
-    framework: string, benchmark: string, type: string, min: number,
+    framework: string, keyed: boolean, benchmark: string, type: string, min: number,
         max: number, mean: number, geometricMean: number,
         standardDeviation: number, median: number, values: Array<number>
 }

--- a/webdriver-ts/src/forkedBenchmarkRunner.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunner.ts
@@ -263,7 +263,7 @@ function buildDriver(benchmarkOptions: BenchmarkOptions) {
     options = options.setLoggingPrefs(logPref);
 
     options = options.setPerfLoggingPrefs(<any>{
-        enableNetwork: true, enablePage: true, 
+        enableNetwork: true, enablePage: true,
         traceCategories: lighthouse.traceCategories.join(", ")
     });
 
@@ -288,7 +288,7 @@ async function forceGC(framework: FrameworkData, driver: WebDriver): Promise<any
 }
 
 async function snapMemorySize(driver: WebDriver): Promise<number> {
-	let heapSnapshot: any = await driver.executeScript(":takeHeapSnapshot");
+    let heapSnapshot: any = await driver.executeScript(":takeHeapSnapshot");
     let node_fields: any = heapSnapshot.snapshot.meta.node_fields;
     let nodes: any = heapSnapshot.nodes;
 
@@ -336,6 +336,13 @@ interface Result<T> {
 function writeResult<T>(res: Result<T>, dir: string) {
     let benchmark = res.benchmark;
     let framework = res.framework.name;
+    let type = null;
+
+    switch (benchmark.type) {
+        case BenchmarkType.CPU: type = "cpu"; break;
+        case BenchmarkType.MEM: type = "memory"; break;
+        case BenchmarkType.STARTUP: type = "startup"; break;
+    }
 
     for (let resultKind of benchmark.resultKinds()) {
         let data = benchmark.extractResult(res.results, resultKind);
@@ -344,7 +351,7 @@ function writeResult<T>(res: Result<T>, dir: string) {
         let result: JSONResult = {
             "framework": framework,
             "benchmark": resultKind.id,
-            "type": benchmark.type === BenchmarkType.CPU ? "cpu" : "memory",
+            "type": type,
             "min": s.min(),
             "max": s.max(),
             "mean": s.mean(),
@@ -476,12 +483,11 @@ process.on('message', (msg) => {
             process.send(errorsAndWarnings);
             process.exit(0);
         }).catch(err => {
-            console.log("error running benchmark", err);            
+            console.log("error running benchmark", err);
             process.exit(1);
         });
     } catch (err) {
-        console.log("error running benchmark", err);            
+        console.log("error running benchmark", err);
         process.exit(1);
-    }    
+    }
   });
-  

--- a/webdriver-ts/src/forkedBenchmarkRunner.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunner.ts
@@ -336,6 +336,7 @@ interface Result<T> {
 function writeResult<T>(res: Result<T>, dir: string) {
     let benchmark = res.benchmark;
     let framework = res.framework.name;
+    let keyed = res.framework.keyed;
     let type = null;
 
     switch (benchmark.type) {
@@ -350,6 +351,7 @@ function writeResult<T>(res: Result<T>, dir: string) {
         console.log(`result ${fileName(res.framework, resultKind)} min ${s.min()} max ${s.max()} mean ${s.mean()} median ${s.median()} stddev ${s.stdev()}`);
         let result: JSONResult = {
             "framework": framework,
+            "keyed": keyed,
             "benchmark": resultKind.id,
             "type": type,
             "min": s.min(),


### PR DESCRIPTION
Hi @krausest,

This is a from-scratch implementation of an interactive results UI. This work builds on top of the necessary minor tweaks in #418.

The original motivation for this was to reduce `node_modules` bloat in `webdriver-ts-results` (~100MB, ~13,000 files) and perhaps improve build times, bundle size as well as boost UI performance. I'm pleased to report that the final result has surpassed my original expectations by a wide margin.

Full feature parity with `webdriver-ts-results` was not a goal, so some things got the axe:

- **Use median instead of mean** - recent improvements in the benchmark runner have made the differences mostly irrelevant
- **Separate keyed and non-keyed** - the ability to display keyed and non-keyed frameworks in the same table is gone
- **Compare with...** - i never really understood how this feature was supposed to work, including why it has a drastically different color scale. How is it different than simply enabling only the frameworks you're interested in comparing?
- **building results from `src/results.ts`** - the results-ui now only builds from the raw `.json` files produced by `webdriver-ts` because it doesn't matter what that file contains since all its contents are from a different environment. if you don't have the original `.json` files produced on your own machine, they may as well not exist.
- **CSS** - dropped bootstrap due to huge size in favor of custom css

The important stuff is still there:

- Toggle frameworks
- Toggle benchmarks
- Sort by benchmark, name or total slowdown
- Reverse sorting **NEW**

Additional notes:

- Some bench names and descriptions no longer represented what they actually did, so I adjusted the names to be more-or-less uniform and accurate.
- The color scale is not identical but it's quite close. Rather than using a smooth scaling function, I generated a 16 color scale [1] that closely resembles the current one and selected the step thresholds [2] carefully to match what exists now. This has a good UI performance benefit since classes are much more likely to be shared during mutation and do not need to change as often as style attributes tweaked precisely to the factor.
- For better compression, I reduced the precision of all measurements to 2 decimal places, followed by encoding all benchmarks into arrays rather than objects. These are inflated at run-time with minimal overhead, but reduce the bundle size enormously.
- The implementation is based on domvm, rollup/buble and uglify-js
- There are no vdom optimizations in this code - the whole vdom is regenerated and diffed for all interactions. This is done for simplicity, but there's still some perf left on the table, if needed.

Now for some fun stats and pictures:

- **node_modules:** 97.6MB (12,927 files) -> 12.0MB (536 files)
![dependencies](https://user-images.githubusercontent.com/43234/43110921-2fe1e928-8eb4-11e8-8cc6-bbd4ce21bba5.png)
- **build time & `table.html` size:** 18.3s -> 2.7s, 1MB -> 197KB
![build-times](https://user-images.githubusercontent.com/43234/43110920-2fd253fa-8eb4-11e8-924b-004ec31e0297.png)
- **initial render (scripting):** 440ms -> 100ms
![load](https://user-images.githubusercontent.com/43234/43110922-2ff7796e-8eb4-11e8-8ffc-788d61afe825.png)
- **sorting by name, each benchmark and total (scripting):** 2333ms -> 260ms
![sorting-11x](https://user-images.githubusercontent.com/43234/43110923-3009cc54-8eb4-11e8-8ace-10ca86fd6caa.png)
- **toggling each keyed bench 2x (scripting):** 2090ms -> 450ms
![toggle-benches](https://user-images.githubusercontent.com/43234/43110924-3018e554-8eb4-11e8-95e0-b3f56273a6e4.png)

(The build time improvement is actually even more drastic since `webdriver-ts-results` was building from a prepared `results.ts` while `results-ui` was synchronously reading/parsing 1,656 `.json` files from `webdriver-ts/results`)

[1] https://www.strangeplanet.fr/work/gradient-generator/?c=16:63BF7C:FFEB84:F9696C
[2] https://github.com/leeoniya/js-framework-benchmark/blob/results-ui/results-ui/src/ui.js#L102-L107