### PR TITLE
ci: test Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 os:
+  - windows
   - osx
   - linux
 


### PR DESCRIPTION
TravisCI has now support for Windows so we can also test there.

See https://blog.travis-ci.com/2018-10-11-windows-early-release

This PR is meant to be WIP as we have to check what we have to adjust in the CI config to get it running there too.