### PR TITLE
Updated to Inferno 7.2.1 and clean up controller.jsx

### DIFF
--- a/frameworks/keyed/inferno/package.json
+++ b/frameworks/keyed/inferno/package.json
@@ -32,6 +32,6 @@
     "rollup-plugin-terser": "5.1.1"
   },
   "dependencies": {
-    "inferno": "7.2.0"
+    "inferno": "7.2.1"
   }
 }

--- a/frameworks/keyed/inferno/src/controller.jsx
+++ b/frameworks/keyed/inferno/src/controller.jsx
@@ -2,10 +2,6 @@ import { Store } from './store.es6'
 import { linkEvent, Component, render } from 'inferno'
 
 function Row({ label, id, selected, deleteFunc, selectFunc }) {
-  /*
-   * Only <td className="col-md-1"> and  <a onClick={linkEvent(id, selectFunc)}/>, nodes needs children shape flags
-   * Because they have dynamic children. We can pre-define children type by using ChildFlags
-   */
   return (
       <tr className={selected ? 'danger' : null}>
         <td className="col-md-1" $HasTextChildren>{id}</td>
@@ -58,7 +54,7 @@ function Header({run, runLots, add, update, clear, swapRows}) {
       <div className="jumbotron">
         <div className="row">
           <div className="col-md-6">
-            <h1>Inferno - keyed</h1>
+            <h1>Inferno</h1>
           </div>
           <div className="col-md-6">
             <div className="row">
@@ -168,10 +164,6 @@ export class Controller extends Component {
   }
 
   render() {
-    /*
-     * Only <table> needs $HasVNodeChildren flag everything else is static
-     * tables children is tbody so another vNode, no other flags needed
-     */
     return (
         <div className="container">
           <Header
@@ -182,7 +174,7 @@ export class Controller extends Component {
               clear={this.clear}
               swapRows={this.swapRows}
           />
-          <table className="table table-hover table-striped test-data" $HasVNodeChildren>
+          <table className="table table-hover table-striped test-data">
             <tbody $HasKeyedChildren>
               {createRows(this.state.store, this.delete, this.select)}
             </tbody>

--- a/frameworks/non-keyed/inferno/package.json
+++ b/frameworks/non-keyed/inferno/package.json
@@ -32,6 +32,6 @@
     "rollup-plugin-terser": "5.1.1"
   },
   "dependencies": {
-    "inferno": "7.2.0"
+    "inferno": "7.2.1"
   }
 }

--- a/frameworks/non-keyed/inferno/src/controller.jsx
+++ b/frameworks/non-keyed/inferno/src/controller.jsx
@@ -2,10 +2,6 @@ import { Store } from './store.es6'
 import { linkEvent, Component, render } from 'inferno'
 
 function Row({ label, id, selected, deleteFunc, selectFunc }) {
-  /*
-   * Only <td className="col-md-1"> and  <a onClick={linkEvent(id, selectFunc)}/>, nodes needs children shape flags
-   * Because they have dynamic children. We can pre-define children type by using ChildFlags
-   */
   return (
       <tr className={selected ? 'danger' : null}>
         <td className="col-md-1" $HasTextChildren>{id}</td>
@@ -57,7 +53,7 @@ function Header({run, runLots, add, update, clear, swapRows}) {
       <div className="jumbotron">
         <div className="row">
           <div className="col-md-6">
-            <h1>Inferno - keyed</h1>
+            <h1>Inferno</h1>
           </div>
           <div className="col-md-6">
             <div className="row">
@@ -167,10 +163,6 @@ export class Controller extends Component {
   }
 
   render() {
-    /*
-     * Only <table> needs $HasVNodeChildren flag everything else is static
-     * tables children is tbody so another vNode, no other flags needed
-     */
     return (
         <div className="container">
           <Header
@@ -181,7 +173,7 @@ export class Controller extends Component {
               clear={this.clear}
               swapRows={this.swapRows}
           />
-          <table className="table table-hover table-striped test-data" $HasVNodeChildren>
+          <table className="table table-hover table-striped test-data">
             <tbody $HasNonKeyedChildren>
               {createRows(this.state.store, this.delete, this.select)}
             </tbody>


### PR DESCRIPTION
Updated Inferno to 7.2.1, because 7.2.0 had a bug where events were not patched correctly.
Removed old comments from inferno controller.jsx file and fixed wrong title in non-keyed implementation. Also removed `$HasVNodeChildren` optimization flag because its done automatically by JSX plugin.