### PR TITLE
Replace swap built-in with reconcile

### DIFF
--- a/frameworks/keyed/mikado/package.json
+++ b/frameworks/keyed/mikado/package.json
@@ -14,14 +14,14 @@
   },
   "scripts": {
     "compile": "mikado-compile src/template/app.html && mikado-compile src/template/item.html && echo Compile Complete. && exit 0",
-    "build": "npm run compile && node task/build RELEASE=custom DEBUG=false USE_POLYFILL=false SUPPORT_CACHE=false SUPPORT_EVENTS=true SUPPORT_STORAGE=true SUPPORT_HELPERS='swap' SUPPORT_ASYNC=false SUPPORT_TRANSPORT=false SUPPORT_TEMPLATE_EXTENSION=false SUPPORT_REACTIVE=false SUPPORT_CACHE_HELPERS=false SUPPORT_POOLS=false SUPPORT_COMPILE=false && exit 0",
+    "build": "npm run compile && node task/build RELEASE=custom DEBUG=false USE_POLYFILL=false SUPPORT_CACHE=false SUPPORT_EVENTS=true SUPPORT_STORAGE=false SUPPORT_HELPERS=false SUPPORT_ASYNC=false SUPPORT_TRANSPORT=false SUPPORT_TEMPLATE_EXTENSION=false SUPPORT_REACTIVE=false SUPPORT_CACHE_HELPERS=false SUPPORT_POOLS=false SUPPORT_CALLBACKS=false SUPPORT_COMPILE=false && exit 0",
     "build-prod": "npm run build"
   },
   "dependencies": {
-    "mikado": "^0.6.53"
+    "mikado": "0.7.35"
   },
   "devDependencies": {
-    "google-closure-compiler": "20191012.0.0-nightly",
+    "google-closure-compiler": "20191027.0.0-nightly",
     "mikado-compile": "0.6.5"
   }
 }

--- a/frameworks/keyed/mikado/src/data.js
+++ b/frameworks/keyed/mikado/src/data.js
@@ -10,14 +10,14 @@ let _nextId = 1;
 
 export function buildData(count){
 
-    if(count === 1){
-
-        return {
-
-            id: _nextId++,
-            label: ADJECTIVES[_random(len_ADJECTIVES)] + " " + COLOURS[_random(len_COLOURS)] + " " + NOUNS[_random(len_NOUNS)]
-        }
-    }
+    // if(count === 1){
+    //
+    //     return {
+    //
+    //         id: _nextId++,
+    //         label: ADJECTIVES[_random(len_ADJECTIVES)] + " " + COLOURS[_random(len_COLOURS)] + " " + NOUNS[_random(len_NOUNS)]
+    //     }
+    // }
 
     const data = new Array(count);
 

--- a/frameworks/keyed/mikado/src/main.js
+++ b/frameworks/keyed/mikado/src/main.js
@@ -5,22 +5,28 @@ import { buildData } from "./data.js";
 
 Mikado.once(document.getElementById("main"), app);
 
+let data;
 const state = { "selected": {} };
 const root = document.getElementById("tbody");
-const mikado = Mikado.new(root, item, {
+const mikado = new Mikado(root, item, {
     "reuse": false, "state": state
 })
-.route("run", () => { mikado.render(buildData(1000)) })
-.route("runlots", () => { mikado.render(buildData(10000)) })
+.route("run", () => { mikado.clear().append(data = buildData(1000)) })
+.route("runlots", () => { mikado.clear().append(buildData(10000)) })
 .route("add", () => { mikado.append(buildData(1000)) })
 .route("update", () => {
     for(let i = 0, len = mikado.length; i < len; i += 10){
-        mikado.data(i).label += " !!!";
-        mikado.refresh(i);
+        data[i].label += " !!!";
+        mikado.apply(mikado.node(i), data[i]);
     }
 })
 .route("clear", () => { mikado.clear() })
-.route("swaprows", () => { mikado.swap(1, 998) })
+.route("swaprows", () => {
+    const tmp = data[998]
+    data[998] = data[1];
+    data[1] = tmp;
+    mikado.reconcile(data);
+})
 .route("remove", target => { mikado.remove(target) })
 .route("select", target => {
     state["selected"].className = "";

--- a/frameworks/keyed/mikado/src/template/item.html
+++ b/frameworks/keyed/mikado/src/template/item.html
@@ -1,4 +1,4 @@
-<tr class="{{this.state.selected === self ? 'danger' : ''}}" root>
+<tr key="data.id" class="{{this.state.selected === self ? 'danger' : ''}}" root>
     <td class="col-md-1">{{data.id}}</td>
     <td class="col-md-4">
         <a class="lbl" click="select:root">{{data.label}}</a>

--- a/frameworks/keyed/mikado/task/build.js
+++ b/frameworks/keyed/mikado/task/build.js
@@ -58,7 +58,7 @@ const parameter = (function(opt){
     generate_exports: true,
     export_local_property_definitions: true,
     language_in: "ECMASCRIPT6_STRICT",
-    language_out: "ECMASCRIPT5_STRICT",
+    language_out: "ECMASCRIPT6_STRICT",
     process_closure_primitives: true,
     summary_detail_level: 3,
     warning_level: "VERBOSE",
@@ -88,7 +88,7 @@ const parameter = (function(opt){
     //formatting: "PRETTY_PRINT"
 });
 
-exec("java -jar node_modules/google-closure-compiler-java/compiler.jar" + parameter + " --js='src/*.js' --js='src/template/*.es6.js' --js='node_modules/mikado/src/*.js' --js='!src/*config.js'" + flag_str + " --js_output_file='dist/main.js' && exit 0", function(){
+exec("java -jar node_modules/google-closure-compiler-java/compiler.jar" + parameter + " --js='src/*.js' --js='src/template/*.es6.js' --js='node_modules/mikado/src/*.js'" + flag_str + " --js_output_file='dist/main.js' && exit 0", function(){
 
     console.log("Build Complete.");
 });


### PR DESCRIPTION
After I got the 3rd shit storm about this swap method I change this built-in method with reconciliation. Please be aware that the keyed test will not become a reconcile test. The first is a paradigm the other is just an implementation detail. It's the same group of library authors which have made its own reconcile libs (which are quite equal^^) and of course they would like to have the best environment for its kind of library. But the truth is that reconcile isn't the holy grail and certainly by far not a standard.

But I would really like to see a 3rd test category especially for this purpose (besides keyed/non-keyed). If you like that idea I would also like to make some suggestions for this new section:

- please please please allow runtime optimizations for the tests instead of reloading, because that isn't natural
- change the concept of test so that each library has to export 1 single function which handles all the data, that will:
  - give you more flexibility in updating/changing tests in the future
  - adding new tests without the need of changing any implementation
  - provides a quite more fairly test base
  - a most simple test implementation for a developer
  - the only way to "force" benchmark library performance and not the performance made by an implementation
  - I do already that way, if you like you can get some suggestions here:
    - https://github.com/nextapps-de/mikado/tree/master/bench
    - look at this tests for example: https://github.com/nextapps-de/mikado/tree/master/bench/test they all have an index.html where a single function is exported to the benchmark test

__Note:__ just the keyed test was updated, the non-keyed stayed as it is