### PR TITLE
Update Sinuous v0.11.4

### DIFF
--- a/frameworks/keyed/sinuous/package.json
+++ b/frameworks/keyed/sinuous/package.json
@@ -17,12 +17,11 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "sinuous": "0.9.2"
+    "sinuous": "0.11.4"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",
     "babel-eslint": "^10.0.1",
-    "babel-plugin-htm": "^2.1.0",
     "eslint": "^5.16.0",
     "rollup": "1.11.3",
     "rollup-plugin-babel": "4.3.2",

--- a/frameworks/keyed/sinuous/rollup.config.js
+++ b/frameworks/keyed/sinuous/rollup.config.js
@@ -5,7 +5,7 @@ import { terser } from 'rollup-plugin-terser';
 const plugins = [
 	babel({
 		exclude: 'node_modules/**',
-		plugins: [['htm']]
+		plugins: [['sinuous/babel-plugin-htm']]
   }),
 	resolve()
 ];

--- a/frameworks/keyed/sinuous/src/main.js
+++ b/frameworks/keyed/sinuous/src/main.js
@@ -72,7 +72,7 @@ const App = () => {
 
 	const Button = ({ id, text, fn }) => html`
 		<div class="col-sm-6 smallpad">
-			<button id="${ id }" class="btn btn-primary btn-block" type=button onclick=${() => fn}>
+			<button id="${ id }" class="btn btn-primary btn-block" type=button onclick=${fn}>
 				${ text }
 			</button>
 		</div>`;
@@ -101,7 +101,7 @@ const App = () => {
 			</div></div>
 		</div></div>
 		<table class="table table-hover table-striped test-data">
-			<tbody onclick=${() => removeOrSelect}>
+			<tbody onclick=${removeOrSelect}>
 				${map(data, Row)}
 			</tbody>
 		</table>


### PR DESCRIPTION
Made a lot of updates mostly to reduce bundle size and fix the weird event syntax for non-observable event listeners. I also removed a lot of specialized attributes/properties which might come back if anyone requests them but I prefer to have the 1:1 with JS element properties if possible. `attrs` is an exception, not sure if everything can be done with properties besides `aria-`, `data-`. 

I'm attaching the changelog since `v0.9.2` for reference.
Hoping it wouldn't affect performance too much.

## 0.11.4 - 2019-07-07

### Changed

- Prioritized string and numeric values for `insert`.

## 0.11.3 - 2019-07-07

### Removed

- Removed array to node support in `insert`. Save some bytes.

## 0.11.2 - 2019-07-07

### Changed

- Fixed mixed exports
  It's not recommended to have a default AND named exports

### Removed

- Removed multi expressions

## 0.11.1 - 2019-07-04

### Added

- Added minified browser version `.min.js`.

### Removed

- Removed shorthand tag parser from hyperscript.
- Removed specialized attribute `ref`.
  No need w/ Sinuous since it returns plain elements.
- Removed unneeded api on `h` tag.

### Changed

- Optimized rollup/terser config for smaller bundle.

## 0.11.0 - 2019-07-03

### Added

- Added `sinuous/htm` and `sinuous/babel-plugin-htm` supporting fragments.
- Added easy import `import { html } from 'sinuous';`

## 0.10.1 - 2019-07-02

### Changed

- Removed specialized attribute `bindings`.
- Removed specialized Capture syntax.
- Used Sinuous's normalizeArray in `map`, save bytes.

## 0.10.0 - 2019-06-30 - BREAKING CHANGES

### Changed

- Removed `classList` property handler, this can be done with a function.
- Removed specialized `events` property, HTM supports spread props.
- Removed initial execution of non observable event handlers so there is now no need for the extra closure. Fixes [#3](https://github.com/luwes/sinuous/issues/3)
- Removed Date, RegExp coercion This can be done in the view.