### PR TITLE
Update Solid, ko-jsx, mobx-jsx

### DIFF
--- a/frameworks/keyed/ko-jsx/package.json
+++ b/frameworks/keyed/ko-jsx/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.3.5",
+    "babel-plugin-jsx-dom-expressions": "0.3.6",
     "knockout": "^3.4.2",
     "ko-jsx": "0.3.0"
   },

--- a/frameworks/keyed/ko-jsx/package.json
+++ b/frameworks/keyed/ko-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-ko-jsx",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "index.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "ko-jsx"
@@ -17,16 +17,16 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.2.0",
+    "babel-plugin-jsx-dom-expressions": "0.3.3",
     "knockout": "^3.4.2",
-    "ko-jsx": "0.2.0"
+    "ko-jsx": "0.3.0"
   },
   "devDependencies": {
     "@babel/core": "7.1.6",
-    "rollup": "0.67.3",
-    "rollup-plugin-babel": "4.0.3",
+    "rollup": "1.0.0",
+    "rollup-plugin-babel": "4.2.0",
     "rollup-plugin-commonjs": "9.2.0",
-    "rollup-plugin-node-resolve": "3.4.0",
+    "rollup-plugin-node-resolve": "4.0.0",
     "rollup-plugin-terser": "3.0.0"
   }
 }

--- a/frameworks/keyed/ko-jsx/package.json
+++ b/frameworks/keyed/ko-jsx/package.json
@@ -17,16 +17,16 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.3.4",
+    "babel-plugin-jsx-dom-expressions": "0.3.5",
     "knockout": "^3.4.2",
     "ko-jsx": "0.3.0"
   },
   "devDependencies": {
-    "@babel/core": "7.1.6",
+    "@babel/core": "7.2.2",
     "rollup": "1.0.0",
     "rollup-plugin-babel": "4.2.0",
     "rollup-plugin-commonjs": "9.2.0",
     "rollup-plugin-node-resolve": "4.0.0",
-    "rollup-plugin-terser": "3.0.0"
+    "rollup-plugin-terser": "4.0.1"
   }
 }

--- a/frameworks/keyed/ko-jsx/package.json
+++ b/frameworks/keyed/ko-jsx/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.3.3",
+    "babel-plugin-jsx-dom-expressions": "0.3.4",
     "knockout": "^3.4.2",
     "ko-jsx": "0.3.0"
   },

--- a/frameworks/keyed/ko-jsx/src/template.jsx
+++ b/frameworks/keyed/ko-jsx/src/template.jsx
@@ -25,17 +25,17 @@ export default function({data, selected, run, runLots, add, update, clear, swapR
         </div>
       </div></div>
     </div></div>
-    <table class='table table-hover table-striped test-data'><tbody onClick={clickRow}>{
-      selectWhen(selected, 'danger')
-      (data.each(row =>
-        <tr model={row.id}>
-          <td class='col-md-1' textContent={row.id} />
-          <td class='col-md-4'><a>{row.label}</a></td>
-          <td class='col-md-1'><a action={'remove'}><span class='glyphicon glyphicon-remove' /></a></td>
-          <td class='col-md-6'/>
-        </tr>
-      ))
-    }</tbody></table>
+    <table class='table table-hover table-striped test-data'><tbody onClick={clickRow}>
+      <$ each={data()} afterRender={selectWhen(selected, 'danger')}>{
+        row =>
+          <tr model={row.id}>
+            <td class='col-md-1' textContent={row.id} />
+            <td class='col-md-4'><a>{row.label}</a></td>
+            <td class='col-md-1'><a action={'remove'}><span class='glyphicon glyphicon-remove' /></a></td>
+            <td class='col-md-6'/>
+          </tr>
+      }</$>
+    </tbody></table>
     <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
   </div>
 }

--- a/frameworks/keyed/ko-jsx/src/template.jsx
+++ b/frameworks/keyed/ko-jsx/src/template.jsx
@@ -1,28 +1,21 @@
 import { r, selectWhen } from 'ko-jsx'
 
+const Button = ({id, text, fn}) =>
+  <div class ='col-sm-6 smallpad'>
+    <button id={id} class='btn btn-primary btn-block' type='button' onClick={fn}>{text}</button>
+  </div>
+
 export default function({data, selected, run, runLots, add, update, clear, swapRows, clickRow}) {
   return <div class='container'>
     <div class='jumbotron'><div class='row'>
       <div class ='col-md-6'><h1>KnockoutJSX-keyed</h1></div>
       <div class ='col-md-6'><div class ='row'>
-        <div class ='col-sm-6 smallpad'>
-          <button id='run' class='btn btn-primary btn-block' type='button' onClick={run}>Create 1,000 rows</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='runlots' class='btn btn-primary btn-block' type='button' onClick={runLots}>Create 10,000 rows</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='add' class='btn btn-primary btn-block' type='button' onClick={add}>Append 1,000 rows</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='update' class='btn btn-primary btn-block' type='button' onClick={update}>Update every 10th row</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='clear' class='btn btn-primary btn-block' type='button' onClick={clear}>Clear</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='swaprows' class='btn btn-primary btn-block' type='button' onClick={swapRows}>Swap Rows</button>
-        </div>
+        <Button id='run' text='Create 1,000 rows' fn={run} />
+        <Button id='runlots' text='Create 10,000 rows' fn={runLots} />
+        <Button id='add' text='Append 1,000 rows' fn={add} />
+        <Button id='update' text='Update every 10th row' fn={update} />
+        <Button id='clear' text='Clear' fn={clear} />
+        <Button id='swaprows' text='Swap Rows' fn={swapRows} />
       </div></div>
     </div></div>
     <table class='table table-hover table-striped test-data'><tbody onClick={clickRow}>

--- a/frameworks/keyed/mobx-jsx/package.json
+++ b/frameworks/keyed/mobx-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-mobx-jsx",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "mobx-jsx"
@@ -17,15 +17,16 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.2.0",
-    "mobx-jsx": "0.0.7",
-    "mobx": "5.6.0"
+    "babel-plugin-jsx-dom-expressions": "0.3.3",
+    "mobx": "5.8.0",
+    "mobx-jsx": "0.1.0"
   },
   "devDependencies": {
-    "@babel/core": "7.1.2",
-    "rollup": "0.67.3",
-    "rollup-plugin-babel": "4.0.3",
-    "rollup-plugin-node-resolve": "3.4.0",
+    "@babel/core": "7.2.2",
+    "rollup": "1.0.0",
+    "rollup-plugin-babel": "4.2.0",
+    "rollup-plugin-node-resolve": "4.0.0",
+    "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "3.0.0"
   }
 }

--- a/frameworks/keyed/mobx-jsx/package.json
+++ b/frameworks/keyed/mobx-jsx/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.3.3",
+    "babel-plugin-jsx-dom-expressions": "0.3.4",
     "mobx": "5.8.0",
     "mobx-jsx": "0.1.0"
   },

--- a/frameworks/keyed/mobx-jsx/package.json
+++ b/frameworks/keyed/mobx-jsx/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.3.4",
+    "babel-plugin-jsx-dom-expressions": "0.3.5",
     "mobx": "5.8.0",
     "mobx-jsx": "0.1.0"
   },
@@ -27,6 +27,6 @@
     "rollup-plugin-babel": "4.2.0",
     "rollup-plugin-node-resolve": "4.0.0",
     "rollup-plugin-replace": "^2.1.0",
-    "rollup-plugin-terser": "3.0.0"
+    "rollup-plugin-terser": "4.0.1"
   }
 }

--- a/frameworks/keyed/mobx-jsx/package.json
+++ b/frameworks/keyed/mobx-jsx/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.3.5",
+    "babel-plugin-jsx-dom-expressions": "0.3.6",
     "mobx": "5.8.0",
     "mobx-jsx": "0.1.0"
   },

--- a/frameworks/keyed/mobx-jsx/rollup.config.js
+++ b/frameworks/keyed/mobx-jsx/rollup.config.js
@@ -1,4 +1,5 @@
 import resolve from 'rollup-plugin-node-resolve';
+import replace from 'rollup-plugin-replace'
 import babel from 'rollup-plugin-babel';
 import { terser } from 'rollup-plugin-terser';
 
@@ -7,7 +8,8 @@ const plugins = [
 		exclude: 'node_modules/**',
 		plugins: ["jsx-dom-expressions"]
   }),
-	resolve({ extensions: ['.js', '.jsx'] })
+	resolve({ extensions: ['.js', '.jsx'] }),
+	replace({"process.env.NODE_ENV": "'production'"})
 ];
 
 if (process.env.production) {

--- a/frameworks/keyed/mobx-jsx/src/main.jsx
+++ b/frameworks/keyed/mobx-jsx/src/main.jsx
@@ -1,5 +1,5 @@
-import { observable, action, untracked } from 'mobx';
-import { r, each, selectWhen, root } from 'mobx-jsx';
+import { observable, action } from 'mobx';
+import { r, selectWhen, root } from 'mobx-jsx';
 
 function _random (max) {
   return Math.round(Math.random() * 1000) % max;
@@ -25,72 +25,49 @@ function App() {
   const state = observable({data: [], selected: null});
 
   const clickRow = (e, id, intent) => {
-    e.stopPropagation();
     action(() => {
       if (intent === 'remove') {
-        // startMeasure('delete');
-        const data = state.data;
+        const data = state.data.slice(0);
         data.splice(data.findIndex(d => d.id === id), 1)
-        // stopMeasure();
-      } else {
-        // startMeasure("select");
-        state.selected = id;
-        // stopMeasure();
-      }
+        state.data = data;
+      } else state.selected = id;
     })();
   };
 
   const run = action(e => {
-    e.stopPropagation();
-    // startMeasure('create 1000');
     state.data = buildData(1000);
     state.selected = null;
-    // stopMeasure();
   });
 
   const runLots = action(e => {
-    e.stopPropagation();
-    // startMeasure('create 10000');
     state.data = buildData(10000);
     state.selected = null;
-    // stopMeasure();
   });
 
   const add = action(e => {
-    e.stopPropagation();
-    // startMeasure('append 1000');
-    state.data.push.apply(state.data, buildData(1000));
-    // stopMeasure();
+    state.data = state.data.concat(buildData(1000));
   });
 
   const update = action(e => {
-    e.stopPropagation();
-    // startMeasure('update');
     let index = 0;
     while (index < state.data.length) {
       state.data[index].label += ' !!!';
       index += 10;
     }
-    // stopMeasure();
   });
 
   const swapRows = action(e => {
-    e.stopPropagation();
-    // startMeasure("swapRows");
     if (state.data.length > 998) {
-      let temp = state.data[1];
-      state.data[1] = state.data[998];
-      state.data[998] = temp;
+      let data = state.data.slice(0);
+      data[1] = state.data[998];
+      data[998] = state.data[1];
+      state.data = data;
     }
-    // stopMeasure();
   });
 
   const clear = action(e => {
-    e.stopPropagation();
-    // startMeasure('clear');
     state.data = [];
     state.selected = null;
-    // stopMeasure();
   });
 
   return <div class='container'>
@@ -117,17 +94,17 @@ function App() {
         </div>
       </div></div>
     </div></div>
-    <table class='table table-hover table-striped test-data'><tbody onClick={ clickRow }>{
-      selectWhen(() => state.selected, 'danger')
-      (each(() => state.data, row =>
-        <tr model={ row.id }>
-          <td class='col-md-1' textContent={ row.id } />
-          <td class='col-md-4'><a>{( row.label )}</a></td>
-          <td class='col-md-1'><a action={'remove'}><span class='glyphicon glyphicon-remove' /></a></td>
-          <td class='col-md-6'/>
-        </tr>
-      ))
-    }</tbody></table>
+    <table class='table table-hover table-striped test-data'><tbody onClick={ clickRow }>
+      <$ each={ state.data } afterRender={selectWhen(() => state.selected, 'danger')}>{
+        row =>
+          <tr model={ row.id }>
+            <td class='col-md-1' textContent={ row.id } />
+            <td class='col-md-4'><a>{( row.label )}</a></td>
+            <td class='col-md-1'><a action={'remove'}><span class='glyphicon glyphicon-remove' /></a></td>
+            <td class='col-md-6'/>
+          </tr>
+      }</$>
+    </tbody></table>
     <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
   </div>
 }

--- a/frameworks/keyed/mobx-jsx/src/main.jsx
+++ b/frameworks/keyed/mobx-jsx/src/main.jsx
@@ -21,7 +21,12 @@ function buildData(count) {
   return data;
 }
 
-function App() {
+const Button = ({ id, text, fn }) =>
+  <div class ='col-sm-6 smallpad'>
+    <button id={ id } class='btn btn-primary btn-block' type='button' onClick={ fn }>{ text }</button>
+  </div>
+
+const App = () => {
   const state = observable({data: [], selected: null});
 
   const clickRow = (e, id, intent) => {
@@ -74,24 +79,12 @@ function App() {
     <div class='jumbotron'><div class='row'>
       <div class ='col-md-6'><h1>MobX-JSX Keyed</h1></div>
       <div class ='col-md-6'><div class ='row'>
-        <div class ='col-sm-6 smallpad'>
-          <button id='run' class='btn btn-primary btn-block' type='button' onClick={ run }>Create 1,000 rows</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='runlots' class='btn btn-primary btn-block' type='button' onClick={ runLots }>Create 10,000 rows</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='add' class='btn btn-primary btn-block' type='button' onClick={ add }>Append 1,000 rows</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='update' class='btn btn-primary btn-block' type='button' onClick={ update }>Update every 10th row</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='clear' class='btn btn-primary btn-block' type='button' onClick={ clear }>Clear</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='swaprows' class='btn btn-primary btn-block' type='button' onClick={ swapRows }>Swap Rows</button>
-        </div>
+        <Button id='run' text='Create 1,000 rows' fn={ run } />
+        <Button id='runlots' text='Create 10,000 rows' fn={ runLots } />
+        <Button id='add' text='Append 1,000 rows' fn={ add } />
+        <Button id='update' text='Update every 10th row' fn={ update } />
+        <Button id='clear' text='Clear' fn={ clear } />
+        <Button id='swaprows' text='Swap Rows' fn={ swapRows } />
       </div></div>
     </div></div>
     <table class='table table-hover table-striped test-data'><tbody onClick={ clickRow }>

--- a/frameworks/keyed/solid/package.json
+++ b/frameworks/keyed/solid/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "babel-plugin-jsx-dom-expressions": "0.3.5",
     "s-js": "0.4.9",
-    "solid-js": "0.3.3"
+    "solid-js": "0.3.4"
   },
   "devDependencies": {
     "@babel/core": "7.2.2",

--- a/frameworks/keyed/solid/package.json
+++ b/frameworks/keyed/solid/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.3.4",
+    "babel-plugin-jsx-dom-expressions": "0.3.5",
     "s-js": "0.4.9",
     "solid-js": "0.3.3"
   },
@@ -26,6 +26,6 @@
     "rollup": "1.0.0",
     "rollup-plugin-babel": "4.2.0",
     "rollup-plugin-node-resolve": "4.0.0",
-    "rollup-plugin-terser": "3.0.0"
+    "rollup-plugin-terser": "4.0.1"
   }
 }

--- a/frameworks/keyed/solid/package.json
+++ b/frameworks/keyed/solid/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "babel-plugin-jsx-dom-expressions": "0.3.4",
     "s-js": "0.4.9",
-    "solid-js": "0.3.2"
+    "solid-js": "0.3.3"
   },
   "devDependencies": {
     "@babel/core": "7.2.2",

--- a/frameworks/keyed/solid/package.json
+++ b/frameworks/keyed/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-solid",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "solid-js"
@@ -17,15 +17,15 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.2.0",
+    "babel-plugin-jsx-dom-expressions": "0.3.3",
     "s-js": "0.4.9",
-    "solid-js": "0.2.0"
+    "solid-js": "0.3.1"
   },
   "devDependencies": {
-    "@babel/core": "7.1.6",
-    "rollup": "0.67.3",
-    "rollup-plugin-babel": "4.0.3",
-    "rollup-plugin-node-resolve": "3.4.0",
+    "@babel/core": "7.2.2",
+    "rollup": "1.0.0",
+    "rollup-plugin-babel": "4.2.0",
+    "rollup-plugin-node-resolve": "4.0.0",
     "rollup-plugin-terser": "3.0.0"
   }
 }

--- a/frameworks/keyed/solid/package.json
+++ b/frameworks/keyed/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-solid",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "solid-js"
@@ -17,8 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.3.5",
-    "s-js": "0.4.9",
+    "babel-plugin-jsx-dom-expressions": "0.3.6",
     "solid-js": "0.3.4"
   },
   "devDependencies": {

--- a/frameworks/keyed/solid/package.json
+++ b/frameworks/keyed/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-solid",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "solid-js"
@@ -19,7 +19,7 @@
   "dependencies": {
     "babel-plugin-jsx-dom-expressions": "0.3.3",
     "s-js": "0.4.9",
-    "solid-js": "0.3.1"
+    "solid-js": "0.3.2"
   },
   "devDependencies": {
     "@babel/core": "7.2.2",

--- a/frameworks/keyed/solid/package.json
+++ b/frameworks/keyed/solid/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.3.3",
+    "babel-plugin-jsx-dom-expressions": "0.3.4",
     "s-js": "0.4.9",
     "solid-js": "0.3.2"
   },

--- a/frameworks/keyed/solid/src/main.jsx
+++ b/frameworks/keyed/solid/src/main.jsx
@@ -1,12 +1,12 @@
-import { useState, root } from 'solid-js';
+import { root, useState } from 'solid-js';
 import { r, selectWhen } from 'solid-js/dom';
-
-function _random (max) { return Math.round(Math.random() * 1000) % max; };
 
 let idCounter = 1;
 const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"],
   colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"],
   nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+
+function _random (max) { return Math.round(Math.random() * 1000) % max; };
 
 function buildData(count) {
   let data = new Array(count);
@@ -19,66 +19,51 @@ function buildData(count) {
   return data;
 }
 
-function App() {
-  const [ state, setState ] = useState({ data: [], selected: null });
+const Button = ({ id, text, fn }) =>
+  <div class ='col-sm-6 smallpad'>
+    <button id={ id } class='btn btn-primary btn-block' type='button' onClick={ fn }>{ text }</button>
+  </div>
+
+const App = () => {
+  const [ state, setState ] = useState({ data: [], selected: null }),
+    run = () => setState({ data: buildData(1000), selected: null }),
+    runLots = () => setState({ data: buildData(10000), selected: null }),
+    add = () => setState('data', d => [...d, ...buildData(1000)]),
+    update = () => setState('data', { by: 10 }, 'label', l => l + ' !!!'),
+    swapRows = () => setState('data', d => d.length > 998 ? { 1: d[998], 998: d[1] } : d),
+    clear = () => setState({ data: [], selected: null }),
+    clickRow = (e, id, action) => {
+      action === 'remove' ?
+        setState('data', d => {
+          const idx = d.findIndex(d => d.id === id);
+          return [...d.slice(0, idx), ...d.slice(idx + 1)];
+        }) : setState('selected', id);
+    };
 
   return <div class='container'>
     <div class='jumbotron'><div class='row'>
       <div class ='col-md-6'><h1>SolidJS Keyed</h1></div>
       <div class ='col-md-6'><div class ='row'>
-        <div class ='col-sm-6 smallpad'>
-          <button id='run' class='btn btn-primary btn-block' type='button' onClick={ run }>Create 1,000 rows</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='runlots' class='btn btn-primary btn-block' type='button' onClick={ runLots }>Create 10,000 rows</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='add' class='btn btn-primary btn-block' type='button' onClick={ add }>Append 1,000 rows</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='update' class='btn btn-primary btn-block' type='button' onClick={ update }>Update every 10th row</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='clear' class='btn btn-primary btn-block' type='button' onClick={ clear }>Clear</button>
-        </div>
-        <div class='col-sm-6 smallpad'>
-          <button id='swaprows' class='btn btn-primary btn-block' type='button' onClick={ swapRows }>Swap Rows</button>
-        </div>
+        <Button id='run' text='Create 1,000 rows' fn={ run } />
+        <Button id='runlots' text='Create 10,000 rows' fn={ runLots } />
+        <Button id='add' text='Append 1,000 rows' fn={ add } />
+        <Button id='update' text='Update every 10th row' fn={ update } />
+        <Button id='clear' text='Clear' fn={ clear } />
+        <Button id='swaprows' text='Swap Rows' fn={ swapRows } />
       </div></div>
     </div></div>
     <table class='table table-hover table-striped test-data'><tbody onClick={ clickRow }>
-      <$ each={ state.data } afterRender={ selectWhen(() => state.selected, 'danger') }>{
-        row =>
-          <tr model={ row.id }>
-            <td class='col-md-1' textContent={ row.id } />
-            <td class='col-md-4'><a>{( row.label )}</a></td>
-            <td class='col-md-1'><a action={ 'remove' }><span class='glyphicon glyphicon-remove' /></a></td>
-            <td class='col-md-6'/>
-          </tr>
+      <$ each={ state.data } afterRender={ selectWhen(() => state.selected, 'danger') }>{ row =>
+        <tr model={ row.id }>
+          <td class='col-md-1' textContent={ row.id } />
+          <td class='col-md-4'><a>{( row.label )}</a></td>
+          <td class='col-md-1'><a action={ 'remove' }><span class='glyphicon glyphicon-remove' /></a></td>
+          <td class='col-md-6'/>
+        </tr>
       }</$>
     </tbody></table>
     <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
   </div>
-
-  function run() { setState({ data: buildData(1000), selected: null }); }
-
-  function runLots() { setState({ data: buildData(10000), selected: null }); }
-
-  function add() { setState('data', d => [...d, ...buildData(1000)]); }
-
-  function update() { setState('data', { by: 10 }, 'label', l => l + ' !!!'); }
-
-  function swapRows() { setState('data', d => d.length > 998 ? { 1: d[998], 998: d[1] } : d); }
-
-  function clear() { setState({ data: [], selected: null }); }
-
-  function clickRow(e, id, action) {
-    action === 'remove' ?
-      setState('data', d => {
-        const idx = d.findIndex(d => d.id === id);
-        return [...d.slice(0, idx), ...d.slice(idx + 1)];
-      }) : setState('selected', id);
-  }
 }
 
 root(() => document.getElementById("main").appendChild(<App />))

--- a/frameworks/keyed/solid/src/main.jsx
+++ b/frameworks/keyed/solid/src/main.jsx
@@ -1,9 +1,7 @@
-import { State, root, each } from 'solid-js';
+import { useState, root } from 'solid-js';
 import { r, selectWhen } from 'solid-js/dom';
 
-function _random (max) {
-  return Math.round(Math.random() * 1000) % max;
-};
+function _random (max) { return Math.round(Math.random() * 1000) % max; };
 
 let idCounter = 1;
 const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"],
@@ -22,7 +20,7 @@ function buildData(count) {
 }
 
 function App() {
-  const state = new State({ data: [], selected: null });
+  const [ state, setState ] = useState({ data: [], selected: null });
 
   return <div class='container'>
     <div class='jumbotron'><div class='row'>
@@ -48,79 +46,38 @@ function App() {
         </div>
       </div></div>
     </div></div>
-    <table class='table table-hover table-striped test-data'><tbody onClick={ clickRow }>{
-      selectWhen(() => state.selected, 'danger')
-      (each(row =>
-        <tr model={ row.id }>
-          <td class='col-md-1' textContent={ row.id } />
-          <td class='col-md-4'><a>{( row.label )}</a></td>
-          <td class='col-md-1'><a action={ 'remove' }>
-            <span class='glyphicon glyphicon-remove' />
-          </a></td>
-          <td class='col-md-6'/>
-        </tr>
-      )(() => state.data))
-    }</tbody></table>
+    <table class='table table-hover table-striped test-data'><tbody onClick={ clickRow }>
+      <$ each={ state.data } afterRender={ selectWhen(() => state.selected, 'danger') }>{
+        row =>
+          <tr model={ row.id }>
+            <td class='col-md-1' textContent={ row.id } />
+            <td class='col-md-4'><a>{( row.label )}</a></td>
+            <td class='col-md-1'><a action={ 'remove' }><span class='glyphicon glyphicon-remove' /></a></td>
+            <td class='col-md-6'/>
+          </tr>
+      }</$>
+    </tbody></table>
     <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
   </div>
 
+  function run() { setState({ data: buildData(1000), selected: null }); }
+
+  function runLots() { setState({ data: buildData(10000), selected: null }); }
+
+  function add() { setState('data', d => [...d, ...buildData(1000)]); }
+
+  function update() { setState('data', { by: 10 }, 'label', l => l + ' !!!'); }
+
+  function swapRows() { setState('data', d => d.length > 998 ? { 1: d[998], 998: d[1] } : d); }
+
+  function clear() { setState({ data: [], selected: null }); }
+
   function clickRow(e, id, action) {
-    e.stopPropagation();
-    if (action === 'remove') {
-      const data = state.data.slice(0);
-      data.splice(data.findIndex(d => d.id === id), 1)
-      state.set({ data });
-    } else state.set({ selected: id })
-  }
-
-  function run(e) {
-    e.stopPropagation();
-    state.set({
-      data: buildData(1000),
-      selected: null
-    });
-  }
-
-  function runLots(e) {
-    e.stopPropagation();
-    state.set({
-      data: buildData(10000),
-      selected: null
-    });
-  }
-
-  function add(e) {
-    e.stopPropagation();
-    state.set({
-      data: state.data.concat(buildData(1000))
-    });
-  }
-
-  function update(e) {
-    e.stopPropagation();
-    let index = 0;
-    while (index < state.data.length) {
-      state.replace('data', index, 'label', state.data[index].label + ' !!!');
-      index += 10;
-    }
-  }
-
-  function swapRows(e) {
-    e.stopPropagation();
-    if (state.data.length > 998) {
-      state.set('data', {
-        1: state.data[998],
-        998: state.data[1]
-      });
-    }
-  }
-
-  function clear(e) {
-    e.stopPropagation();
-    state.set({
-      data: [],
-      selected: null
-    });
+    action === 'remove' ?
+      setState('data', d => {
+        const idx = d.findIndex(d => d.id === id);
+        return [...d.slice(0, idx), ...d.slice(idx + 1)];
+      }) : setState('selected', id);
   }
 }
 


### PR DESCRIPTION
Please merge this update to the latest version of these libraries.
- Reduced build size
- Centralized reconciliation for all libraries in renderer runtime, (based on Stage-0)
- Added support for JSX Fragments in List reconciliation
- Further reduced and streamlined Solid API
  - Changed to React Hooks inspired API
  - Added a compact Falcor inspired path API to Solid setState
- Removed many mostly useless micro optimizations from implementations that hurt readability/compactness
- Updated MobX implementation to use production mode.

I'm hoping none of this has a negative performance impact, but centralized reconciliation will lend to easier time of optimizing in the future. 