### PR TITLE
update domvm-v3.4.5

### DIFF
--- a/frameworks/keyed/domvm/build.js
+++ b/frameworks/keyed/domvm/build.js
@@ -1,6 +1,6 @@
 const rollup = require('rollup').rollup;
 const buble = require('rollup-plugin-buble');
-const ClosureCompiler = require('closure-compiler-js-prebuilt');
+const UglifyJS = require('uglify-js');
 const fs = require('fs');
 
 rollup({
@@ -14,15 +14,68 @@ rollup({
 		format: 'iife'
 	})
 }).then(() => {
-	const flags = {
-		jsCode: [{src: fs.readFileSync('dist/bundle.js', 'utf8')}],
-		languageIn: 'ECMASCRIPT5_STRICT',
-		languageOut: 'ECMASCRIPT5',
-		compilationLevel: 'SIMPLE',
-		rewritePolyfills: false,
+	// from docs (https://github.com/mishoo/UglifyJS2)
+	const compressDefaults = {
+		arguments: true,
+		booleans: true,
+		collapse_vars: true,
+		comparisons: true,
+		conditionals: true,
+		dead_code: true,
+		directives: true,
+		drop_console: false,
+		drop_debugger: true,
+		evaluate: true,
+		expression: false,
+		global_defs: {},
+		hoist_funs: false,
+		hoist_props: true,
+		hoist_vars: false,
+		if_return: true,
+		inline: 3,
+		join_vars: true,
+		keep_fargs: true,
+		keep_fnames: false,
+		keep_infinity: false,
+		loops: true,
+		negate_iife: true,
+		passes: 1,
+		properties: true,
+		pure_funcs: null,
+		pure_getters: "strict",
+		reduce_funcs: true,
+		reduce_vars: true,
+		sequences: true,
+		side_effects: true,
+		switches: true,
+		toplevel: false,
+		top_retain: null,
+		typeofs: true,
+		unsafe: false,
+		unsafe_comps: false,
+		unsafe_Function: false,
+		unsafe_math: false,
+		unsafe_proto: false,
+		unsafe_regexp: false,
+		unsafe_undefined: false,
+		unused: true,
+		warnings: false,
 	};
 
-	const compiled = new ClosureCompiler(flags).run().compiledCode;
+	const opts = {
+		compress: Object.assign({}, compressDefaults, {
+			booleans: false,
+			inline: 0,
+			keep_fargs: false,
+			hoist_props: false,
+			loops: false,
+			reduce_funcs: false,
+			unsafe: true,
+			unsafe_math: true,
+		}),
+	};
+
+	const compiled = UglifyJS.minify(fs.readFileSync('dist/bundle.js', 'utf8'), opts).code;
 
 	fs.writeFileSync('dist/bundle.min.js', compiled, 'utf8');
 }).catch(err => console.log(err.stack));

--- a/frameworks/keyed/domvm/package.json
+++ b/frameworks/keyed/domvm/package.json
@@ -10,9 +10,9 @@
     "build-prod": "node build.js"
   },
   "devDependencies": {
-    "closure-compiler-js-prebuilt": "git://github.com/domvm/closure-compiler-js-prebuilt.git#20180805.0.0",
-    "rollup": "*",
-    "rollup-plugin-buble": "*"
+    "rollup": "^0.64.1",
+    "rollup-plugin-buble": "^0.19.2",
+    "uglify-js": "^3.4.7"
   },
   "dependencies": {
     "domvm": "git://github.com/domvm/domvm.git#3.4.5"

--- a/frameworks/keyed/domvm/package.json
+++ b/frameworks/keyed/domvm/package.json
@@ -1,20 +1,20 @@
 {
   "name": "js-framework-benchmark-domvm-keyed",
-  "version": "3.4.3-keyed",
+  "version": "3.4.5-keyed",
   "description": "Benchmark for domvm framework (keyed)",
   "js-framework-benchmark": {
-    "frameworkVersion": "3.4.3"
+    "frameworkVersion": "3.4.5"
   },
   "scripts": {
     "build-dev": "node build.js",
     "build-prod": "node build.js"
   },
   "devDependencies": {
-    "closure-compiler-js-prebuilt": "git://github.com/domvm/closure-compiler-js-prebuilt.git#20180716.0.0",
+    "closure-compiler-js-prebuilt": "git://github.com/domvm/closure-compiler-js-prebuilt.git#20180805.0.0",
     "rollup": "*",
     "rollup-plugin-buble": "*"
   },
   "dependencies": {
-    "domvm": "git://github.com/domvm/domvm.git#3.4.3"
+    "domvm": "git://github.com/domvm/domvm.git#3.4.5"
   }
 }

--- a/frameworks/non-keyed/domvm/build.js
+++ b/frameworks/non-keyed/domvm/build.js
@@ -1,6 +1,6 @@
 const rollup = require('rollup').rollup;
 const buble = require('rollup-plugin-buble');
-const ClosureCompiler = require('closure-compiler-js-prebuilt');
+const UglifyJS = require('uglify-js');
 const fs = require('fs');
 
 rollup({
@@ -14,15 +14,68 @@ rollup({
 		format: 'iife'
 	})
 }).then(() => {
-	const flags = {
-		jsCode: [{src: fs.readFileSync('dist/bundle.js', 'utf8')}],
-		languageIn: 'ECMASCRIPT5_STRICT',
-		languageOut: 'ECMASCRIPT5',
-		compilationLevel: 'SIMPLE',
-		rewritePolyfills: false,
+	// from docs (https://github.com/mishoo/UglifyJS2)
+	const compressDefaults = {
+		arguments: true,
+		booleans: true,
+		collapse_vars: true,
+		comparisons: true,
+		conditionals: true,
+		dead_code: true,
+		directives: true,
+		drop_console: false,
+		drop_debugger: true,
+		evaluate: true,
+		expression: false,
+		global_defs: {},
+		hoist_funs: false,
+		hoist_props: true,
+		hoist_vars: false,
+		if_return: true,
+		inline: 3,
+		join_vars: true,
+		keep_fargs: true,
+		keep_fnames: false,
+		keep_infinity: false,
+		loops: true,
+		negate_iife: true,
+		passes: 1,
+		properties: true,
+		pure_funcs: null,
+		pure_getters: "strict",
+		reduce_funcs: true,
+		reduce_vars: true,
+		sequences: true,
+		side_effects: true,
+		switches: true,
+		toplevel: false,
+		top_retain: null,
+		typeofs: true,
+		unsafe: false,
+		unsafe_comps: false,
+		unsafe_Function: false,
+		unsafe_math: false,
+		unsafe_proto: false,
+		unsafe_regexp: false,
+		unsafe_undefined: false,
+		unused: true,
+		warnings: false,
 	};
 
-	const compiled = new ClosureCompiler(flags).run().compiledCode;
+	const opts = {
+		compress: Object.assign({}, compressDefaults, {
+			booleans: false,
+			inline: 0,
+			keep_fargs: false,
+			hoist_props: false,
+			loops: false,
+			reduce_funcs: false,
+			unsafe: true,
+			unsafe_math: true,
+		}),
+	};
+
+	const compiled = UglifyJS.minify(fs.readFileSync('dist/bundle.js', 'utf8'), opts).code;
 
 	fs.writeFileSync('dist/bundle.min.js', compiled, 'utf8');
 }).catch(err => console.log(err.stack));

--- a/frameworks/non-keyed/domvm/package.json
+++ b/frameworks/non-keyed/domvm/package.json
@@ -1,20 +1,20 @@
 {
   "name": "js-framework-benchmark-domvm-non-keyed",
-  "version": "3.4.3-non-keyed",
+  "version": "3.4.5-non-keyed",
   "description": "Benchmark for domvm framework (non-keyed)",
   "js-framework-benchmark": {
-    "frameworkVersion": "3.4.3"
+    "frameworkVersion": "3.4.5"
   },
   "scripts": {
     "build-dev": "node build.js",
     "build-prod": "node build.js"
   },
   "devDependencies": {
-    "closure-compiler-js-prebuilt": "git://github.com/domvm/closure-compiler-js-prebuilt.git#20180716.0.0",
+    "closure-compiler-js-prebuilt": "git://github.com/domvm/closure-compiler-js-prebuilt.git#20180805.0.0",
     "rollup": "*",
     "rollup-plugin-buble": "*"
   },
   "dependencies": {
-    "domvm": "git://github.com/domvm/domvm.git#3.4.3"
+    "domvm": "git://github.com/domvm/domvm.git#3.4.5"
   }
 }

--- a/frameworks/non-keyed/domvm/package.json
+++ b/frameworks/non-keyed/domvm/package.json
@@ -10,9 +10,9 @@
     "build-prod": "node build.js"
   },
   "devDependencies": {
-    "closure-compiler-js-prebuilt": "git://github.com/domvm/closure-compiler-js-prebuilt.git#20180805.0.0",
-    "rollup": "*",
-    "rollup-plugin-buble": "*"
+    "rollup": "^0.64.1",
+    "rollup-plugin-buble": "^0.19.2",
+    "uglify-js": "^3.4.7"
   },
   "dependencies": {
     "domvm": "git://github.com/domvm/domvm.git#3.4.5"

--- a/results-ui/package.json
+++ b/results-ui/package.json
@@ -15,11 +15,11 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "domvm": "git://github.com/domvm/domvm.git#3.4.4",
-    "clean-css": "*",
-    "rollup": "*",
-    "rollup-plugin-buble": "*",
-    "rollup-plugin-uglify": "*"
+    "clean-css": "^4.2.1",
+    "domvm": "git://github.com/domvm/domvm.git#3.4.5",
+    "rollup": "^0.64.1",
+    "rollup-plugin-buble": "^0.19.2",
+    "uglify-js": "^3.4.7"
   },
   "dependencies": {}
 }

--- a/results-ui/src/build.js
+++ b/results-ui/src/build.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const rollup = require('rollup');
 const buble = require('rollup-plugin-buble');
-const uglify = require('rollup-plugin-uglify').uglify;
+const UglifyJS = require('uglify-js');
 const CleanCSS = require('clean-css');
 const path = require("path");
 
@@ -59,21 +59,80 @@ async function build() {
         input: __dirname + "/ui.js",
         plugins: [
             buble(),
-            uglify(),
         ],
     });
+
+	// from docs (https://github.com/mishoo/UglifyJS2)
+	const compressDefaults = {
+		arguments: true,
+		booleans: true,
+		collapse_vars: true,
+		comparisons: true,
+		conditionals: true,
+		dead_code: true,
+		directives: true,
+		drop_console: false,
+		drop_debugger: true,
+		evaluate: true,
+		expression: false,
+		global_defs: {},
+		hoist_funs: false,
+		hoist_props: true,
+		hoist_vars: false,
+		if_return: true,
+		inline: 3,
+		join_vars: true,
+		keep_fargs: true,
+		keep_fnames: false,
+		keep_infinity: false,
+		loops: true,
+		negate_iife: true,
+		passes: 1,
+		properties: true,
+		pure_funcs: null,
+		pure_getters: "strict",
+		reduce_funcs: true,
+		reduce_vars: true,
+		sequences: true,
+		side_effects: true,
+		switches: true,
+		toplevel: false,
+		top_retain: null,
+		typeofs: true,
+		unsafe: false,
+		unsafe_comps: false,
+		unsafe_Function: false,
+		unsafe_math: false,
+		unsafe_proto: false,
+		unsafe_regexp: false,
+		unsafe_undefined: false,
+		unused: true,
+		warnings: false,
+	};
+
+	const uglifyOpts = {
+		compress: Object.assign({}, compressDefaults, {
+			booleans: false,
+			inline: 0,
+			keep_fargs: false,
+			hoist_props: false,
+			loops: false,
+			reduce_funcs: false,
+			unsafe: true,
+			unsafe_math: true,
+		}),
+	};
 
     const { code, map } = await bundle.generate({
         format: "iife",
     });
 
+    const minJs = UglifyJS.minify(code, uglifyOpts).code;
+
     var css = fs.readFileSync(__dirname + '/bootstrap-reboot.css', 'utf8').replace(/\/\*[\s\S]+?\*\/\s*/gm, '');
     css += fs.readFileSync(__dirname + '/style.css', 'utf8');
-    const opts = {
-        level: 2
-    };
 
-    const minCss = new CleanCSS(opts).minify(css).styles;
+    const minCss = new CleanCSS({level: 2}).minify(css).styles;
 
     const html = [
         '<!doctype html>',
@@ -89,7 +148,7 @@ async function build() {
         '</head>',
         '<body>',
         '<script>',
-        code.trim(),
+        minJs.trim(),
         '</script>',
         '</body>',
         '</html>',


### PR DESCRIPTION
this update reverts the removal of an internal cleanup pass after some potential memleak issues were discovered related to imperative/retained views (though not used in this bench).

i expect this to slightly reduce perf of metrics with mass removals (1k replace and 10k clear).

really enjoying the new "low maintenance" update process/diff :+1: 