### PR TITLE
heresy: custom elements for lighterhtml

### DIFF
--- a/frameworks/keyed/heresy/index.html
+++ b/frameworks/keyed/heresy/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>heresy keyed</title>
+<link href="/css/currentStyle.css" rel="stylesheet" />
+<div id="container"></div>
+<script src='dist/index.js'></script>

--- a/frameworks/keyed/heresy/package.json
+++ b/frameworks/keyed/heresy/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "js-framework-benchmark-heresy",
+  "version": "1.0.0",
+  "description": "heresy demo",
+  "main": "index.js",
+  "js-framework-benchmark": {
+    "frameworkVersionFromPackage": "heresy"
+  },
+  "scripts": {
+    "build-dev": "rollup -c -w",
+    "build-prod": "rollup -c"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "keywords": [
+    "heresy"
+  ],
+  "author": "Mathis Zeiher",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/krausest/js-framework-benchmark/issues"
+  },
+  "homepage": "https://github.com/krausest/js-framework-benchmark#readme",
+  "dependencies": {
+    "heresy": "^0.23.2"
+  },
+  "devDependencies": {
+    "@ungap/degap": "^0.1.4",
+    "rollup": "^1.27.5",
+    "rollup-plugin-includepaths": "^0.2.3",
+    "rollup-plugin-minify-html-literals": "^1.2.2",
+    "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-terser": "^5.1.2"
+  }
+}

--- a/frameworks/keyed/heresy/rollup.config.js
+++ b/frameworks/keyed/heresy/rollup.config.js
@@ -1,0 +1,39 @@
+import resolve from 'rollup-plugin-node-resolve';
+import includePaths from 'rollup-plugin-includepaths';
+import minifyHTML from 'rollup-plugin-minify-html-literals';
+import { terser } from 'rollup-plugin-terser';
+
+export default {
+  input: 'src/index.js',
+  plugins: [
+    minifyHTML({
+      options: {
+        minifyOptions: {
+          keepClosingSlash: true
+        }
+      }
+    }),
+    includePaths({
+      include: {
+        "@ungap/create-content": "./node_modules/@ungap/degap/create-content.js",
+        "@ungap/template-tag-arguments": "./node_modules/@ungap/degap/template-tag-arguments.js",
+        "@ungap/template-literal": "./node_modules/@ungap/degap/template-literal.js",
+        "@ungap/weakmap": "./node_modules/@ungap/degap/weakmap.js",
+        "@ungap/weakset": "./node_modules/@ungap/degap/weakset.js",
+        "@ungap/event": "./node_modules/@ungap/degap/event.js",
+        "@ungap/essential-map": "./node_modules/@ungap/degap/essential-map.js",
+        "@ungap/import-node": "./node_modules/@ungap/degap/import-node.js",
+        "@ungap/trim": "./node_modules/@ungap/degap/trim.js"
+      },
+    }),
+    resolve(),
+    terser()
+  ],
+  context: 'null',
+  moduleContext: 'null',
+  output: {
+    file: 'dist/index.js',
+    format: 'iife',
+    name: 'app'
+  }
+};

--- a/frameworks/keyed/heresy/src/index.js
+++ b/frameworks/keyed/heresy/src/index.js
@@ -1,0 +1,81 @@
+import { define, html, render } from '../node_modules/heresy/esm/index.js';
+
+import App from './ui/app.js';
+define('App', App);
+
+let did = 1;
+const buildData = (count) => {
+    const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"];
+    const colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"];
+    const nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+    const data = [];
+    for (let i = 0; i < count; i++) {
+        data.push({
+            id: did++,
+            label: adjectives[_random(adjectives.length)] + " " + colours[_random(colours.length)] + " " + nouns[_random(nouns.length)]
+        });
+    }
+    return data;
+};
+
+const _random = max => Math.round(Math.random() * 1000) % max;
+
+const scope = {
+    add() {
+        scope.data = scope.data.concat(buildData(1000));
+        update(main, scope);
+    },
+    run() {
+        scope.data = buildData(1000);
+        update(main, scope);
+    },
+    runLots() {
+        scope.data = buildData(10000);
+        update(main, scope);
+    },
+    clear() {
+        scope.data = [];
+        update(main, scope);
+    },
+    update() {
+        const {data} = scope;
+        for (let i = 0, {length} = data; i < length; i += 10)
+            data[i].label += ' !!!';
+        update(main, scope);
+    },
+    swapRows() {
+        const {data} = scope;
+        if (data.length > 998) {
+            const tmp = data[1];
+            data[1] = data[998];
+            data[998] = tmp;
+        }
+        update(main, scope);
+    },
+    interact(event) {
+      event.preventDefault();
+      const a = event.target.closest('a');
+      const id = parseInt(a.closest('tr').id, 10);
+      scope[a.dataset.action](id);
+    },
+    delete(id) {
+        const {data} = scope;
+        const idx = data.findIndex(d => d.id === id);
+        data.splice(idx, 1);
+        update(main, scope);
+    },
+    select(id) {
+        scope.selected = id;
+        update(main, scope);
+    },
+    selected: -1,
+    data: [],
+};
+
+const main = document.getElementById('container');
+
+update(main, scope);
+
+function update(main, scope) {
+  render(main, html`<App .scope=${scope} />`);
+}

--- a/frameworks/keyed/heresy/src/ui/app.js
+++ b/frameworks/keyed/heresy/src/ui/app.js
@@ -1,0 +1,48 @@
+import { html } from '../../node_modules/heresy/esm/index.js';
+
+import Button from './button.js';
+import Row from './row.js';
+
+export default {
+  extends: 'div',
+  includes: {Button, Row},
+  mappedAttributes: ['scope'],
+  oninit() {
+    this.classList.add('container');
+  },
+  onscope() {
+    this.render();
+  },
+  render() {
+    const {
+      run, runLots, add, update, clear, swapRows,
+      interact, data, selected
+    } = this.scope;
+    this.html`
+    <div class="jumbotron">
+      <div class="row">
+        <div class="col-md-6">
+          <h1>heresy keyed</h1>
+        </div>
+        <div class="col-md-6">
+          <div class="row">
+            <Button .id=${'run'} .cb=${run} .text=${'Create 1,000 rows'} />
+            <Button .id=${'runlots'} .cb=${runLots} .text=${'Create 10,000 rows'} />
+            <Button .id=${'add'} .cb=${add} .text=${'Append 1,000 rows'} />
+            <Button .id=${'update'} .cb=${update} .text=${'Update every 10th row'} />
+            <Button .id=${'clear'} .cb=${clear} .text=${'Clear'} />
+            <Button .id=${'swaprows'} .cb=${swapRows} .text=${'Swap Rows'} />
+          </div>
+        </div>
+      </div>
+    </div>
+    <table onclick=${interact} class="table table-hover table-striped test-data">
+      <tbody>
+      ${data.map(({id, label}) => html.for(this, id)`
+        <Row id=${id} class=${id === selected ? 'danger' : ''} label=${label} />
+      `)}
+      </tbody>
+    </table>
+    <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true" />`;
+  }
+};

--- a/frameworks/keyed/heresy/src/ui/button.js
+++ b/frameworks/keyed/heresy/src/ui/button.js
@@ -1,0 +1,18 @@
+export default {
+  extends: 'div',
+  mappedAttributes: ['id', 'cb', 'text'],
+  oninit() {
+    this.classList.add('col-sm-6', 'smallpad');
+  },
+  render() {
+    const {id, cb, text} = this;
+    this.html`
+    <button
+      type="button" class="btn btn-primary btn-block"
+      id=${id}
+      onclick=${cb}
+    >
+      ${text}
+    </button>`;
+  }
+};

--- a/frameworks/keyed/heresy/src/ui/row.js
+++ b/frameworks/keyed/heresy/src/ui/row.js
@@ -1,0 +1,21 @@
+export default {
+  extends: 'tr',
+  observedAttributes: ['label'],
+  onattributechanged() {
+    this.render();
+  },
+  render() {
+    const {id} = this;
+    this.html`
+    <td class="col-md-1">${id}</td>
+    <td class="col-md-4">
+      <a data-action='select'>${this.getAttribute('label')}</a>
+    </td>
+    <td class="col-md-1">
+      <a data-action='delete'>
+        <span class="glyphicon glyphicon-remove" aria-hidden="true" />
+      </a>
+    </td>
+    <td class="col-md-6" />`;
+  }
+};

--- a/frameworks/non-keyed/heresy/index.html
+++ b/frameworks/non-keyed/heresy/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>heresy non-keyed</title>
+<link href="/css/currentStyle.css" rel="stylesheet" />
+<div id="container"></div>
+<script src='dist/index.js'></script>

--- a/frameworks/non-keyed/heresy/package.json
+++ b/frameworks/non-keyed/heresy/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "js-framework-benchmark-heresy",
+  "version": "1.0.0",
+  "description": "heresy demo",
+  "main": "index.js",
+  "js-framework-benchmark": {
+    "frameworkVersionFromPackage": "heresy"
+  },
+  "scripts": {
+    "build-dev": "rollup -c -w",
+    "build-prod": "rollup -c"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "keywords": [
+    "heresy"
+  ],
+  "author": "Mathis Zeiher",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/krausest/js-framework-benchmark/issues"
+  },
+  "homepage": "https://github.com/krausest/js-framework-benchmark#readme",
+  "dependencies": {
+    "heresy": "^0.23.2"
+  },
+  "devDependencies": {
+    "@ungap/degap": "^0.1.4",
+    "rollup": "^1.27.5",
+    "rollup-plugin-includepaths": "^0.2.3",
+    "rollup-plugin-minify-html-literals": "^1.2.2",
+    "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-terser": "^5.1.2"
+  }
+}

--- a/frameworks/non-keyed/heresy/rollup.config.js
+++ b/frameworks/non-keyed/heresy/rollup.config.js
@@ -1,0 +1,39 @@
+import resolve from 'rollup-plugin-node-resolve';
+import includePaths from 'rollup-plugin-includepaths';
+import minifyHTML from 'rollup-plugin-minify-html-literals';
+import { terser } from 'rollup-plugin-terser';
+
+export default {
+  input: 'src/index.js',
+  plugins: [
+    minifyHTML({
+      options: {
+        minifyOptions: {
+          keepClosingSlash: true
+        }
+      }
+    }),
+    includePaths({
+      include: {
+        "@ungap/create-content": "./node_modules/@ungap/degap/create-content.js",
+        "@ungap/template-tag-arguments": "./node_modules/@ungap/degap/template-tag-arguments.js",
+        "@ungap/template-literal": "./node_modules/@ungap/degap/template-literal.js",
+        "@ungap/weakmap": "./node_modules/@ungap/degap/weakmap.js",
+        "@ungap/weakset": "./node_modules/@ungap/degap/weakset.js",
+        "@ungap/event": "./node_modules/@ungap/degap/event.js",
+        "@ungap/essential-map": "./node_modules/@ungap/degap/essential-map.js",
+        "@ungap/import-node": "./node_modules/@ungap/degap/import-node.js",
+        "@ungap/trim": "./node_modules/@ungap/degap/trim.js"
+      },
+    }),
+    resolve(),
+    terser()
+  ],
+  context: 'null',
+  moduleContext: 'null',
+  output: {
+    file: 'dist/index.js',
+    format: 'iife',
+    name: 'app'
+  }
+};

--- a/frameworks/non-keyed/heresy/src/index.js
+++ b/frameworks/non-keyed/heresy/src/index.js
@@ -1,0 +1,81 @@
+import { define, html, render } from '../node_modules/heresy/esm/index.js';
+
+import App from './ui/app.js';
+define('App', App);
+
+let did = 1;
+const buildData = (count) => {
+    const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"];
+    const colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"];
+    const nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+    const data = [];
+    for (let i = 0; i < count; i++) {
+        data.push({
+            id: did++,
+            label: adjectives[_random(adjectives.length)] + " " + colours[_random(colours.length)] + " " + nouns[_random(nouns.length)]
+        });
+    }
+    return data;
+};
+
+const _random = max => Math.round(Math.random() * 1000) % max;
+
+const scope = {
+    add() {
+        scope.data = scope.data.concat(buildData(1000));
+        update(main, scope);
+    },
+    run() {
+        scope.data = buildData(1000);
+        update(main, scope);
+    },
+    runLots() {
+        scope.data = buildData(10000);
+        update(main, scope);
+    },
+    clear() {
+        scope.data = [];
+        update(main, scope);
+    },
+    update() {
+        const {data} = scope;
+        for (let i = 0, {length} = data; i < length; i += 10)
+            data[i].label += ' !!!';
+        update(main, scope);
+    },
+    swapRows() {
+        const {data} = scope;
+        if (data.length > 998) {
+            const tmp = data[1];
+            data[1] = data[998];
+            data[998] = tmp;
+        }
+        update(main, scope);
+    },
+    interact(event) {
+      event.preventDefault();
+      const a = event.target.closest('a');
+      const id = parseInt(a.closest('tr').id, 10);
+      scope[a.dataset.action](id);
+    },
+    delete(id) {
+        const {data} = scope;
+        const idx = data.findIndex(d => d.id === id);
+        data.splice(idx, 1);
+        update(main, scope);
+    },
+    select(id) {
+        scope.selected = id;
+        update(main, scope);
+    },
+    selected: -1,
+    data: [],
+};
+
+const main = document.getElementById('container');
+
+update(main, scope);
+
+function update(main, scope) {
+  render(main, html`<App .scope=${scope} />`);
+}

--- a/frameworks/non-keyed/heresy/src/ui/app.js
+++ b/frameworks/non-keyed/heresy/src/ui/app.js
@@ -1,0 +1,48 @@
+import { html } from '../../node_modules/heresy/esm/index.js';
+
+import Button from './button.js';
+import Row from './row.js';
+
+export default {
+  extends: 'div',
+  includes: {Button, Row},
+  mappedAttributes: ['scope'],
+  oninit() {
+    this.classList.add('container');
+  },
+  onscope() {
+    this.render();
+  },
+  render() {
+    const {
+      run, runLots, add, update, clear, swapRows,
+      interact, data, selected
+    } = this.scope;
+    this.html`
+    <div class="jumbotron">
+      <div class="row">
+        <div class="col-md-6">
+          <h1>heresy non-keyed</h1>
+        </div>
+        <div class="col-md-6">
+          <div class="row">
+            <Button .id=${'run'} .cb=${run} .text=${'Create 1,000 rows'} />
+            <Button .id=${'runlots'} .cb=${runLots} .text=${'Create 10,000 rows'} />
+            <Button .id=${'add'} .cb=${add} .text=${'Append 1,000 rows'} />
+            <Button .id=${'update'} .cb=${update} .text=${'Update every 10th row'} />
+            <Button .id=${'clear'} .cb=${clear} .text=${'Clear'} />
+            <Button .id=${'swaprows'} .cb=${swapRows} .text=${'Swap Rows'} />
+          </div>
+        </div>
+      </div>
+    </div>
+    <table onclick=${interact} class="table table-hover table-striped test-data">
+      <tbody>
+      ${data.map(({id, label}) => html`
+        <Row id=${id} class=${id === selected ? 'danger' : ''} .label=${label} />
+      `)}
+      </tbody>
+    </table>
+    <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true" />`;
+  }
+};

--- a/frameworks/non-keyed/heresy/src/ui/button.js
+++ b/frameworks/non-keyed/heresy/src/ui/button.js
@@ -1,0 +1,18 @@
+export default {
+  extends: 'div',
+  mappedAttributes: ['id', 'cb', 'text'],
+  oninit() {
+    this.classList.add('col-sm-6', 'smallpad');
+  },
+  render() {
+    const {id, cb, text} = this;
+    this.html`
+    <button
+      type="button" class="btn btn-primary btn-block"
+      id=${id}
+      onclick=${cb}
+    >
+      ${text}
+    </button>`;
+  }
+};

--- a/frameworks/non-keyed/heresy/src/ui/row.js
+++ b/frameworks/non-keyed/heresy/src/ui/row.js
@@ -1,0 +1,23 @@
+export default {
+  extends: 'tr',
+  mappedAttributes: ['label'],
+  onlabel({detail}) {
+    if (detail !== this._label)
+      this.render();
+  },
+  render() {
+    const {id, label} = this;
+    this._label = label;
+    this.html`
+    <td class="col-md-1">${id}</td>
+    <td class="col-md-4">
+      <a data-action='select'>${label}</a>
+    </td>
+    <td class="col-md-1">
+      <a data-action='delete'>
+        <span class="glyphicon glyphicon-remove" aria-hidden="true" />
+      </a>
+    </td>
+    <td class="col-md-6" />`;
+  }
+};


### PR DESCRIPTION
The [heresy](https://github.com/WebReflection/heresy/#readme) project can perform both keyed and non-keyed updates through Custom Elements, via _lighterhtml_ engine, without name clashing and through simplified literal non-dom-coupled definition.

The project is close to reach v1 and I would like to compare it with other projects, even if Custom Elements re not super common in this benchmark.

Thanks for eventually considering this PR.
