### PR TITLE
[redom] avoid unnecessary classlist updates

### DIFF
--- a/frameworks/keyed/redom/src/app.js
+++ b/frameworks/keyed/redom/src/app.js
@@ -131,13 +131,14 @@ class Tr {
     this.data = {};
     this.app = app;
     this.store = store;
+    this.isSelected = false;
     this.el = el('tr',
       this.id = el('td.col-md-1'),
       el('td.col-md-4',
         this.label = el('a', { onclick: e => app.select(this.data.id) })
       ),
       el('td.col-md-1',
-        this.remove = el('a', { onclick: e => app.remove(this.data.id) },
+        el('a', { onclick: e => app.remove(this.data.id) },
           el('span.glyphicon.glyphicon-remove', { 'aria-hidden': true })
         )
       ),
@@ -156,10 +157,12 @@ class Tr {
       this.label.textContent = label;
     }
 
-    if (id === selected) {
-    this.el.classList.add('danger');
-    } else {
-    this.el.classList.remove('danger');
+    if (id === selected && !this.isSelected) {
+      this.el.classList.add('danger');
+      this.isSelected = true;
+    } else if (this.isSelected) {
+      this.el.classList.remove('danger');
+      this.isSelected = false;
     }
 
     this.data = { id, label };

--- a/frameworks/non-keyed/redom/src/app.js
+++ b/frameworks/non-keyed/redom/src/app.js
@@ -131,13 +131,14 @@ class Tr {
     this.data = {};
     this.app = app;
     this.store = store;
+    this.isSelected = false;
     this.el = el('tr',
       this.id = el('td.col-md-1'),
       el('td.col-md-4',
         this.label = el('a', { onclick: e => app.select(this.data.id) })
       ),
       el('td.col-md-1',
-        this.remove = el('a', { onclick: e => app.remove(this.data.id) },
+        el('a', { onclick: e => app.remove(this.data.id) },
           el('span.glyphicon.glyphicon-remove', { 'aria-hidden': true })
         )
       ),
@@ -156,10 +157,12 @@ class Tr {
       this.label.textContent = label;
     }
 
-    if (id === selected) {
-    this.el.classList.add('danger');
-    } else {
-    this.el.classList.remove('danger');
+    if (id === selected && !this.isSelected) {
+      this.el.classList.add('danger');
+      this.isSelected = true;
+    } else if (this.isSelected) {
+      this.el.classList.remove('danger');
+      this.isSelected = false;
     }
 
     this.data = { id, label };


### PR DESCRIPTION
Tiny improvement for RE:DOM:
- Avoids modifying the class list if not needed.
- Storing `this.remove` was probably not needed.

My measurement have high statistical errors, but for "select row" the improvement is likely statically significant:

| Before                                                                                                        |                                                     After                                                     |
|---------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------:|
| ![old_2](https://user-images.githubusercontent.com/3620703/58127081-d23e5000-7c14-11e9-973f-860a5498cd2d.png) | ![new_1](https://user-images.githubusercontent.com/3620703/58127094-da968b00-7c14-11e9-9933-091e5c523a92.png) |

Would be good to wait for approval from @pakastin if he's happy with the change.