### PR TITLE
Update CircleCI version to Node 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
 
       - run: |
           source $NVM_DIR/nvm.sh
-          nvm install v8.9.1
+          nvm install v10.16.0
 
           npm install
           npm start &


### PR DESCRIPTION
This is required for Lighthouse.

> Lighthouse requires Node 10 LTS (10.13) or later.

I know Docker is used now but would still be nice to see CI passing :)

```js
/home/circleci/project/webdriver-ts/node_modules/lighthouse/lighthouse-core/lib/url-shim.js:35
class URLShim extends URL {
                      ^

ReferenceError: URL is not defined
```

Fixes #593