### PR TITLE
Update solid, ko-jsx, mobx-jsx

### DIFF
--- a/frameworks/keyed/ko-jsx/package.json
+++ b/frameworks/keyed/ko-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-ko-jsx",
-  "version": "0.6.3",
+  "version": "0.8.1",
   "main": "index.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "ko-jsx"
@@ -17,16 +17,16 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.8.2",
+    "babel-plugin-jsx-dom-expressions": "0.11.2",
     "knockout": "3.5.0",
-    "ko-jsx": "0.6.3"
+    "ko-jsx": "0.8.1"
   },
   "devDependencies": {
-    "@babel/core": "7.4.4",
-    "rollup": "1.12.1",
-    "rollup-plugin-babel": "4.3.2",
+    "@babel/core": "7.5.5",
+    "rollup": "1.17.0",
+    "rollup-plugin-babel": "4.3.3",
     "rollup-plugin-commonjs": "9.2.0",
-    "rollup-plugin-node-resolve": "5.0.0",
-    "rollup-plugin-terser": "4.0.4"
+    "rollup-plugin-node-resolve": "5.2.0",
+    "rollup-plugin-terser": "5.1.1"
   }
 }

--- a/frameworks/keyed/ko-jsx/rollup.config.js
+++ b/frameworks/keyed/ko-jsx/rollup.config.js
@@ -12,7 +12,10 @@ const plugins = [
 	commonjs({
     include: 'node_modules/**',
     namedExports: {
-      'node_modules/knockout/build/output/knockout-latest.js': ['ignoreDependencies', 'computed']
+      'node_modules/knockout/build/output/knockout-latest.js': [
+        'ignoreDependencies', 'observable', 'observableArray',
+        'computed', 'subscribable'
+      ]
     }
 	})
 ];

--- a/frameworks/keyed/ko-jsx/src/Main.js
+++ b/frameworks/keyed/ko-jsx/src/Main.js
@@ -1,5 +1,5 @@
-import { root } from 'ko-jsx';
-import ko from 'knockout';
+import { render } from 'ko-jsx';
+import { observable, observableArray } from 'knockout';
 import template from './template';
 
 function _random(max) { return Math.round(Math.random() * 1000) % max; }
@@ -14,15 +14,15 @@ function buildData(count) {
   for (var i = 0; i < count; i++) {
     data.push({
       id: rowId++,
-      label: ko.observable(adjectives[_random(adjectives.length)] + " " + colours[_random(colours.length)] + " " + nouns[_random(nouns.length)])
+      label: observable(adjectives[_random(adjectives.length)] + " " + colours[_random(colours.length)] + " " + nouns[_random(nouns.length)])
     });
   }
   return data;
 }
 
 var HomeViewModel = function () {
-  const selected = ko.observable(null),
-    data = ko.observableArray();
+  const selected = observable(null),
+    data = observableArray();
 
   return {
     data,
@@ -66,6 +66,4 @@ var HomeViewModel = function () {
   }
 };
 
-root(function () {
-  document.getElementById('main').appendChild(template(new HomeViewModel()))
-});
+render(() => template(new HomeViewModel()), document.getElementById('main'))

--- a/frameworks/keyed/ko-jsx/src/template.jsx
+++ b/frameworks/keyed/ko-jsx/src/template.jsx
@@ -1,9 +1,20 @@
-import { selectWhen } from 'ko-jsx'
+import { computed } from 'knockout';
 
 const Button = ({id, text, fn}) =>
   <div class='col-sm-6 smallpad'>
     <button id={id} class='btn btn-primary btn-block' type='button' onClick={fn}>{text}</button>
   </div>
+
+const selectRow = (selected, rows) => {
+  let tr;
+  const cached = computed(rows);
+  computed(() => {
+    const s = selected();
+    if (tr) tr.className = '';
+    if (tr = s && cached().find(tr => tr.model === s)) tr.className = 'danger';
+  });
+  return cached;
+}
 
 export default function({data, selected, run, runLots, add, update, clear, swapRows, remove, select}) {
   return <div class='container'>
@@ -18,16 +29,16 @@ export default function({data, selected, run, runLots, add, update, clear, swapR
         <Button id='swaprows' text='Swap Rows' fn={swapRows} />
       </div></div>
     </div></div>
-    <table class='table table-hover table-striped test-data'><tbody>
-      <$ each={data()} afterRender={selectWhen(selected, 'danger')}>{ row =>
+    <table class='table table-hover table-striped test-data'><tbody>{
+      selectRow(selected, data.memoMap(row =>
         <tr model={row.id}>
           <td class='col-md-1' textContent={row.id} />
           <td class='col-md-4'><a onClick={select}>{row.label}</a></td>
           <td class='col-md-1'><a onClick={remove}><span class='glyphicon glyphicon-remove' aria-hidden='true' /></a></td>
           <td class='col-md-6'/>
         </tr>
-      }</$>
-    </tbody></table>
+      ))
+    }</tbody></table>
     <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
   </div>
 }

--- a/frameworks/keyed/mobx-jsx/package.json
+++ b/frameworks/keyed/mobx-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-mobx-jsx",
-  "version": "0.4.2",
+  "version": "0.6.3",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "mobx-jsx"
@@ -17,16 +17,18 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.8.2",
-    "mobx": "5.9.4",
-    "mobx-jsx": "0.4.2"
+    "babel-plugin-jsx-dom-expressions": "0.11.2",
+    "mobx": "5.13.0",
+    "mobx-jsx": "0.6.3"
   },
   "devDependencies": {
-    "@babel/core": "7.3.3",
-    "rollup": "1.12.1",
+    "@babel/core": "7.5.5",
+    "@babel/plugin-proposal-decorators": "7.4.4",
+    "@babel/plugin-proposal-class-properties": "7.5.5",
+    "rollup": "1.17.0",
     "rollup-plugin-babel": "4.3.2",
-    "rollup-plugin-node-resolve": "5.0.0",
+    "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "4.0.4"
+    "rollup-plugin-terser": "5.1.1"
   }
 }

--- a/frameworks/keyed/mobx-jsx/rollup.config.js
+++ b/frameworks/keyed/mobx-jsx/rollup.config.js
@@ -6,7 +6,11 @@ import { terser } from 'rollup-plugin-terser';
 const plugins = [
 	babel({
 		exclude: 'node_modules/**',
-		plugins: [["jsx-dom-expressions", {moduleName: 'mobx-jsx'}]]
+		plugins: [
+      ["jsx-dom-expressions", {moduleName: 'mobx-jsx', alwaysCreateComponents: true}],
+      ["@babel/plugin-proposal-decorators", { "legacy": true}],
+      ["@babel/plugin-proposal-class-properties", { "loose": true}]
+    ]
   }),
 	resolve({ extensions: ['.js', '.jsx'] }),
 	replace({"process.env.NODE_ENV": "'production'"})

--- a/frameworks/keyed/mobx-jsx/src/main.jsx
+++ b/frameworks/keyed/mobx-jsx/src/main.jsx
@@ -1,9 +1,7 @@
-import { observable, action } from 'mobx';
-import { selectWhen, root } from 'mobx-jsx';
+import { observable, action, autorun, computed } from 'mobx';
+import { Component, map, render } from 'mobx-jsx';
 
-function _random (max) {
-  return Math.round(Math.random() * 1000) % max;
-};
+function _random (max) { return Math.round(Math.random() * 1000) % max; };
 
 let idCounter = 1;
 const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"],
@@ -26,77 +24,77 @@ const Button = ({ id, text, fn }) =>
     <button id={ id } class='btn btn-primary btn-block' type='button' onClick={ fn }>{ text }</button>
   </div>
 
-const App = () => {
-  const state = observable({data: [], selected: null});
+class App extends Component {
+  @observable data = [];
+  @observable selected = null;
+  remove = (e, item) => action(() => this.data.remove(item))();
+  select = (e, item) =>  action(() => this.selected = item)();
 
-  const remove = (e, id) => action(() => {
-    const data = state.data.slice(0);
-    data.splice(data.findIndex(d => d.id === id), 1)
-    state.data = data;
-  })();
-
-  const select = (e, id) => action(() => state.selected = id)();
-
-  const run = action(e => {
-    state.data = buildData(1000);
-    state.selected = null;
-  });
-
-  const runLots = action(e => {
-    state.data = buildData(10000);
-    state.selected = null;
-  });
-
-  const add = action(e => {
-    state.data = state.data.concat(buildData(1000));
-  });
-
-  const update = action(e => {
+  @action.bound run(e) {
+    this.data.replace(buildData(1000));
+    this.selected = null;
+  };
+  @action.bound runLots(e) {
+    this.data.replace(buildData(10000));
+    this.selected = null;
+  };
+  @action.bound add(e) { this.data.spliceWithArray(this.data.length, 0, buildData(1000)); };
+  @action.bound update(e) {
     let index = 0;
-    while (index < state.data.length) {
-      state.data[index].label += ' !!!';
+    while (index < this.data.length) {
+      this.data[index].label += ' !!!';
       index += 10;
     }
-  });
-
-  const swapRows = action(e => {
-    if (state.data.length > 998) {
-      let data = state.data.slice(0);
-      data[1] = state.data[998];
-      data[998] = state.data[1];
-      state.data = data;
+  }
+  @action.bound swapRows(e) {
+    if (this.data.length > 998) {
+      let a = this.data[1];
+    	this.data[1] = this.data[998];
+      this.data[998] = a;
     }
-  });
+  }
+  @action.bound clear(e) {
+    this.data.clear();
+    this.selected = null;
+  }
+  selectRow(rows) {
+    let tr;
+    const b = observable.box();
+    autorun(() => b.set(rows()));
+    autorun(() => {
+      const s = this.selected;
+      if (tr) tr.className = '';
+      if (tr = s && b.get().find(tr => tr.model === s)) tr.className = 'danger';
+    });
+    return () => b.get();
+  }
 
-  const clear = action(e => {
-    state.data = [];
-    state.selected = null;
-  });
-
-  return <div class='container'>
-    <div class='jumbotron'><div class='row'>
-      <div class='col-md-6'><h1>MobX-JSX Keyed</h1></div>
-      <div class='col-md-6'><div class='row'>
-        <Button id='run' text='Create 1,000 rows' fn={ run } />
-        <Button id='runlots' text='Create 10,000 rows' fn={ runLots } />
-        <Button id='add' text='Append 1,000 rows' fn={ add } />
-        <Button id='update' text='Update every 10th row' fn={ update } />
-        <Button id='clear' text='Clear' fn={ clear } />
-        <Button id='swaprows' text='Swap Rows' fn={ swapRows } />
+  render() {
+    return <div class='container'>
+      <div class='jumbotron'><div class='row'>
+        <div class='col-md-6'><h1>MobX-JSX Keyed</h1></div>
+        <div class='col-md-6'><div class='row'>
+          <Button id='run' text='Create 1,000 rows' fn={ this.run } />
+          <Button id='runlots' text='Create 10,000 rows' fn={ this.runLots } />
+          <Button id='add' text='Append 1,000 rows' fn={ this.add } />
+          <Button id='update' text='Update every 10th row' fn={ this.update } />
+          <Button id='clear' text='Clear' fn={ this.clear } />
+          <Button id='swaprows' text='Swap Rows' fn={ this.swapRows } />
+        </div></div>
       </div></div>
-    </div></div>
-    <table class='table table-hover table-striped test-data'><tbody>
-      <$ each={ state.data } afterRender={selectWhen(() => state.selected, 'danger')}>{ row =>
-        <tr model={ row.id }>
-          <td class='col-md-1' textContent={ row.id } />
-          <td class='col-md-4'><a onClick={ select }>{( row.label )}</a></td>
-          <td class='col-md-1'><a onClick={ remove }><span class='glyphicon glyphicon-remove' aria-hidden='true' /></a></td>
-          <td class='col-md-6'/>
-        </tr>
-      }</$>
-    </tbody></table>
-    <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
-  </div>
+      <table class='table table-hover table-striped test-data'><tbody>{
+        this.selectRow(map(this.data, row =>
+          <tr model={ row }>
+            <td class='col-md-1' textContent={ row.id } />
+            <td class='col-md-4'><a onClick={ this.select }>{( row.label )}</a></td>
+            <td class='col-md-1'><a onClick={ this.remove }><span class='glyphicon glyphicon-remove' aria-hidden='true' /></a></td>
+            <td class='col-md-6'/>
+          </tr>
+        ))
+      }</tbody></table>
+      <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
+    </div>
+  }
 }
 
-root(() => document.getElementById("main").appendChild(<App />))
+render(() => <App />, document.getElementById("main"));

--- a/frameworks/keyed/solid-signals/package.json
+++ b/frameworks/keyed/solid-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-solid",
-  "version": "0.8.6",
+  "version": "0.9.3",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "solid-js"
@@ -17,14 +17,14 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.10.1",
-    "solid-js": "0.8.6"
+    "solid-js": "0.9.3"
   },
   "devDependencies": {
-    "@babel/core": "7.4.5",
-    "rollup": "1.15.6",
-    "rollup-plugin-babel": "4.3.2",
-    "rollup-plugin-node-resolve": "5.0.2",
-    "rollup-plugin-terser": "5.0.0"
+    "@babel/core": "7.5.5",
+    "babel-preset-solid": "0.1.0",
+    "rollup": "1.17.0",
+    "rollup-plugin-babel": "4.3.3",
+    "rollup-plugin-node-resolve": "5.2.0",
+    "rollup-plugin-terser": "5.1.1"
   }
 }

--- a/frameworks/keyed/solid-signals/rollup.config.js
+++ b/frameworks/keyed/solid-signals/rollup.config.js
@@ -5,7 +5,7 @@ import { terser } from 'rollup-plugin-terser';
 const plugins = [
 	babel({
 		exclude: 'node_modules/**',
-		plugins: [["jsx-dom-expressions", {moduleName: 'solid-js/dom'}]]
+		presets: ['solid']
   }),
 	resolve({ extensions: ['.js', '.jsx'] })
 ];

--- a/frameworks/keyed/solid-signals/src/main.jsx
+++ b/frameworks/keyed/solid-signals/src/main.jsx
@@ -41,14 +41,14 @@ const App = () => {
       </div></div>
     </div></div>
     <table class='table table-hover table-striped test-data'><tbody>
-      <$ each={ data() } afterRender={ selectWhen(selected, 'danger') }>{ row =>
+      <For each={( data() )} transform={ selectWhen(selected, 'danger') }>{ row =>
         <tr model={ row.id }>
           <td class='col-md-1' textContent={ row.id } />
           <td class='col-md-4'><a onClick={ select }>{ row.label }</a></td>
-          <td class='col-md-1'><a onClick={ remove }><span class='glyphicon glyphicon-remove' aria-hidden='true'/></a></td>
+          <td class='col-md-1'><a onClick={ remove }><span class='glyphicon glyphicon-remove' aria-hidden="true" /></a></td>
           <td class='col-md-6'/>
         </tr>
-      }</$>
+      }</For>
     </tbody></table>
     <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
   </div>

--- a/frameworks/keyed/solid/package.json
+++ b/frameworks/keyed/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-solid",
-  "version": "0.8.6",
+  "version": "0.9.3",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "solid-js"
@@ -17,14 +17,14 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.10.1",
-    "solid-js": "0.8.6"
+    "solid-js": "0.9.3"
   },
   "devDependencies": {
-    "@babel/core": "7.4.5",
-    "rollup": "1.15.6",
-    "rollup-plugin-babel": "4.3.2",
-    "rollup-plugin-node-resolve": "5.0.2",
-    "rollup-plugin-terser": "5.0.0"
+    "@babel/core": "7.5.5",
+    "babel-preset-solid": "0.1.0",
+    "rollup": "1.17.0",
+    "rollup-plugin-babel": "4.3.3",
+    "rollup-plugin-node-resolve": "5.2.0",
+    "rollup-plugin-terser": "5.1.1"
   }
 }

--- a/frameworks/keyed/solid/rollup.config.js
+++ b/frameworks/keyed/solid/rollup.config.js
@@ -4,8 +4,8 @@ import { terser } from 'rollup-plugin-terser';
 
 const plugins = [
 	babel({
-		exclude: 'node_modules/**',
-		plugins: [["jsx-dom-expressions", {moduleName: 'solid-js/dom'}]]
+    exclude: 'node_modules/**',
+    presets: ['solid']
   }),
 	resolve({ extensions: ['.js', '.jsx'] })
 ];

--- a/frameworks/keyed/solid/src/main.jsx
+++ b/frameworks/keyed/solid/src/main.jsx
@@ -50,14 +50,14 @@ const App = () => {
       </div></div>
     </div></div>
     <table class='table table-hover table-striped test-data'><tbody>
-      <$ each={ state.data } afterRender={ selectWhen(() => state.selected, 'danger') }>{ row =>
+      <For each={( state.data )} transform={ selectWhen(() => state.selected, 'danger') }>{ row =>
         <tr model={ row.id }>
           <td class='col-md-1' textContent={ row.id } />
           <td class='col-md-4'><a onClick={ select }>{( row.label )}</a></td>
           <td class='col-md-1'><a onClick={ remove }><span class='glyphicon glyphicon-remove' aria-hidden='true' /></a></td>
           <td class='col-md-6'/>
         </tr>
-      }</$>
+      }</For>
     </tbody></table>
     <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
   </div>


### PR DESCRIPTION
Pretty big changes. I split out the control flow from the reconciler. This, in theory, has to be a de-optimization but it really opens up the flexibility of the libraries. I was pushing my opinion too strong on these libraries in the name of performance.  Now I can use the underlying renderer to fit whatever fine-grained API makes sense for the library. This commit exemplifies that:

* Solid has new JSX Component control flow
* MobX JSX now uses MobX's built in mutable API, and uses a Class Component with Decorators.
* Knockout JSX uses a custom fn method for memoMapping

Overall the logic is much simpler now, but there is some duplicate work that needs to be done between the reactive systems, and the generalized renderer. I've done a bunch of work to try to optimize performance despite this. Replace rows has taken a small hit, but most benchmarks have stayed relatively the same. I believe I've even managed to gain ground in other areas (like initial render). But I'd like to verify that.