### PR TITLE
Add ReasonReact implementation

### DIFF
--- a/frameworks/keyed/reason-react/.gitignore
+++ b/frameworks/keyed/reason-react/.gitignore
@@ -1,0 +1,3 @@
+lib
+**/*.bs.js
+.merlin

--- a/frameworks/keyed/reason-react/bsconfig.json
+++ b/frameworks/keyed/reason-react/bsconfig.json
@@ -1,0 +1,23 @@
+/* This is the BuckleScript configuration file. Note that this is a comment;
+  BuckleScript comes with a JSON parser that supports comments and trailing
+  comma. If this screws with your editor highlighting, please tell us by filing
+  an issue! */
+{
+  "name": "js-framework-reason-react",
+  "reason": {
+    "react-jsx": 2
+  },
+  "sources": {
+    "dir" : "src/"
+  },
+  "package-specs": [{
+    "module": "commonjs",
+    "in-source": true
+  }],
+  "suffix": ".bs.js",
+  "namespace": true,
+  "bs-dependencies": [
+    "reason-react"
+  ],
+  "refmt": 3
+}

--- a/frameworks/keyed/reason-react/index.html
+++ b/frameworks/keyed/reason-react/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>ReasonReact</title>
+  <link href="/css/currentStyle.css" rel="stylesheet"/>
+</head>
+<body>
+  <div id='main'></div>
+  <script src="dist/main.js"></script>
+</body>
+</html>

--- a/frameworks/keyed/reason-react/package.json
+++ b/frameworks/keyed/reason-react/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "js-framework-benchmark-reason-react",
+  "version": "1.0.0",
+  "description": "ReasonReact benchmark",
+  "main": "index.js",
+  "js-framework-benchmark": {
+    "frameworkVersionFromPackage": "reason-react"
+  },
+  "scripts": {
+    "build-dev": "webpack --watch",
+    "prebuild-prod": "bsb -clean -make-world",
+    "build-prod": "webpack",
+    "clean": "bsb -clean-world"
+  },
+  "keywords": [
+    "react",
+    "webpack",
+    "ReasonML"
+  ],
+  "author": "Michael Boulton",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "devDependencies": {
+    "bs-platform": "4.0.18",
+    "@babel/core": "7.2.2",
+    "@babel/preset-env": "7.3.1",
+    "@babel/preset-react": "7.0.0",
+    "@babel/plugin-proposal-class-properties": "7.3.0",
+    "babel-loader": "8.0.5",
+    "terser-webpack-plugin": "1.2.2",
+    "webpack": "4.29.2",
+    "webpack-cli": "3.2.3"
+  },
+  "dependencies": {
+    "react": "16.8.1",
+    "react-dom": "16.8.1",
+    "reason-react": "0.5.3"
+  }
+}

--- a/frameworks/keyed/reason-react/src/Button.re
+++ b/frameworks/keyed/reason-react/src/Button.re
@@ -1,0 +1,11 @@
+let component = ReasonReact.statelessComponent("Button");
+
+let make = (~id, ~title, ~cb, _children) => {
+  ...component,
+  render: _self =>
+    <div className="col-sm-6 smallpad">
+      <button type_="button" className="btn btn-primary btn-block" id onClick=cb>
+        {title |> ReasonReact.string}
+      </button>
+    </div>,
+};

--- a/frameworks/keyed/reason-react/src/Index.re
+++ b/frameworks/keyed/reason-react/src/Index.re
@@ -1,0 +1,2 @@
+
+ReactDOMRe.renderToElementWithId(<Main />, "main");

--- a/frameworks/keyed/reason-react/src/Jumbotron.re
+++ b/frameworks/keyed/reason-react/src/Jumbotron.re
@@ -1,0 +1,26 @@
+let component = ReasonReact.statelessComponent("Jumbotron");
+
+let make = (~run, ~runLots, ~add, ~update, ~clear, ~swapRows, _children) => {
+  ...component,
+  render: _self => {
+    let hdr = ReasonReact.string("React keyed");
+
+    <div className="jumbotron">
+      <div className="row">
+        <div className="col-md-6"> <h1> hdr </h1> </div>
+        <div className="col-md-6">
+          <div className="row">
+            <Button id="run" title="Create 1,000 rows" cb=run />
+            <Button id="runlots" title="Create 10,000 rows" cb=runLots />
+            <Button id="add" title="Append 1,000 rows" cb=add />
+            <Button id="update" title="Update every 10th row" cb=update />
+            <Button id="clear" title="Clear" cb=clear />
+            <Button id="swaprows" title="Swap Rows" cb=swapRows />
+          </div>
+        </div>
+      </div>
+    </div>;
+  },
+
+  shouldUpdate: (_s) => false
+};

--- a/frameworks/keyed/reason-react/src/Main.re
+++ b/frameworks/keyed/reason-react/src/Main.re
@@ -1,0 +1,128 @@
+type main_state_t = {
+  data: array(Util.item),
+  selected: option(Util.item),
+};
+
+type main_actions_t =
+  | RUN
+  | RUNLOTS
+  | ADD
+  | UPDATEEVERYTENTH
+  | SELECT(Util.item)
+  | REMOVE(Util.item)
+  | CLEAR
+  | SWAPROWS;
+
+let component = ReasonReact.reducerComponent("Main");
+
+let exclaim = (idx, d: Util.item) =>
+  if (0 == idx mod 10) {
+    {...d, label: d.label ++ " !!!"};
+  } else {
+    d;
+  };
+
+/*
+ let exclaim_inplace = (arr: array(Util.item)) => {
+   let impl = (idx, d: Util.item) =>
+     if (0 == idx mod 10) {
+       arr[idx] = {...d, label: d.label ++ " !!!"};
+     };
+   impl;
+ };
+ */
+
+let make = _children => {
+  ...component,
+
+  initialState: () => {data: [||], selected: None},
+
+  reducer: (action: main_actions_t, state: main_state_t) =>
+    switch (action) {
+    | RUN => ReasonReact.Update({...state, data: Util.build_data(1000)})
+
+    | RUNLOTS => ReasonReact.Update({...state, data: Util.build_data(10000)})
+
+    | ADD =>
+      ReasonReact.Update({
+        ...state,
+        data: Belt.Array.concat(state.data, Util.build_data(1000)),
+      })
+
+    | UPDATEEVERYTENTH =>
+      /*
+       Array.iteri(exclaim_inplace(state.data), state.data);
+       ReasonReact.Update(state);
+       */
+      ReasonReact.Update({...state, data: Array.mapi(exclaim, state.data)})
+
+    | SELECT(i) => ReasonReact.Update({...state, selected: Some(i)})
+
+    | REMOVE(i) =>
+      let isnt_item = c => !(i === c);
+      switch (state.selected) {
+      | Some(n) when n === i =>
+        ReasonReact.Update({
+          selected: None,
+          data: Js.Array.filter(isnt_item, state.data),
+        })
+      | _ =>
+        ReasonReact.Update({
+          ...state,
+          data: Js.Array.filter(isnt_item, state.data),
+        })
+      };
+
+    | CLEAR => ReasonReact.Update({data: [||], selected: None})
+
+    | SWAPROWS =>
+      if (Array.length(state.data) > 998) {
+        let elem_1 = state.data[1];
+        let elem_2 = state.data[998];
+        state.data[1] = elem_2;
+        state.data[998] = elem_1;
+        ReasonReact.Update(state);
+      } else {
+        ReasonReact.NoUpdate;
+      }
+    },
+
+  render: self => {
+    let sender = (message, _event) => self.send(message);
+    let is_selected =
+      switch (self.state.selected) {
+      | None => (_i => false)
+      | Some(n) => ((i: Util.item) => i === n)
+      };
+
+    <div className="container">
+      <Jumbotron
+        run={sender(RUN)}
+        runLots={sender(RUNLOTS)}
+        add={sender(ADD)}
+        update={sender(UPDATEEVERYTENTH)}
+        clear={sender(CLEAR)}
+        swapRows={sender(SWAPROWS)}
+      />
+      <table className="table table-hover table-striped test-data">
+        <tbody>
+          ...{Array.map(
+            (item: Util.item) =>
+              <Row
+                key={item.id |> string_of_int}
+                item
+                selected={is_selected(item)}
+                onSelect={sender(SELECT(item))}
+                onRemove={sender(REMOVE(item))}
+              />,
+            self.state.data,
+          )}
+        </tbody>
+      </table>
+      <span
+        className="preloadicon glyphicon glyphicon-remove"
+        ariaHidden=true
+      />
+    </div>;
+  },
+};

--- a/frameworks/keyed/reason-react/src/Row.re
+++ b/frameworks/keyed/reason-react/src/Row.re
@@ -1,0 +1,41 @@
+type retained_props_t = {
+  item: Util.item,
+  selected: bool,
+};
+
+type actions_t =
+  | SELECT_CHANGE;
+
+let component = ReasonReact.reducerComponent("Row");
+
+let glyph_icon =
+  <span className="glyphicon glyphicon-remove" ariaHidden=true />;
+
+let make = (~onSelect, ~onRemove, ~selected, ~item: Util.item, _children) => {
+  ...component,
+  initialState: () => {item, selected: false},
+
+  reducer: (_action: actions_t, state: retained_props_t) => {
+    ReasonReact.Update({...state, selected: !state.selected});
+  },
+
+  render: self => {
+    if (selected != self.state.selected) {
+      self.send(SELECT_CHANGE);
+    };
+
+    <tr className={selected ? "danger" : ""}>
+      <td className="col-md-1">
+        {item.id |> string_of_int |> ReasonReact.string}
+      </td>
+      <td className="col-md-4">
+        <a onClick=onSelect> {item.label |> ReasonReact.string} </a>
+      </td>
+      <td className="col-md-1"> <a onClick=onRemove> glyph_icon </a> </td>
+      <td className="col-md-6" />
+    </tr>;
+  },
+
+  shouldUpdate: ({oldSelf}) =>
+    oldSelf.state.selected !== selected || oldSelf.state.item !== item,
+};

--- a/frameworks/keyed/reason-react/src/Util.re
+++ b/frameworks/keyed/reason-react/src/Util.re
@@ -1,0 +1,85 @@
+let random = max => Random.int(max);
+
+let adjectives = [|
+  "pretty",
+  "large",
+  "big",
+  "small",
+  "tall",
+  "short",
+  "long",
+  "handsome",
+  "plain",
+  "quaint",
+  "clean",
+  "elegant",
+  "easy",
+  "angry",
+  "crazy",
+  "helpful",
+  "mushy",
+  "odd",
+  "unsightly",
+  "adorable",
+  "important",
+  "inexpensive",
+  "cheap",
+  "expensive",
+  "fancy",
+|];
+let colours = [|
+  "red",
+  "yellow",
+  "blue",
+  "green",
+  "pink",
+  "brown",
+  "purple",
+  "brown",
+  "white",
+  "black",
+  "orange",
+|];
+let names = [|
+  "table",
+  "chair",
+  "house",
+  "bbq",
+  "desk",
+  "car",
+  "pony",
+  "cookie",
+  "sandwich",
+  "burger",
+  "pizza",
+  "mouse",
+  "keyboard",
+|];
+
+type item = {
+  id: int,
+  label: string,
+};
+
+let build_data_impl = () => {
+  let state = ref(1);
+
+  let impl = count => {
+    let makeitem = n => {
+      id: n + state^,
+      label:
+        adjectives[random(Array.length(adjectives))]
+        ++ " "
+        ++ colours[random(Array.length(colours))]
+        ++ " "
+        ++ names[random(Array.length(names))],
+    };
+    let generated = Belt.Array.makeBy(count, makeitem);
+    state := state^ + count;
+    generated;
+  };
+
+  impl;
+};
+
+let build_data = build_data_impl();

--- a/frameworks/keyed/reason-react/webpack.config.js
+++ b/frameworks/keyed/reason-react/webpack.config.js
@@ -1,0 +1,78 @@
+const path = require('path');
+const webpack = require('webpack');
+const TerserPlugin = require('terser-webpack-plugin');
+
+module.exports = {
+	mode: 'production',
+	// mode: 'development',
+	entry: {
+		main: path.join(__dirname, 'src', 'Index.bs.js'),
+	},
+	output: {
+		path: path.join(__dirname, 'dist'),
+		filename: '[name].js'
+	},
+	resolve: {
+		extensions: ['.js', '.jsx']
+	},
+	module: {
+		rules: [{
+			test: /\.jsx?$/,
+			exclude: /node_modules/,
+			use: [
+				{
+					loader: 'babel-loader',
+					options: {
+						presets: ['@babel/preset-env', '@babel/preset-react'],
+						plugins: ['@babel/plugin-proposal-class-properties'],
+					}
+				}
+			]
+		}]
+	},
+	optimization: {
+		minimizer: [
+			new TerserPlugin({
+				terserOptions: {
+					parse: {
+						// we want terser to parse ecma 8 code. However, we don't want it
+						// to apply any minfication steps that turns valid ecma 5 code
+						// into invalid ecma 5 code. This is why the 'compress' and 'output'
+						// sections only apply transformations that are ecma 5 safe
+						// https://github.com/facebook/create-react-app/pull/4234
+						ecma: 8,
+					},
+					compress: {
+						ecma: 5,
+						warnings: false,
+						// Disabled because of an issue with Uglify breaking seemingly valid code:
+						// https://github.com/facebook/create-react-app/issues/2376
+						// Pending further investigation:
+						// https://github.com/mishoo/UglifyJS2/issues/2011
+						comparisons: false,
+					},
+					mangle: {
+						safari10: true,
+					},
+					output: {
+						ecma: 5,
+						comments: false,
+						// Turned on because emoji and regex is not minified properly using default
+						// https://github.com/facebook/create-react-app/issues/2488
+						ascii_only: true,
+					},
+				},
+				// Use multi-process parallel running to improve the build speed
+				// Default number of concurrent runs: os.cpus().length - 1
+				parallel: true,
+				// Enable file caching
+				cache: true,
+			}),
+		]
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			'process.env': { NODE_ENV: JSON.stringify('production') }
+		}),
+	],
+};


### PR DESCRIPTION
This is a (mostly) idiomatic implementation in ReasonML using ReasonReact.

- It uses the `option` type for seeing if a row is selected rather than just having 0 be a magic number for 'nothing selected', or just never resetting it if a row gets deleted like most other implementations
- I did implement the "update every 10th row" using an inplace method but it felt like a bit of a hack so I've left it in there but commented out.
- The `Row` component had to be a `reducerComponent` even though it is pretty much stateless - this is so that it can properly use `shouldUpdate` rather than rerendering all the time

The JSX (and the webpack config) is pretty much just copied from the various react implementations and changed to fit with the Reason syntax. Performance seems to be roughly the same as react-redux, which is about what you would expect.