### PR TITLE
Update sinuous to v0.7.1

### DIFF
--- a/frameworks/keyed/sinuous/package.json
+++ b/frameworks/keyed/sinuous/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-sinuous",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "sinuous"
@@ -17,8 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "htm": "2.1.1",
-    "sinuous": "0.6.1"
+    "sinuous": "0.7.0"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",

--- a/frameworks/keyed/sinuous/package.json
+++ b/frameworks/keyed/sinuous/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "sinuous": "0.7.0"
+    "sinuous": "0.7.1"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",

--- a/frameworks/keyed/sinuous/package.json
+++ b/frameworks/keyed/sinuous/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "htm": "2.1.1",
-    "sinuous": "0.6.0"
+    "sinuous": "0.6.1"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",

--- a/frameworks/keyed/sinuous/src/main.js
+++ b/frameworks/keyed/sinuous/src/main.js
@@ -1,7 +1,6 @@
-import o, { subscribe, root, sample } from 'sinuous/observable';
-import each from 'sinuous/each';
-import sinuous from 'sinuous';
-const h = sinuous({ subscribe, root, sample });
+import { o, h } from 'sinuous';
+import { subscribe } from 'sinuous/observable';
+import map from 'sinuous/map';
 
 let idCounter = 1;
 const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"],
@@ -87,7 +86,7 @@ const App = () => {
 		</div></div>
 		<table class="table table-hover table-striped test-data">
 			<tbody onclick=${() => removeOrSelect}>
-				${each(data, (row) => html`
+				${map(data, (row) => html`
 					<tr data-id="${ row.id }">
 						<td class=col-md-1 textContent=${ row.id } />
 						<td class=col-md-4><a>${ row.label }</a></td>


### PR DESCRIPTION
This should improve memory use for reactive libraries w/ semi-automatic cleanups.
The parent computations take care of that.

Thanks to @ryansolid for detecting this issue!