### PR TITLE
push NaNs in geometric means to end of sort

### DIFF
--- a/webdriver-ts-results/src/Common.tsx
+++ b/webdriver-ts-results/src/Common.tsx
@@ -182,7 +182,7 @@ export class ResultTableData {
         let zipped = this.frameworks.map((f,frameworkIndex) => {
             let sortValue;
             if (sortKey === SORT_BY_NAME) sortValue = f.name;
-            else if (sortKey === SORT_BY_GEOMMEAN) sortValue = this.geomMeanCPU[frameworkIndex]!.mean;
+            else if (sortKey === SORT_BY_GEOMMEAN) sortValue = this.geomMeanCPU[frameworkIndex]!.mean || Number.POSITIVE_INFINITY;
             else {
                 let cpuIdx = this.benchmarksCPU.findIndex(b => b.id === sortKey);
                 let startupIdx = this.benchmarksStartup.findIndex(b => b.id === sortKey);


### PR DESCRIPTION
Sorting the tables by geometric mean doesn't work when some frameworks have NaN results, because `<` isn't a valid partial order for NaNs.  Paralleling the similar fix for the cpu tests, this replaces NaNs with Number.POSITIVE_INFINITY to push NaNs to the end.