### PR TITLE
Add non-keyed Elm, follow more Elm best practices

### DIFF
--- a/frameworks/keyed/elm/elm-package.json
+++ b/frameworks/keyed/elm/elm-package.json
@@ -8,6 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "Skinney/elm-array-exploration": "2.0.5 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"

--- a/frameworks/keyed/elm/package.json
+++ b/frameworks/keyed/elm/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "postinstall": "elm-package install -y",
-    "build-prod": "elm-make src/Main.elm --output=dist/main.js"
+    "build-prod": "elm-make src/Main.elm --output=dist/main.js && uglifyjs dist/main.js --compress --mangle --output=dist/main.js"
   },
   "keywords": [
     "elm"
@@ -21,6 +21,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "elm": "0.18.0"
+    "elm": "0.18.0",
+    "uglify-js": "3.4.7"
   }
 }

--- a/frameworks/keyed/elm/src/Main.elm
+++ b/frameworks/keyed/elm/src/Main.elm
@@ -1,6 +1,6 @@
 module Main exposing (..)
 
-import Array exposing (Array)
+import Array.Hamt as Array exposing (Array)
 import Html exposing (Attribute, Html, a, button, div, h1, program, span, table, td, text, tr)
 import Html.Attributes exposing (attribute, class, classList, href, id, type_)
 import Html.Events exposing (onClick)

--- a/frameworks/keyed/elm/src/Main.elm
+++ b/frameworks/keyed/elm/src/Main.elm
@@ -1,13 +1,13 @@
 module Main exposing (..)
 
 import Array exposing (Array)
-import Html exposing (Html, Attribute, program, div, a, h1, span, button, table, td, tr, text)
-import Html.Attributes exposing (id, class, classList, attribute, type_, href)
+import Html exposing (Attribute, Html, a, button, div, h1, program, span, table, td, text, tr)
+import Html.Attributes exposing (attribute, class, classList, href, id, type_)
 import Html.Events exposing (onClick)
 import Html.Keyed
 import Html.Lazy
+import Random.Pcg exposing (Generator, Seed)
 import String
-import Random.Pcg exposing (Seed, Generator)
 
 
 main : Program Never Model Msg
@@ -86,10 +86,10 @@ nouns =
 
 buttons : List ( String, String, Msg )
 buttons =
-    [ ( "run", "Create 1,000 rows", (Create 1000) )
-    , ( "runlots", "Create 10,000 rows", (Create 10000) )
-    , ( "add", "Append 1,000 rows", (Append 1000) )
-    , ( "update", "Update every 10th row", (UpdateEvery 10) )
+    [ ( "run", "Create 1,000 rows", Create 1000 )
+    , ( "runlots", "Create 10,000 rows", Create 10000 )
+    , ( "add", "Append 1,000 rows", Append 1000 )
+    , ( "update", "Update every 10th row", UpdateEvery 10 )
     , ( "clear", "Clear", Clear )
     , ( "swaprows", "Swap Rows", Swap )
     ]
@@ -194,7 +194,7 @@ createRandomBatch maybeSeed amount lastId =
                 row =
                     createRow lastId
             in
-                ( List.indexedMap row list, newSeed )
+            ( List.indexedMap row list, newSeed )
 
         Nothing ->
             Debug.crash "Attempting to create values without a seed!"
@@ -221,7 +221,7 @@ type Msg
 
 get : Int -> Array a -> a
 get id arr =
-    case (Array.get id arr) of
+    case Array.get id arr of
         Just row ->
             row
 
@@ -237,26 +237,26 @@ update msg model =
                 ( newRows, seed ) =
                     createRandomBatch model.seed amount model.lastId
             in
-                ( { model
-                    | rows = newRows
-                    , seed = Just seed
-                    , lastId = model.lastId + amount
-                  }
-                , Cmd.none
-                )
+            ( { model
+                | rows = newRows
+                , seed = Just seed
+                , lastId = model.lastId + amount
+              }
+            , Cmd.none
+            )
 
         Append amount ->
             let
                 ( newRows, seed ) =
                     createRandomBatch model.seed amount model.lastId
             in
-                ( { model
-                    | rows = model.rows ++ newRows
-                    , seed = Just seed
-                    , lastId = model.lastId + amount
-                  }
-                , Cmd.none
-                )
+            ( { model
+                | rows = model.rows ++ newRows
+                , seed = Just seed
+                , lastId = model.lastId + amount
+              }
+            , Cmd.none
+            )
 
         UpdateEvery amount ->
             ( { model | rows = List.indexedMap updateRow model.rows }, Cmd.none )
@@ -277,15 +277,16 @@ update msg model =
                     to =
                         get 998 arr
                 in
-                    ( { model
-                        | rows =
-                            arr
-                                |> Array.set 1 to
-                                |> Array.set 998 from
-                                |> Array.toList
-                      }
-                    , Cmd.none
-                    )
+                ( { model
+                    | rows =
+                        arr
+                            |> Array.set 1 to
+                            |> Array.set 998 from
+                            |> Array.toList
+                  }
+                , Cmd.none
+                )
+
             else
                 ( model, Cmd.none )
 
@@ -303,6 +304,7 @@ updateRow : Int -> Row -> Row
 updateRow index row =
     if index % 10 == 0 then
         { row | label = row.label ++ " !!!" }
+
     else
         row
 
@@ -311,8 +313,10 @@ select : Int -> Row -> Row
 select targetId ({ id, label, selected } as row) =
     if id == targetId then
         Row id label True
+
     else if selected == True then
         Row id label False
+
     else
         row
 
@@ -337,7 +341,7 @@ init =
       , rows = []
       , lastId = 1
       }
-    , Random.Pcg.generate (UpdateSeed) (Random.Pcg.independentSeed)
+    , Random.Pcg.generate UpdateSeed Random.Pcg.independentSeed
     )
 
 

--- a/frameworks/non-keyed/elm/.gitignore
+++ b/frameworks/non-keyed/elm/.gitignore
@@ -1,0 +1,6 @@
+# elm-package generated files
+elm-stuff/
+
+# elm-repl generated files
+repl-temp-*
+

--- a/frameworks/non-keyed/elm/elm-package.json
+++ b/frameworks/non-keyed/elm/elm-package.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}

--- a/frameworks/non-keyed/elm/elm-package.json
+++ b/frameworks/non-keyed/elm/elm-package.json
@@ -8,6 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "Skinney/elm-array-exploration": "2.0.5 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"

--- a/frameworks/non-keyed/elm/index.html
+++ b/frameworks/non-keyed/elm/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Elm v0.18.0</title>
+  <link href="/css/currentStyle.css" rel="stylesheet"/>
+</head>
+<body>
+  <div id='main'></div>
+  <script src='dist/main.js'></script>
+  <script type="text/javascript">
+  	Elm.Main.embed(document.getElementById('main'));
+  </script>
+</body>
+</html>

--- a/frameworks/non-keyed/elm/package.json
+++ b/frameworks/non-keyed/elm/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "js-framework-benchmark-elm",
+  "version": "1.0.0",
+  "description": "Elm demo",
+  "main": "index.js",
+  "js-framework-benchmark": {
+    "frameworkVersionFromPackage": "elm"
+  },
+  "scripts": {
+    "postinstall": "elm-package install -y",
+    "build-prod": "elm-make src/Main.elm --output=dist/main.js; uglifyjs dist/main.js --compress --mangle --output=dist/main.js"
+  },
+  "keywords": [
+    "elm"
+  ],
+  "author": "Eduard Kyvenko <eduard.kyvenko@gmail.com>",
+  "license": "ISC",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "devDependencies": {
+    "elm": "0.18.0",
+    "uglify-js": "3.4.7"
+  }
+}

--- a/frameworks/non-keyed/elm/package.json
+++ b/frameworks/non-keyed/elm/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "postinstall": "elm-package install -y",
-    "build-prod": "elm-make src/Main.elm --output=dist/main.js; uglifyjs dist/main.js --compress --mangle --output=dist/main.js"
+    "build-prod": "elm-make src/Main.elm --output=dist/main.js && uglifyjs dist/main.js --compress --mangle --output=dist/main.js"
   },
   "keywords": [
     "elm"

--- a/frameworks/non-keyed/elm/src/Main.elm
+++ b/frameworks/non-keyed/elm/src/Main.elm
@@ -1,6 +1,6 @@
 module Main exposing (..)
 
-import Array exposing (Array)
+import Array.Hamt as Array exposing (Array)
 import Html exposing (Attribute, Html, a, button, div, h1, program, span, table, tbody, td, text, tr)
 import Html.Attributes exposing (attribute, class, classList, href, id, type_)
 import Html.Events exposing (onClick)

--- a/frameworks/non-keyed/elm/src/Main.elm
+++ b/frameworks/non-keyed/elm/src/Main.elm
@@ -1,0 +1,354 @@
+module Main exposing (..)
+
+import Array exposing (Array)
+import Html exposing (Attribute, Html, a, button, div, h1, program, span, table, tbody, td, text, tr)
+import Html.Attributes exposing (attribute, class, classList, href, id, type_)
+import Html.Events exposing (onClick)
+import Html.Lazy
+import Random.Pcg exposing (Generator, Seed)
+import String
+
+
+main : Program Never Model Msg
+main =
+    program
+        { view = view
+        , update = update
+        , init = init
+        , subscriptions = subscriptions
+        }
+
+
+adjectives : List String
+adjectives =
+    [ "pretty"
+    , "large"
+    , "big"
+    , "small"
+    , "tall"
+    , "short"
+    , "long"
+    , "handsome"
+    , "plain"
+    , "quaint"
+    , "clean"
+    , "elegant"
+    , "easy"
+    , "angry"
+    , "crazy"
+    , "helpful"
+    , "mushy"
+    , "odd"
+    , "unsightly"
+    , "adorable"
+    , "important"
+    , "inexpensive"
+    , "cheap"
+    , "expensive"
+    , "fancy"
+    ]
+
+
+colours : List String
+colours =
+    [ "red"
+    , "yellow"
+    , "blue"
+    , "green"
+    , "pink"
+    , "brown"
+    , "purple"
+    , "brown"
+    , "white"
+    , "black"
+    , "orange"
+    ]
+
+
+nouns : List String
+nouns =
+    [ "table"
+    , "chair"
+    , "house"
+    , "bbq"
+    , "desk"
+    , "car"
+    , "pony"
+    , "cookie"
+    , "sandwich"
+    , "burger"
+    , "pizza"
+    , "mouse"
+    , "keyboard"
+    ]
+
+
+buttons : List ( String, String, Msg )
+buttons =
+    [ ( "run", "Create 1,000 rows", Create 1000 )
+    , ( "runlots", "Create 10,000 rows", Create 10000 )
+    , ( "add", "Append 1,000 rows", Append 1000 )
+    , ( "update", "Update every 10th row", UpdateEvery 10 )
+    , ( "clear", "Clear", Clear )
+    , ( "swaprows", "Swap Rows", Swap )
+    ]
+
+
+btnPrimaryBlock : ( String, String, Msg ) -> Html Msg
+btnPrimaryBlock ( buttonId, labelText, msg ) =
+    div
+        [ class "col-sm-6 smallpad" ]
+        [ button
+            [ type_ "button"
+            , class "btn btn-primary btn-block"
+            , id buttonId
+            , onClick msg
+            , attribute "ref" "text"
+            ]
+            [ text labelText ]
+        ]
+
+
+viewRow : Row -> Html Msg
+viewRow { id, label, selected } =
+    tr
+        [ classList [ ( "danger", selected ) ] ]
+        [ td [ class "col-md-1" ] [ text (toString id) ]
+        , td
+            [ class "col-md-4" ]
+            [ a
+                [ href "#"
+                , onClick (Select id)
+                ]
+                [ text label ]
+            ]
+        , td
+            [ class "col-md-1" ]
+            [ a
+                [ href "#"
+                , onClick (Remove id)
+                ]
+                [ span
+                    [ class "glyphicon glyphicon-remove"
+                    , attribute "aria-hidden" "true"
+                    ]
+                    []
+                ]
+            ]
+        , td [ class "col-md-6" ] []
+        ]
+
+
+view : Model -> Html Msg
+view model =
+    div
+        [ class "container" ]
+        [ div
+            [ class "jumbotron" ]
+            [ div
+                [ class "row" ]
+                [ div
+                    [ class "col-md-6" ]
+                    [ h1
+                        []
+                        [ text "Elm 0.18.0" ]
+                    ]
+                , div
+                    [ class "col-md-6" ]
+                    (List.map btnPrimaryBlock buttons)
+                ]
+            ]
+        , table
+            [ class "table table-hover table-striped test-data" ]
+            [ tbody []
+                (List.map (Html.Lazy.lazy viewRow) model.rows)
+            ]
+        , span
+            [ class "preloadicon glyphicon glyphicon-remove"
+            , attribute "aria-hidden" "true"
+            ]
+            []
+        ]
+
+
+createRandomBatch : Maybe Seed -> Int -> Int -> ( List Row, Seed )
+createRandomBatch maybeSeed amount lastId =
+    case maybeSeed of
+        Just seed ->
+            let
+                ( list, newSeed ) =
+                    Random.Pcg.step (batch amount) seed
+
+                row =
+                    createRow lastId
+            in
+            ( List.indexedMap row list, newSeed )
+
+        Nothing ->
+            Debug.crash "Attempting to create values without a seed!"
+
+
+createRow : Int -> Int -> String -> Row
+createRow lastId index label =
+    { id = lastId + index
+    , label = label
+    , selected = False
+    }
+
+
+type Msg
+    = Create Int
+    | Append Int
+    | UpdateEvery Int
+    | Clear
+    | Swap
+    | Remove Int
+    | Select Int
+    | UpdateSeed Seed
+
+
+get : Int -> Array a -> a
+get id arr =
+    case Array.get id arr of
+        Just row ->
+            row
+
+        Nothing ->
+            Debug.crash "Attempted to retrieve non-existant element from array"
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        Create amount ->
+            let
+                ( newRows, seed ) =
+                    createRandomBatch model.seed amount model.lastId
+            in
+            ( { model
+                | rows = newRows
+                , seed = Just seed
+                , lastId = model.lastId + amount
+              }
+            , Cmd.none
+            )
+
+        Append amount ->
+            let
+                ( newRows, seed ) =
+                    createRandomBatch model.seed amount model.lastId
+            in
+            ( { model
+                | rows = model.rows ++ newRows
+                , seed = Just seed
+                , lastId = model.lastId + amount
+              }
+            , Cmd.none
+            )
+
+        UpdateEvery amount ->
+            ( { model | rows = List.indexedMap updateRow model.rows }, Cmd.none )
+
+        Clear ->
+            ( { model | rows = [] }, Cmd.none )
+
+        Swap ->
+            if List.length model.rows > 998 then
+                let
+                    arr =
+                        model.rows
+                            |> Array.fromList
+
+                    from =
+                        get 1 arr
+
+                    to =
+                        get 998 arr
+                in
+                ( { model
+                    | rows =
+                        arr
+                            |> Array.set 1 to
+                            |> Array.set 998 from
+                            |> Array.toList
+                  }
+                , Cmd.none
+                )
+
+            else
+                ( model, Cmd.none )
+
+        Remove id ->
+            ( { model | rows = List.filter (\r -> r.id /= id) model.rows }, Cmd.none )
+
+        Select id ->
+            ( { model | rows = List.map (select id) model.rows }, Cmd.none )
+
+        UpdateSeed seed ->
+            ( { model | seed = Just seed }, Cmd.none )
+
+
+updateRow : Int -> Row -> Row
+updateRow index row =
+    if index % 10 == 0 then
+        { row | label = row.label ++ " !!!" }
+
+    else
+        row
+
+
+select : Int -> Row -> Row
+select targetId ({ id, label, selected } as row) =
+    if id == targetId then
+        Row id label True
+
+    else if selected == True then
+        Row id label False
+
+    else
+        row
+
+
+type alias Model =
+    { seed : Maybe Seed
+    , rows : List Row
+    , lastId : Int
+    }
+
+
+type alias Row =
+    { id : Int
+    , label : String
+    , selected : Bool
+    }
+
+
+init : ( Model, Cmd Msg )
+init =
+    ( { seed = Nothing
+      , rows = []
+      , lastId = 1
+      }
+    , Random.Pcg.generate UpdateSeed Random.Pcg.independentSeed
+    )
+
+
+batch : Int -> Generator (List String)
+batch n =
+    Random.Pcg.list n generator
+
+
+generator : Generator String
+generator =
+    Random.Pcg.map (Maybe.withDefault "")
+        (Random.Pcg.map3
+            (Maybe.map3 (\a c n -> String.join " " [ a, c, n ]))
+            (Random.Pcg.sample adjectives)
+            (Random.Pcg.sample colours)
+            (Random.Pcg.sample nouns)
+        )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none


### PR DESCRIPTION
I noticed there's only a `keyed` Elm example, but in Elm, non-keyed is the default and what almost everyone does almost all the time (many people don't even know the keyed option exists!) - so I added a `non-keyed` Elm one. 😄 

I also noticed the Elm ones weren't uglified, which is a standard part of building for prod which impacts performance, so I added that to their `build-prod`.

Finally, I noticed the `keyed` Elm version wasn't using `Array.Hamt`, which is the best practice Array implementation to use in Elm 0.18. (In the upcoming Elm 0.19, it has become the default Array implementation in `core`.)