### PR TITLE
Update Sinuous v0.9.2

### DIFF
--- a/frameworks/keyed/sinuous/package.json
+++ b/frameworks/keyed/sinuous/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "sinuous": "0.9.0"
+    "sinuous": "0.9.2"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",

--- a/frameworks/keyed/sinuous/src/main.js
+++ b/frameworks/keyed/sinuous/src/main.js
@@ -22,8 +22,8 @@ function buildData(count) {
 
 function getParentId(node) {
 	do {
-		if (node.data && node.data.id) {
-			return node.data.id;
+		if (node.props && node.props.id) {
+			return node.props.id;
 		}
 	} while ((node = node.parentNode));
 }
@@ -79,7 +79,7 @@ const App = () => {
 
 	const Row = template(() => html`
 		<tr class=${ o('selected') }>
-			<td class=col-md-1 textContent=${ t('id') } />
+			<td class=col-md-1>${ t('id') }</td>
 			<td class=col-md-4><a>${ o('label') }</a></td>
 			<td class=col-md-1><a>
 				<span class="glyphicon glyphicon-remove remove" aria-hidden=true />


### PR DESCRIPTION
Added an optimization where `sinuous/template` can update text nodes w/ `Text.data` instead of `parent.textContent`.

Also changes that the top element in a template can access the props via `node.props` instead of `node.data` which could collide with the native text node `.data` property.

