### PR TITLE
Add sinuous-v0.6.0-keyed

### DIFF
--- a/frameworks/keyed/sinuous/.eslintrc.yml
+++ b/frameworks/keyed/sinuous/.eslintrc.yml
@@ -1,0 +1,21 @@
+env:
+  browser: true
+  es6: true
+
+extends:
+  - eslint:recommended
+
+parser: babel-eslint
+
+parserOptions:
+  ecmaVersion: 9
+  sourceType: module
+
+globals:
+  html: readonly
+
+rules:
+  semi: error
+  no-unused-vars:
+    - error
+    - varsIgnorePattern: ^h$

--- a/frameworks/keyed/sinuous/index.html
+++ b/frameworks/keyed/sinuous/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>Sinuous-keyed</title>
+    <link href="/css/currentStyle.css" rel="stylesheet"/>
+</head>
+<body>
+<div id='main'></div>
+<script src='dist/main.js'></script>
+</body>
+</html>

--- a/frameworks/keyed/sinuous/package.json
+++ b/frameworks/keyed/sinuous/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "js-framework-benchmark-sinuous",
+  "version": "0.0.1",
+  "main": "dist/main.js",
+  "js-framework-benchmark": {
+    "frameworkVersionFromPackage": "sinuous"
+  },
+  "scripts": {
+    "build-dev": "rollup -c -w",
+    "build-prod": "rollup -c --environment production"
+  },
+  "author": "Wesley Luyten",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "dependencies": {
+    "htm": "2.1.1",
+    "sinuous": "0.6.0"
+  },
+  "devDependencies": {
+    "@babel/core": "7.4.4",
+    "babel-eslint": "^10.0.1",
+    "babel-plugin-htm": "^2.1.0",
+    "eslint": "^5.16.0",
+    "rollup": "1.11.3",
+    "rollup-plugin-babel": "4.3.2",
+    "rollup-plugin-node-resolve": "4.2.3",
+    "rollup-plugin-terser": "4.0.4"
+  }
+}

--- a/frameworks/keyed/sinuous/rollup.config.js
+++ b/frameworks/keyed/sinuous/rollup.config.js
@@ -1,0 +1,24 @@
+import resolve from 'rollup-plugin-node-resolve';
+import babel from 'rollup-plugin-babel';
+import { terser } from 'rollup-plugin-terser';
+
+const plugins = [
+	babel({
+		exclude: 'node_modules/**',
+		plugins: [['htm']]
+  }),
+	resolve()
+];
+
+if (process.env.production) {
+	plugins.push(terser());
+}
+
+export default {
+	input: 'src/main.js',
+	output: {
+		file: 'dist/main.js',
+		format: 'iife'
+	},
+	plugins
+};

--- a/frameworks/keyed/sinuous/src/main.js
+++ b/frameworks/keyed/sinuous/src/main.js
@@ -1,0 +1,106 @@
+import o, { subscribe, root, sample } from 'sinuous/observable';
+import each from 'sinuous/each';
+import sinuous from 'sinuous';
+const h = sinuous({ subscribe, root, sample });
+
+let idCounter = 1;
+const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"],
+	colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"],
+	nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+
+function _random (max) { return Math.round(Math.random() * 1000) % max; }
+
+function buildData(count) {
+	let data = new Array(count);
+	for (let i = 0; i < count; i++) {
+		data[i] = {
+			id: idCounter++,
+			label: o(`${adjectives[_random(adjectives.length)]} ${colours[_random(colours.length)]} ${nouns[_random(nouns.length)]}`)
+		};
+	}
+	return data;
+}
+
+function getParentData(node, name) {
+	do {
+		if (node.dataset[name]) return node.dataset[name];
+	} while ((node = node.parentNode));
+}
+
+const Button = ({ id, text, fn }) => html`
+	<div class="col-sm-6 smallpad">
+		<button id="${ id }" class="btn btn-primary btn-block" type=button onclick=${() => fn}>
+			${ text }
+		</button>
+	</div>`;
+
+const App = () => {
+	const data = o([]);
+	const selected = o();
+	const run = () => data(buildData(1000)) && selected(null);
+	const runLots = () => data(buildData(10000)) && selected(null);
+	const add = () => data(data().concat(buildData(1000)));
+	const update = () => {
+		const d = data();
+		for (let i = 0; i < d.length; i += 10) {
+			d[i].label(d[i].label() + ' !!!');
+		}
+	};
+	const swapRows = () => {
+		const d = data();
+		if (d.length > 998) {
+			const tmp = d[1];
+			d[1] = d[998];
+			d[998] = tmp;
+			data(d);
+		}
+	};
+	const clear = () => data([]) && selected(null);
+	const removeOrSelect = (e) => e.target.matches('.remove') ? remove(e) : select(e);
+	const select = (e) => selected(getParentData(e.target, 'id'));
+	subscribe((tr) => {
+		const id = selected();
+		if (tr) tr.className = '';
+		if (id && (tr = document.querySelector(`tr[data-id="${id}"]`))) {
+			tr.className = 'danger';
+		}
+		return tr;
+	});
+	const remove = (e) => {
+		const d = data();
+		const idx = d.findIndex(d => d.id == getParentData(e.target, 'id'));
+		d.splice(idx, 1);
+		data(d);
+	};
+
+	return html`<div class=container>
+		<div class=jumbotron><div class=row>
+			<div class=col-md-6><h1>Sinuous Keyed</h1></div>
+			<div class=col-md-6><div class=row>
+				<${Button} id=run text="Create 1,000 rows" fn=${ run } />
+				<${Button} id=runlots text="Create 10,000 rows" fn=${ runLots } />
+				<${Button} id=add text="Append 1,000 rows" fn=${ add } />
+				<${Button} id=update text="Update every 10th row" fn=${ update } />
+				<${Button} id=clear text=Clear fn=${ clear } />
+				<${Button} id=swaprows text="Swap Rows" fn=${ swapRows } />
+			</div></div>
+		</div></div>
+		<table class="table table-hover table-striped test-data">
+			<tbody onclick=${() => removeOrSelect}>
+				${each(data, (row) => html`
+					<tr data-id="${ row.id }">
+						<td class=col-md-1 textContent=${ row.id } />
+						<td class=col-md-4><a>${ row.label }</a></td>
+						<td class=col-md-1><a>
+							<span class="glyphicon glyphicon-remove remove" />
+						</a></td>
+						<td class=col-md-6 />
+					</tr>
+				`)}
+			</tbody>
+		</table>
+		<span class="preloadicon glyphicon glyphicon-remove" aria-hidden=true />
+	</div>`;
+};
+
+document.getElementById('main').appendChild(App());


### PR DESCRIPTION
Adds [Sinuous](https://github.com/luwes/sinuous/) v0.6.0.

Thanks to @ryansolid, @adamhaile and @Freak613 for crucial code in this lib,  
also @developit and @jviide for [htm](https://github.com/developit/htm)!

The idea was to 

- keep the original [hyperscript](https://github.com/hyperhype/hyperscript) idea alive 
- with a better [observable](https://github.com/luwes/sinuous/tree/master/packages/sinuous/observable) API 
- favor template literal over JSX
- no "precompilation", `h` tag is the lowest it can get
- keep bundle size small for lightweight components
A minimal Sinuous app without a list is `< 2kB` gzip
- developer experience++, less library specialized concepts, plain JS feel

Results:

<img width="224" alt="Screen Shot 2019-05-21 at 10 46 30 AM" src="https://user-images.githubusercontent.com/360826/58107829-aab99a00-7bb8-11e9-9fc2-410bf3758f62.png">
