### PR TITLE
Fix performance regression in Solid, MobX JSX, and Knockout JSX

### DIFF
--- a/frameworks/keyed/ko-jsx/package.json
+++ b/frameworks/keyed/ko-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-ko-jsx",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "main": "index.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "ko-jsx"
@@ -17,16 +17,16 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.8.0",
+    "babel-plugin-jsx-dom-expressions": "0.8.2",
     "knockout": "3.5.0",
-    "ko-jsx": "0.6.2"
+    "ko-jsx": "0.6.3"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",
-    "rollup": "1.11.3",
+    "rollup": "1.12.1",
     "rollup-plugin-babel": "4.3.2",
     "rollup-plugin-commonjs": "9.2.0",
-    "rollup-plugin-node-resolve": "4.2.3",
+    "rollup-plugin-node-resolve": "5.0.0",
     "rollup-plugin-terser": "4.0.4"
   }
 }

--- a/frameworks/keyed/mobx-jsx/package.json
+++ b/frameworks/keyed/mobx-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-mobx-jsx",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "mobx-jsx"
@@ -17,15 +17,15 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.8.0",
+    "babel-plugin-jsx-dom-expressions": "0.8.2",
     "mobx": "5.9.4",
-    "mobx-jsx": "0.4.1"
+    "mobx-jsx": "0.4.2"
   },
   "devDependencies": {
     "@babel/core": "7.3.3",
-    "rollup": "1.11.3",
+    "rollup": "1.12.1",
     "rollup-plugin-babel": "4.3.2",
-    "rollup-plugin-node-resolve": "4.2.3",
+    "rollup-plugin-node-resolve": "5.0.0",
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "4.0.4"
   }

--- a/frameworks/keyed/solid/package.json
+++ b/frameworks/keyed/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-solid",
-  "version": "0.6.2",
+  "version": "0.6.4",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "solid-js"
@@ -17,14 +17,14 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.8.0",
-    "solid-js": "0.6.2"
+    "babel-plugin-jsx-dom-expressions": "0.8.2",
+    "solid-js": "0.6.4"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",
-    "rollup": "1.11.3",
+    "rollup": "1.12.1",
     "rollup-plugin-babel": "4.3.2",
-    "rollup-plugin-node-resolve": "4.2.3",
+    "rollup-plugin-node-resolve": "5.0.0",
     "rollup-plugin-terser": "4.0.4"
   }
 }


### PR DESCRIPTION
I believe I've found the culprit to the issue found in #559 . A too strict null check lead to unoptimized clear all path for all 3 libraries. This pull requests updates the libraries to version with the fix.