### PR TITLE
Hyperapp update to 1.2.9

### DIFF
--- a/frameworks/keyed/hyperapp/package.json
+++ b/frameworks/keyed/hyperapp/package.json
@@ -7,7 +7,7 @@
     "frameworkVersionFromPackage": "hyperapp"
   },
   "dependencies": {
-    "hyperapp": "1.2.0"
+    "hyperapp": "1.2.9"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/frameworks/non-keyed/hyperapp/package.json
+++ b/frameworks/non-keyed/hyperapp/package.json
@@ -7,7 +7,7 @@
     "frameworkVersionFromPackage": "hyperapp"
   },
   "dependencies": {
-    "hyperapp": "1.2.0"
+    "hyperapp": "1.2.9"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
Updating hyperapp to the latest: v1.2.9.

There were some performance optimizations since 1.2 (the current benchmark version), so I'm very interested in seeing how it does.