### PR TITLE
Upgrade Sinuous to v0.15.1

### DIFF
--- a/frameworks/keyed/sinuous/package.json
+++ b/frameworks/keyed/sinuous/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "sinuous": "0.12.6"
+    "sinuous": "0.15.0"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",

--- a/frameworks/keyed/sinuous/package.json
+++ b/frameworks/keyed/sinuous/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "sinuous": "0.15.0"
+    "sinuous": "0.15.1"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",

--- a/frameworks/keyed/sinuous/src/main.js
+++ b/frameworks/keyed/sinuous/src/main.js
@@ -1,6 +1,6 @@
 import { observable, h } from 'sinuous';
 import { template, t, o } from 'sinuous/template';
-import map from 'sinuous/map';
+import { map } from 'sinuous/map';
 
 let idCounter = 1;
 const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"],


### PR DESCRIPTION
Lots of changes but shouldn't affect performance too much. Here is the changelog since v0.12.6.

This change should affect perf positively:

- Disable `observable` cleaning by default in `map` for repeated `template`'s.

The rest probably negatively 😄 size increased a bit too 😢 

https://github.com/luwes/sinuous/blob/master/CHANGELOG.md

## 0.15.1 - 2019-09-25

### Changed

- Changed map mini import to be `import { map } from 'sinuous/map/mini'` instead of `import { mini } from 'sinuous/map'`.
- Re-named variables in `map` and golfed down the bundle from 1.45kB to 1.19kB, also by removing the fast path for swap backward and swap forward.

## 0.15.0 - 2019-09-13

### Added

- Added basic `hydrate` feature [#36](https://github.com/luwes/sinuous/pull/36)
- Disable `observable` cleaning by default in `map` for repeated `template`'s.

## 0.14.2 - 2019-09-04

### Fixed

- Prevented running duplicate nested computations.
- Marked removed children computations as fresh so they skip running.
- Fixed a `transaction` bug which prevent nullish values from being set.
- Improved performance by using `Set` for the subscribers [#20](https://github.com/luwes/sinuous/issues/20)

### Added

- Added `import { computed } from 'sinuous/observable'` which `S` is now an alias for.

## 0.14.1 - 2019-08-29

### Fixed

- Fixed template scope key actions bug. Impacted performance and incorrect rendering. Visible in JS Framework Benchmark.

### Changed

## 0.14.0 - 2019-08-27 - BREAKING CHANGES

### Added

- Added `import { mini } from 'sinuous/map'`. It's only 570 bytes heiiii! [#32](https://github.com/luwes/sinuous/issues/32)

![Gob](https://media.giphy.com/media/n0WvhHFTpihk4/giphy.gif)

### Changed

- Breaking changes `import map from 'sinuous/map'` to `import { map } from 'sinuous/map'`

## 0.13.1 - 2019-08-11

### Fixed

- Fixed same key observe tags in template fix [#5](https://github.com/luwes/sinuous/issues/5)

### Added

- Added transaction method [#21](https://github.com/luwes/sinuous/issues/21)

## 0.13.0 - 2019-08-03

### Added

- Added web ES modules support [#27](https://github.com/luwes/sinuous/issues/27)

### Fixed

- Fixed [Observable set works from other computed #28](https://github.com/luwes/sinuous/issues/28)

## 0.12.9 - 2019-07-31

### Fixed

- Fixed bundling issue
- Fixed [Verify `map` disposers index #23](https://github.com/luwes/sinuous/issues/23) by using `Map` again

## 0.12.8 - 2019-07-31

### Added

- Added HTM's support for HTML comments
- Added out of the box support down to IE9

### Fixed

- Fixed [Verify `map` disposers index #23](https://github.com/luwes/sinuous/issues/23)

## 0.12.7 - 2019-07-28

### Fixed

- Fixed [Plain computed in root doesn't return result #22](https://github.com/luwes/sinuous/issues/22)

## 0.12.6 - 2019-07-28

### Fixed

- Fixed naming issue for umd and iife bundles
- Add observable duplicate edges check
- Replace Map w/ array for `map` disposers