### PR TITLE
Update lighterhtml to 0.8.10

### DIFF
--- a/frameworks/keyed/lighterhtml/package.json
+++ b/frameworks/keyed/lighterhtml/package.json
@@ -24,13 +24,15 @@
   },
   "homepage": "https://github.com/krausest/js-framework-benchmark#readme",
   "dependencies": {
-    "lighterhtml": "0.8.7"
+    "lighterhtml": "0.8.10"
   },
   "devDependencies": {
-    "rollup": "1.1.2",
-    "rollup-plugin-commonjs": "^9.2.0",
-    "rollup-plugin-minify-html-literals": "^1.1.2",
+    "@babel/core": "^7.2.2",
+    "babel-plugin-remove-ungap": "^0.1.1",
+    "rollup": "^1.1.2",
+    "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-node-resolve": "^4.0.0",
-    "rollup-plugin-terser": "4.0.2"
+    "rollup-plugin-replace": "^2.1.0",
+    "rollup-plugin-terser": "^4.0.4"
   }
 }

--- a/frameworks/keyed/lighterhtml/rollup.config.js
+++ b/frameworks/keyed/lighterhtml/rollup.config.js
@@ -1,35 +1,32 @@
+import resolve from 'rollup-plugin-node-resolve';
+import replace from 'rollup-plugin-replace';
+import babel from 'rollup-plugin-babel';
 import { terser } from 'rollup-plugin-terser';
-import minifyHTML from 'rollup-plugin-minify-html-literals';
-import commonjs from 'rollup-plugin-commonjs';
-import nodeResolve from 'rollup-plugin-node-resolve';
 
 export default {
-    input: `src/index.js`,
-    context: 'null', 
-    moduleContext: 'null',
-    output: {
-        file: `dist/index.js`,
-        format: 'iife'
-    },
-    plugins: [
-        nodeResolve({
-            module: true,
-            jsnext: true,
-            main: true
-        }),
-
-        commonjs({
-            include: 'node_modules/**',
-            extensions: ['.js', '.coffee'],
-            ignoreGlobal: false,
-            sourceMap: false
-        }),
-        minifyHTML(),
-        terser({
-            warnings: true,
-            mangle: {
-                module: true
-            }
-        })
-    ]
+  input: 'src/index.js',
+  plugins: [
+    resolve(),
+    replace({
+      'tta.apply(null, arguments)': 'arguments',
+      delimiters: ['', '']
+    }),
+    babel({
+      plugins: [
+        ['remove-ungap', {
+          exclude: [
+            '@ungap/create-content'
+          ]
+        }]
+      ],
+    }),
+    terser()
+  ],
+  context: 'null',
+  moduleContext: 'null',
+  output: {
+    file: 'dist/index.js',
+    format: 'iife',
+    name: 'app'
+  }
 };

--- a/frameworks/non-keyed/lighterhtml/package.json
+++ b/frameworks/non-keyed/lighterhtml/package.json
@@ -24,13 +24,15 @@
   },
   "homepage": "https://github.com/krausest/js-framework-benchmark#readme",
   "dependencies": {
-    "lighterhtml": "0.8.7"
+    "lighterhtml": "0.8.10"
   },
   "devDependencies": {
-    "rollup": "1.1.2",
-    "rollup-plugin-commonjs": "^9.2.0",
-    "rollup-plugin-minify-html-literals": "^1.1.2",
+    "@babel/core": "^7.2.2",
+    "babel-plugin-remove-ungap": "^0.1.1",
+    "rollup": "^1.1.2",
+    "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-node-resolve": "^4.0.0",
-    "rollup-plugin-terser": "4.0.2"
+    "rollup-plugin-replace": "^2.1.0",
+    "rollup-plugin-terser": "^4.0.4"
   }
 }

--- a/frameworks/non-keyed/lighterhtml/rollup.config.js
+++ b/frameworks/non-keyed/lighterhtml/rollup.config.js
@@ -1,35 +1,33 @@
+import resolve from 'rollup-plugin-node-resolve';
+import replace from 'rollup-plugin-replace';
+import babel from 'rollup-plugin-babel';
 import { terser } from 'rollup-plugin-terser';
-import minifyHTML from 'rollup-plugin-minify-html-literals';
-import commonjs from 'rollup-plugin-commonjs';
-import nodeResolve from 'rollup-plugin-node-resolve';
 
 export default {
-    input: `src/index.js`,
-    context: 'null', 
-    moduleContext: 'null',
-    output: {
-        file: `dist/index.js`,
-        format: 'iife'
-    },
-    plugins: [
-        nodeResolve({
-            module: true,
-            jsnext: true,
-            main: true
-        }),
-
-        commonjs({
-            include: 'node_modules/**',
-            extensions: ['.js', '.coffee'],
-            ignoreGlobal: false,
-            sourceMap: false
-        }),
-        minifyHTML(),
-        terser({
-            warnings: true,
-            mangle: {
-                module: true
-            }
-        })
-    ]
+  input: 'src/index.js',
+  plugins: [
+    resolve(),
+    replace({
+      'tta.apply(null, arguments)': 'arguments',
+      delimiters: ['', '']
+    }),
+    babel({
+      plugins: [
+        ['remove-ungap', {
+          exclude: [
+            '@ungap/create-content'
+          ]
+        }]
+      ],
+    }),
+    terser()
+  ],
+  context: 'null',
+  moduleContext: 'null',
+  output: {
+    file: 'dist/index.js',
+    format: 'iife',
+    name: 'app'
+  }
 };
+


### PR DESCRIPTION
First of all, thank you so much for your patience.
I have investigated a bit further possible bottlenecks when it comes to the selection, and the only thing that came up is that addressing `className` instead of dealing with a `class` `Attribute` node might place _lighterhtml_ slightly higher in the table (in terms of faster, so ... moving to the left).

With the promise that I won't change/PR anything else for a little while since there's literally nothing else I could optimize in the current _lighterhtml_ library (it's eventually a core change that would take much longer to land), please consider updating, for the last time, this library.

Thank you! 