### PR TITLE
ci: decrease Git clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,4 +92,4 @@ script:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then  (npm run selenium -- --framework $JS_FRAMEWORK --count 1 --benchmark 01_ 02_ 03_ 04_ 05_ 06_) fi
   
 git:
-  depth: 700
+  depth: 5


### PR DESCRIPTION
Cloning the last 700 commits seems a bit much or is there a (good) reason?

The last 5 commits should be sufficient and we get faster clone times.