### PR TITLE
Update react-redux to 6.0

### DIFF
--- a/frameworks/keyed/react-redux/package.json
+++ b/frameworks/keyed/react-redux/package.json
@@ -4,7 +4,7 @@
   "description": "React demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react:redux"
+    "frameworkVersionFromPackage": "react:react-redux"
   },
   "scripts": {
     "build-dev": "webpack --watch",
@@ -22,19 +22,19 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "@babel/core": "7.1.2",
-    "@babel/preset-env": "7.1.0",
+    "@babel/core": "7.2.0",
+    "@babel/preset-env": "7.2.0",
     "@babel/preset-react": "7.0.0",
-    "@babel/plugin-proposal-class-properties": "7.1.0",
+    "@babel/plugin-proposal-class-properties": "7.2.1",
     "babel-loader": "8.0.4",
     "terser-webpack-plugin": "1.1.0",
-    "webpack": "4.22.0",
+    "webpack": "4.27.0",
     "webpack-cli": "3.1.2"
   },
   "dependencies": {
-    "react": "16.6.0",
-    "react-dom": "16.6.0",
-    "react-redux": "5.0.7",
+    "react": "16.6.3",
+    "react-dom": "16.6.3",
+    "react-redux": "6.0.0",
     "redux": "4.0.1"
   }
 }


### PR DESCRIPTION
- Updated react-redux to 6.0.0, it is now using modern Context API
- Redux version is captured from `react-redux` package instead of `redux`
