### PR TITLE
Update hyperHTML to 2.25.4

### DIFF
--- a/frameworks/keyed/hyperhtml/package.json
+++ b/frameworks/keyed/hyperhtml/package.json
@@ -12,16 +12,11 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "hyperhtml": "2.13.0"
+    "hyperhtml": "2.25.4"
   },
   "devDependencies": {
-    "babel-core": "6.26.3",
-    "babel-plugin-external-helpers": "6.22.0",
-    "babel-preset-es2016": "6.24.1",
-    "rollup": "0.63.4",
-    "rollup-plugin-babel": "3.0.7",
-    "rollup-plugin-node-resolve": "3.3.0",
-    "rollup-plugin-uglify": "4.0.0",
-    "uglify-es": "3.3.9"
+    "rollup": "^1.1.2",
+    "rollup-plugin-node-resolve": "^4.0.0",
+    "rollup-plugin-terser": "^4.0.4"
   }
 }

--- a/frameworks/keyed/hyperhtml/rollup.config.js
+++ b/frameworks/keyed/hyperhtml/rollup.config.js
@@ -1,31 +1,19 @@
 "use strict";
 
-import * as path from "path";
-import babel from "rollup-plugin-babel";
-import resolve from "rollup-plugin-node-resolve";
-import { uglify } from "rollup-plugin-uglify";
-import { minify } from "uglify-es";
+import resolve from 'rollup-plugin-node-resolve';
+import { terser } from "rollup-plugin-terser";
 
 export default {
-  input: "src/index.js",
-  output: {
-    file: "dist/index.min.js",
-    format: "iife",
-    name: "app"
-  },
+  input: 'src/index.js',
   plugins: [
-    resolve({
-      module: true,
-      jsnext: true,
-      browser: true
-    }),
-    babel({
-      exclude: "node_modules/**",
-      presets: [["es2016"]],
-      plugins: ["external-helpers"],
-      runtimeHelpers: true,
-      babelrc: false
-    }),
-    uglify({}, minify)
-  ]
+    resolve({module: true}),
+    terser()
+  ],
+  context: 'null',
+  moduleContext: 'null',
+  output: {
+    file: 'dist/index.min.js',
+    format: 'iife',
+    name: 'app'
+  }
 };

--- a/frameworks/keyed/hyperhtml/src/index.js
+++ b/frameworks/keyed/hyperhtml/src/index.js
@@ -1,4 +1,4 @@
-import { bind, wire } from "hyperhtml/esm";
+import { bind, wire } from "hyperhtml";
 
 import { startMeasure, stopMeasure } from "./utils";
 import { Store } from "./store";
@@ -121,7 +121,7 @@ function row(state) {
 
 function createRow(state) {
   const row = {
-    render: wire(),
+    render: wire(state),
     class(selected) {
       return state.id === selected ? 'danger' : '';
     },


### PR DESCRIPTION
Not only the current version of _hyperHTML_ is way outdated, I have also noticed that competitors are allowed to use native ES2015 syntax without any transpiled penalization.

Well, I guess it's time to compare keyed _hyperHTML_ for real 😃 