### PR TITLE
Update lighterhtml bundle + minifyHTML

### DIFF
--- a/frameworks/keyed/lighterhtml/index.html
+++ b/frameworks/keyed/lighterhtml/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8" />
-<title>lighterhtml-"non-keyed"</title>
+<title>lighterhtml keyed</title>
 <link href="/css/currentStyle.css" rel="stylesheet" />
 <div id="container"></div>
 <script src='dist/index.js'></script>

--- a/frameworks/keyed/lighterhtml/package.json
+++ b/frameworks/keyed/lighterhtml/package.json
@@ -31,6 +31,7 @@
     "babel-plugin-remove-ungap": "^0.1.1",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",
+    "rollup-plugin-minify-html-literals": "^1.1.2",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "^4.0.4"

--- a/frameworks/keyed/lighterhtml/rollup.config.js
+++ b/frameworks/keyed/lighterhtml/rollup.config.js
@@ -1,3 +1,4 @@
+import minifyHTML from 'rollup-plugin-minify-html-literals';
 import resolve from 'rollup-plugin-node-resolve';
 import replace from 'rollup-plugin-replace';
 import babel from 'rollup-plugin-babel';
@@ -6,6 +7,7 @@ import { terser } from 'rollup-plugin-terser';
 export default {
   input: 'src/index.js',
   plugins: [
+    minifyHTML(),
     resolve(),
     replace({
       'tta.apply(null, arguments)': 'arguments',

--- a/frameworks/keyed/lighterhtml/src/index.js
+++ b/frameworks/keyed/lighterhtml/src/index.js
@@ -25,16 +25,12 @@ const clear = () => {
   data = [];
   _render();
 };
-const interact = e => {
-  e.stopPropagation();
-  e.preventDefault();
-  const interaction = e.target.getAttribute('data-interaction');
-  const id = parseInt(
-    e.target.parentNode.id || 
-    e.target.parentNode.parentNode.id ||
-    e.target.parentNode.parentNode.parentNode.id
-  );
-  if (interaction === 'delete') {
+const interact = event => {
+  event.preventDefault();
+  event.stopPropagation();
+  const {target} = event;
+  const id = +target.closest('tr').id;
+  if (target.getAttribute('data-interaction') === 'delete') {
     del(id)
   } else {
     select(id)
@@ -123,7 +119,7 @@ const template = () => html.for(container)`
     </div>
   </div>
   <table onclick=${interact} class="table table-hover table-striped test-data">
-    <tbody>${data.map((item) => html.for(item)`
+    <tbody>${data.map(item => html.for(item)`
       <tr id=${item.id} class=${item.selected ? 'danger' : ''}>
         <td class="col-md-1">${item.id}</td>
         <td data-interaction='select' class="col-md-4">

--- a/frameworks/non-keyed/lighterhtml/index.html
+++ b/frameworks/non-keyed/lighterhtml/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8" />
-<title>lighterhtml-"non-keyed"</title>
+<title>lighterhtml non-keyed</title>
 <link href="/css/currentStyle.css" rel="stylesheet" />
 <div id="container"></div>
 <script src='dist/index.js'></script>

--- a/frameworks/non-keyed/lighterhtml/package.json
+++ b/frameworks/non-keyed/lighterhtml/package.json
@@ -31,6 +31,7 @@
     "babel-plugin-remove-ungap": "^0.1.1",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",
+    "rollup-plugin-minify-html-literals": "^1.1.2",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "^4.0.4"

--- a/frameworks/non-keyed/lighterhtml/rollup.config.js
+++ b/frameworks/non-keyed/lighterhtml/rollup.config.js
@@ -1,3 +1,4 @@
+import minifyHTML from 'rollup-plugin-minify-html-literals';
 import resolve from 'rollup-plugin-node-resolve';
 import replace from 'rollup-plugin-replace';
 import babel from 'rollup-plugin-babel';
@@ -6,6 +7,7 @@ import { terser } from 'rollup-plugin-terser';
 export default {
   input: 'src/index.js',
   plugins: [
+    minifyHTML(),
     resolve(),
     replace({
       'tta.apply(null, arguments)': 'arguments',
@@ -30,4 +32,3 @@ export default {
     name: 'app'
   }
 };
-

--- a/frameworks/non-keyed/lighterhtml/src/index.js
+++ b/frameworks/non-keyed/lighterhtml/src/index.js
@@ -25,16 +25,12 @@ const clear = () => {
   data = [];
   _render();
 };
-const interact = e => {
-  e.stopPropagation();
-  e.preventDefault();
-  const interaction = e.target.getAttribute('data-interaction');
-  const id = parseInt(
-    e.target.parentNode.id || 
-    e.target.parentNode.parentNode.id ||
-    e.target.parentNode.parentNode.parentNode.id
-  );
-  if (interaction === 'delete') {
+const interact = event => {
+  event.preventDefault();
+  event.stopPropagation();
+  const {target} = event;
+  const id = +target.closest('tr').id;
+  if (target.getAttribute('data-interaction') === 'delete') {
     del(id)
   } else {
     select(id)
@@ -47,10 +43,10 @@ const del = id => {
 };
 const select = id => {
   if (selected > -1) {
-    data[selected] = { ...data[selected], selected: false }
+    data[selected] = { ...data[selected], selected: false };
   }
   selected = data.findIndex(d => d.id === id);
-  data[selected] = { ...data[selected], selected: true }
+  data[selected] = { ...data[selected], selected: true };
   _render();
 };
 const swapRows = () => {
@@ -63,8 +59,7 @@ const swapRows = () => {
 };
 const update = () => {
   for(let i = 0; i < data.length; i += 10) {
-    const item = data[i]
-    data[i] = { ...item, label: item.label + ' !!!' }
+    data[i].label += ' !!!';
   }
   _render();
 };
@@ -124,8 +119,8 @@ const template = () => html`
     </div>
   </div>
   <table onclick=${interact} class="table table-hover table-striped test-data">
-    <tbody>${data.map((item, index) => html`
-      <tr data-i="${index}" id=${item.id} class=${item.selected ? 'danger' : ''}>
+    <tbody>${data.map(item => html`
+      <tr id=${item.id} class=${item.selected ? 'danger' : ''}>
         <td class="col-md-1">${item.id}</td>
         <td data-interaction='select' class="col-md-4">
           <a data-interaction='select'>${item.label}</a>


### PR DESCRIPTION
Turns out that minifying HTML is somehow key to score better at this benchmark.

I know I've promised I wouldn't have changed the library, and indeed I just changed the rollup config.

At this point there's really nothing else I can do, except eventually find out slow paths and improve, but for now I just want a fair comparison with the major competitor.

Thanks again for your patience.

<img width="237" alt="screen shot 2019-02-09 at 12 42 44" src="https://user-images.githubusercontent.com/85749/52520303-6426dc00-2c68-11e9-8d4e-3ca8901116d2.png">
