### PR TITLE
fix build process for react-easy-state (bump webpack)

### DIFF
--- a/frameworks/keyed/react-easy-state/package.json
+++ b/frameworks/keyed/react-easy-state/package.json
@@ -27,7 +27,7 @@
     "babel-preset-es2015": "6.24.1",
     "babel-preset-react": "6.24.1",
     "jsx-loader": "0.13.2",
-    "webpack": "^4.0.0-beta.1"
+    "webpack": "4.16.3"
   },
   "dependencies": {
     "react": "16.1.0",


### PR DESCRIPTION
Fixes https://github.com/krausest/js-framework-benchmark/pull/465. easy-state was stuck with a beta version of webpack 4, which had some issues. I updated the webpack version to match with the other react implementations. (I think Redux is also behind, but I didn't want to touch it).