### PR TITLE
Fix Solid Select performance

### DIFF
--- a/frameworks/keyed/solid/package.json
+++ b/frameworks/keyed/solid/package.json
@@ -1,12 +1,12 @@
 {
   "name": "js-framework-benchmark-solid",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "solid-js"
   },
   "scripts": {
-    "build-dev": "rollup -c",
+    "build-dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Ryan Carniato",
@@ -17,15 +17,15 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.1.0",
+    "babel-plugin-jsx-dom-expressions": "0.1.3",
     "s-js": "0.4.9",
-    "solid-js": "0.1.0"
+    "solid-js": "0.1.2"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0",
-    "rollup": "0.65.2",
+    "@babel/core": "7.1.2",
+    "rollup": "0.66.6",
     "rollup-plugin-babel": "4.0.3",
     "rollup-plugin-node-resolve": "3.4.0",
-    "rollup-plugin-terser": "2.0.2"
+    "rollup-plugin-terser": "3.0.0"
   }
 }


### PR DESCRIPTION
Updated Solid to 0.1.2.

Seriously this benchmark is the best. After seeing how strangely variable Solid results were on the 16x slowdown select I realized a pretty serious performance issue in my selection operator where I was re-evaluating the whole list on every select needlessly.