### PR TITLE
ci: use Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ env:
   - JS_FRAMEWORK=vue-v2.3.3-non-keyed
 
 language : node_js
-node_js  : 7
+node_js  : 8
 
 addons:
   chrome: beta


### PR DESCRIPTION
Node.js 7 like every odd release branch is a short living release and has already reached its EOL.

Current LTS are 6, 8 and 10. 8 should be fine here.

See https://github.com/nodejs/Release/blob/master/README.md