### PR TITLE
Update lighterhtml test

### DIFF
--- a/frameworks/keyed/lighterhtml/src/index.js
+++ b/frameworks/keyed/lighterhtml/src/index.js
@@ -27,27 +27,24 @@ const clear = () => {
 };
 const interact = event => {
   event.preventDefault();
-  event.stopPropagation();
-  const {target} = event;
-  const id = +target.closest('tr').id;
-  if (target.getAttribute('data-interaction') === 'delete') {
-    del(id)
-  } else {
-    select(id)
+  const a = event.target.closest('a');
+  const id = parseInt(a.closest('tr').id, 10);
+  const idx = data.findIndex(item => item.id === id);
+  switch (a.dataset.action) {
+    case 'delete':
+      data.splice(idx, 1);
+      _render();
+      break;
+    case 'select':
+      if (selected !== idx) {
+        if (-1 < selected)
+          data[selected] = { ...data[selected], selected: false };
+        selected = idx;
+        data[selected] = { ...data[selected], selected: true };
+        _render();
+      }
+      break;
   }
-};
-const del = id => {
-  const idx = data.findIndex(d => d.id === id);
-  data.splice(idx, 1)
-  _render();
-};
-const select = id => {
-  if (selected > -1) {
-    data[selected].selected = false;
-  }
-  selected = data.findIndex(d => d.id === id);
-  data[selected].selected = true;
-  _render();
 };
 const swapRows = () => {
   if (data.length > 998) {
@@ -80,7 +77,7 @@ const _random = max => {
 
 const container = document.getElementById('container');
 const _render = () => {
-  render(container, html.for(container)`
+  render(container, html`
   <div class="container">
     <div class="jumbotron">
       <div class="row">
@@ -119,12 +116,12 @@ const _render = () => {
       <tbody>${data.map(item => html.for(item)`
         <tr id=${item.id} class=${item.selected ? 'danger' : ''}>
           <td class="col-md-1">${item.id}</td>
-          <td data-interaction='select' class="col-md-4">
-            <a data-interaction='select'>${item.label}</a>
+          <td class="col-md-4">
+            <a data-action='select'>${item.label}</a>
           </td>
-          <td data-interaction='delete' class="col-md-1">
-            <a data-interaction='delete'>
-              <span data-interaction='delete' class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+          <td class="col-md-1">
+            <a data-action='delete'>
+              <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
             </a>
           </td>
           <td class="col-md-6"></td>

--- a/frameworks/non-keyed/lighterhtml/src/index.js
+++ b/frameworks/non-keyed/lighterhtml/src/index.js
@@ -27,27 +27,24 @@ const clear = () => {
 };
 const interact = event => {
   event.preventDefault();
-  event.stopPropagation();
-  const {target} = event;
-  const id = +target.closest('tr').id;
-  if (target.getAttribute('data-interaction') === 'delete') {
-    del(id)
-  } else {
-    select(id)
+  const a = event.target.closest('a');
+  const id = parseInt(a.closest('tr').id, 10);
+  const idx = data.findIndex(item => item.id === id);
+  switch (a.dataset.action) {
+    case 'delete':
+      data.splice(idx, 1);
+      _render();
+      break;
+    case 'select':
+      if (selected !== idx) {
+        if (-1 < selected)
+          data[selected] = { ...data[selected], selected: false };
+        selected = idx;
+        data[selected] = { ...data[selected], selected: true };
+        _render();
+      }
+      break;
   }
-};
-const del = id => {
-  const idx = data.findIndex(d => d.id === id);
-  data.splice(idx, 1)
-  _render();
-};
-const select = id => {
-  if (selected > -1) {
-    data[selected] = { ...data[selected], selected: false };
-  }
-  selected = data.findIndex(d => d.id === id);
-  data[selected] = { ...data[selected], selected: true };
-  _render();
 };
 const swapRows = () => {
   if (data.length > 998) {
@@ -117,14 +114,14 @@ const _render = () => {
     </div>
     <table onclick=${interact} class="table table-hover table-striped test-data">
       <tbody>${data.map(item => html`
-        <tr id=${item.id} class=${item.selected ? 'danger' : ''}>
+        <tr data=${item} class=${item.selected ? 'danger' : ''}>
           <td class="col-md-1">${item.id}</td>
-          <td data-interaction='select' class="col-md-4">
-            <a data-interaction='select'>${item.label}</a>
+          <td class="col-md-4">
+            <a data-action='select'>${item.label}</a>
           </td>
-          <td data-interaction='delete' class="col-md-1">
-            <a data-interaction='delete'>
-              <span data-interaction='delete' class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+          <td class="col-md-1">
+            <a data-action='delete'>
+              <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
             </a>
           </td>
           <td class="col-md-6"></td>


### PR DESCRIPTION
~~Both _hyperHTML_ and _lighterhtml_ have a special `data` behavior [since about ever](https://viperhtml.js.org/hyperhtml/documentation/#essentials-6-2), which would make the selection or removal of an item straight forward, as it is already for [domc](https://github.com/krausest/js-framework-benchmark/blob/master/frameworks/non-keyed/domc/src/app.js#L57-L67) or other cases, where the `item` is passed right away.~~

~~This behavior allows me to also cleanup a bit redundant layout details, so I hope it's OK to ask for this update.~~

~~Only thing that is slightly different, but it's the way I'd solve this "challenge", is that the item is not re-created each time, but I'm not sure that pattern is mandatory.~~

~~If that's the case, I'd be more than happy to update this MR to still retrieve the index via `data.findIndex`, instead of simply using `data.indexOf`.~~

Never mind, I've realized if I need to retrieve the id, like any other test does, there's no reason to store the item as `data`, so this is just a basic cleanup that I hope will be merged at some point.

Best Regards.