### PR TITLE
Update lighterhtml test

### DIFF
--- a/frameworks/keyed/lighterhtml/src/index.js
+++ b/frameworks/keyed/lighterhtml/src/index.js
@@ -26,6 +26,8 @@ const clear = () => {
   _render();
 };
 const interact = e => {
+  e.stopPropagation();
+  e.preventDefault();
   const interaction = e.target.getAttribute('data-interaction');
   const id = parseInt(
     e.target.parentNode.id || 
@@ -45,10 +47,10 @@ const del = id => {
 };
 const select = id => {
   if (selected > -1) {
-    data[selected] = { ...data[selected], selected: false }
+    data[selected].selected = false;
   }
   selected = data.findIndex(d => d.id === id);
-  data[selected] = { ...data[selected], selected: true }
+  data[selected].selected = true;
   _render();
 };
 const swapRows = () => {
@@ -61,8 +63,7 @@ const swapRows = () => {
 };
 const update = () => {
   for(let i = 0; i < data.length; i += 10) {
-    const item = data[i]
-    data[i] = { ...item, label: item.label + ' !!!' }
+    data[i].label += ' !!!';
   }
   _render();
 };

--- a/frameworks/non-keyed/lighterhtml/src/index.js
+++ b/frameworks/non-keyed/lighterhtml/src/index.js
@@ -26,6 +26,8 @@ const clear = () => {
   _render();
 };
 const interact = e => {
+  e.stopPropagation();
+  e.preventDefault();
   const interaction = e.target.getAttribute('data-interaction');
   const id = parseInt(
     e.target.parentNode.id || 


### PR DESCRIPTION
The following changes has been made:

  * the keyed version of the test shouldn't create new objects each time otherwise the key gets lost for no reason
  * the click event prevents defaults and stops its propagation to grant nothing else is affected while benchmarking