### PR TITLE
Simplify lit-html benchmark code (without direct DOM manipulation)

### DIFF
--- a/frameworks/keyed/lit-html/src/index.js
+++ b/frameworks/keyed/lit-html/src/index.js
@@ -30,47 +30,47 @@ const clear = () => {
 const interact = e => {
   const interaction = e.target.getAttribute('data-interaction');
   const id = parseInt(
-    e.target.parentNode.id || 
+    e.target.parentNode.id ||
     e.target.parentNode.parentNode.id ||
     e.target.parentNode.parentNode.parentNode.id
   );
   if (interaction === 'delete') {
-    del(id)
+    del(id);
   } else {
-    select(id)
+    select(id);
   }
 };
 const del = id => {
   const idx = data.findIndex(d => d.id === id);
-  data.splice(idx, 1)
+  data.splice(idx, 1);
   _render();
 };
 const select = id => {
   if (selected > -1) {
-    data[selected] = { ...data[selected], selected: false }
+    data[selected] = { ...data[selected], selected: false };
   }
   selected = data.findIndex(d => d.id === id);
-  data[selected] = { ...data[selected], selected: true }
+  data[selected] = { ...data[selected], selected: true };
   _render();
 };
 const swapRows = () => {
   if (data.length > 998) {
-    const tmp = data[1]
-    data[1] = data[998]
-    data[998] = tmp
+    const tmp = data[1];
+    data[1] = data[998];
+    data[998] = tmp;
   }
   _render();
 };
 const update = () => {
-  for(let i = 0; i < data.length; i += 10) {
-    const item = data[i]
-    data[i] = { ...item, label: item.label + ' !!!' }
+  for (let i = 0; i < data.length; i += 10) {
+    const item = data[i];
+    data[i] = { ...item, label: item.label + ' !!!' };
   }
   _render();
 };
 const buildData = count => {
   const data = [];
-  for (var i = 0; i < count; i++) {
+  for (let i = 0; i < count; i++) {
     data.push({
       id: did++,
       label: `${adjectives[_random(adjectives.length)]} ${colours[_random(colours.length)]} ${nouns[_random(nouns.length)]}`,

--- a/frameworks/keyed/lit-html/src/index.js
+++ b/frameworks/keyed/lit-html/src/index.js
@@ -1,6 +1,5 @@
 import { html, render } from '../node_modules/lit-html/lit-html.js';
 import { repeat } from '../node_modules/lit-html/directives/repeat.js';
-import { guard } from '../node_modules/lit-html/directives/guard.js';
 
 const adjectives = [
   'pretty', 'large', 'big', 'small', 'tall', 'short', 'long', 'handsome', 'plain', 'quaint', 'clean', 'elegant', 'easy', 'angry', 'crazy', 'helpful', 'mushy', 'odd', 'unsightly', 'adorable', 'important', 'inexpensive', 'cheap', 'expensive', 'fancy'];
@@ -47,10 +46,10 @@ const del = id => {
 };
 const select = id => {
   if (selected > -1) {
-    data[selected] = { ...data[selected], selected: false };
+    data[selected].selected = false;
   }
   selected = data.findIndex(d => d.id === id);
-  data[selected] = { ...data[selected], selected: true };
+  data[selected].selected = true;
   _render();
 };
 const swapRows = () => {
@@ -64,7 +63,7 @@ const swapRows = () => {
 const update = () => {
   for (let i = 0; i < data.length; i += 10) {
     const item = data[i];
-    data[i] = { ...item, label: item.label + ' !!!' };
+    data[i].label += ' !!!';
   }
   _render();
 };
@@ -126,7 +125,7 @@ const template = () => html`
   <table @click=${interact} class="table table-hover table-striped test-data">
     <tbody>${repeat(data,
       item => item.id,
-      item => guard(item, () => html`
+      item => html`
       <tr id=${item.id} class=${item.selected ? 'danger' : ''}>
         <td class="col-md-1">${item.id}</td>
         <td data-interaction='select' class="col-md-4">
@@ -138,8 +137,7 @@ const template = () => html`
           </a>
         </td>
         <td class="col-md-6"></td>
-      </tr>`)
-    )}
+      </tr>`)}
     </tbody>
   </table>
   <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>

--- a/frameworks/keyed/lit-html/src/index.js
+++ b/frameworks/keyed/lit-html/src/index.js
@@ -27,12 +27,9 @@ const clear = () => {
   _render();
 };
 const interact = e => {
-  const interaction = e.target.getAttribute('data-interaction');
-  const id = parseInt(
-    e.target.parentNode.id ||
-    e.target.parentNode.parentNode.id ||
-    e.target.parentNode.parentNode.parentNode.id
-  );
+  const td = e.target.closest('td');
+  const interaction = td.getAttribute('data-interaction');
+  const id = parseInt(td.parentNode.id);
   if (interaction === 'delete') {
     del(id);
   } else {
@@ -128,12 +125,12 @@ const template = () => html`
       item => html`
       <tr id=${item.id} class=${item.selected ? 'danger' : ''}>
         <td class="col-md-1">${item.id}</td>
-        <td data-interaction='select' class="col-md-4">
-          <a data-interaction='select'>${item.label}</a>
+        <td class="col-md-4">
+          <a>${item.label}</a>
         </td>
         <td data-interaction='delete' class="col-md-1">
-          <a data-interaction='delete'>
-            <span data-interaction='delete' class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+          <a>
+            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
           </a>
         </td>
         <td class="col-md-6"></td>

--- a/frameworks/non-keyed/lit-html/src/index.js
+++ b/frameworks/non-keyed/lit-html/src/index.js
@@ -34,36 +34,36 @@ const interact = e => {
     e.target.parentNode.parentNode.parentNode.id
   );
   if (interaction === 'delete') {
-    del(id)
+    del(id);
   } else {
-    select(id)
+    select(id);
   }
 };
 const del = id => {
   const idx = data.findIndex(d => d.id === id);
-  data.splice(idx, 1)
+  data.splice(idx, 1);
   _render();
 };
 const select = id => {
   if (selected > -1) {
-    data[selected] = { ...data[selected], selected: false }
+    data[selected] = { ...data[selected], selected: false };
   }
   selected = data.findIndex(d => d.id === id);
-  data[selected] = { ...data[selected], selected: true }
+  data[selected] = { ...data[selected], selected: true };
   _render();
 };
 const swapRows = () => {
   if (data.length > 998) {
-    const tmp = data[1]
-    data[1] = data[998]
-    data[998] = tmp
+    const tmp = data[1];
+    data[1] = data[998];
+    data[998] = tmp;
   }
   _render();
 };
 const update = () => {
-  for(let i = 0; i < data.length; i += 10) {
-    const item = data[i]
-    data[i] = { ...item, label: item.label + ' !!!' }
+  for (let i = 0; i < data.length; i += 10) {
+    const item = data[i];
+    data[i] = { ...item, label: item.label + ' !!!' };
   }
   _render();
 };

--- a/frameworks/non-keyed/lit-html/src/index.js
+++ b/frameworks/non-keyed/lit-html/src/index.js
@@ -1,5 +1,4 @@
 import { html, render } from '../node_modules/lit-html/lit-html.js';
-import { guard } from '../node_modules/lit-html/directives/guard.js';
 
 const adjectives = [
   'pretty', 'large', 'big', 'small', 'tall', 'short', 'long', 'handsome', 'plain', 'quaint', 'clean', 'elegant', 'easy', 'angry', 'crazy', 'helpful', 'mushy', 'odd', 'unsightly', 'adorable', 'important', 'inexpensive', 'cheap', 'expensive', 'fancy'];
@@ -46,10 +45,10 @@ const del = id => {
 };
 const select = id => {
   if (selected > -1) {
-    data[selected] = { ...data[selected], selected: false };
+    data[selected].selected = false;
   }
   selected = data.findIndex(d => d.id === id);
-  data[selected] = { ...data[selected], selected: true };
+  data[selected].selected = true;
   _render();
 };
 const swapRows = () => {
@@ -63,7 +62,7 @@ const swapRows = () => {
 const update = () => {
   for (let i = 0; i < data.length; i += 10) {
     const item = data[i];
-    data[i] = { ...item, label: item.label + ' !!!' };
+    data[i].label += ' !!!';
   }
   _render();
 };
@@ -123,7 +122,7 @@ const template = () => html`
     </div>
   </div>
   <table @click=${interact} class="table table-hover table-striped test-data">
-    <tbody>${data.map(item => guard(item, () => html`
+    <tbody>${data.map(item => html`
       <tr id=${item.id} class=${item.selected ? 'danger' : ''}>
         <td class="col-md-1">${item.id}</td>
         <td data-interaction='select' class="col-md-4">
@@ -135,8 +134,7 @@ const template = () => html`
           </a>
         </td>
         <td class="col-md-6"></td>
-      </tr>`)
-    )}
+      </tr>`)}
     </tbody>
   </table>
   <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>

--- a/frameworks/non-keyed/lit-html/src/index.js
+++ b/frameworks/non-keyed/lit-html/src/index.js
@@ -26,12 +26,9 @@ const clear = () => {
   _render();
 };
 const interact = e => {
-  const interaction = e.target.getAttribute('data-interaction');
-  const id = parseInt(
-    e.target.parentNode.id || 
-    e.target.parentNode.parentNode.id ||
-    e.target.parentNode.parentNode.parentNode.id
-  );
+  const td = e.target.closest('td');
+  const interaction = td.getAttribute('data-interaction');
+  const id = parseInt(td.parentNode.id);
   if (interaction === 'delete') {
     del(id);
   } else {
@@ -125,12 +122,12 @@ const template = () => html`
     <tbody>${data.map(item => html`
       <tr id=${item.id} class=${item.selected ? 'danger' : ''}>
         <td class="col-md-1">${item.id}</td>
-        <td data-interaction='select' class="col-md-4">
-          <a data-interaction='select'>${item.label}</a>
+        <td class="col-md-4">
+          <a>${item.label}</a>
         </td>
         <td data-interaction='delete' class="col-md-1">
-          <a data-interaction='delete'>
-            <span data-interaction='delete' class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+          <a>
+            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
           </a>
         </td>
         <td class="col-md-6"></td>


### PR DESCRIPTION
This is the same as PR https://github.com/krausest/js-framework-benchmark/pull/521, but without the controversial change involving directly setting a class on the table row.

A few simplifications to the lit-html benchmark implementations:

* Minor style updates (semicolons etc.).
* Update `select` and `label` properties in-place and remove `guard` directive, instead of creating new row objects every time.
* Remove some unnecessary attributes and use `closest()` to find the action and row id.
* <strike>Directly update row class on select instead of forcing an unnecessary render.</strike>

cc @justinfagnani @rictic @CaptainCodeman