### PR TITLE
lighterhtml: dependencies update

### DIFF
--- a/frameworks/keyed/lighterhtml/package.json
+++ b/frameworks/keyed/lighterhtml/package.json
@@ -24,11 +24,11 @@
   },
   "homepage": "https://github.com/krausest/js-framework-benchmark#readme",
   "dependencies": {
-    "lighterhtml": "^2.0.2"
+    "lighterhtml": "2.0.7"
   },
   "devDependencies": {
     "@ungap/degap": "^0.1.4",
-    "rollup": "^1.27.0",
+    "rollup": "^1.27.5",
     "rollup-plugin-includepaths": "^0.2.3",
     "rollup-plugin-minify-html-literals": "^1.2.2",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/frameworks/keyed/lighterhtml/rollup.config.js
+++ b/frameworks/keyed/lighterhtml/rollup.config.js
@@ -20,7 +20,7 @@ export default {
         "@ungap/trim": "./node_modules/@ungap/degap/trim.js"
       },
     }),
-    resolve({module: true}),
+    resolve(),
     terser()
   ],
   context: 'null',

--- a/frameworks/keyed/lighterhtml/src/index.js
+++ b/frameworks/keyed/lighterhtml/src/index.js
@@ -81,7 +81,7 @@ function update(
     <div class="jumbotron">
       <div class="row">
         <div class="col-md-6">
-          <h1>lighterhtml</h1>
+          <h1>lighterhtml keyed</h1>
         </div>
         <div class="col-md-6">
           <div class="row">

--- a/frameworks/non-keyed/lighterhtml/package.json
+++ b/frameworks/non-keyed/lighterhtml/package.json
@@ -24,11 +24,11 @@
   },
   "homepage": "https://github.com/krausest/js-framework-benchmark#readme",
   "dependencies": {
-    "lighterhtml": "^2.0.2"
+    "lighterhtml": "2.0.7"
   },
   "devDependencies": {
     "@ungap/degap": "^0.1.4",
-    "rollup": "^1.27.0",
+    "rollup": "^1.27.5",
     "rollup-plugin-includepaths": "^0.2.3",
     "rollup-plugin-minify-html-literals": "^1.2.2",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/frameworks/non-keyed/lighterhtml/rollup.config.js
+++ b/frameworks/non-keyed/lighterhtml/rollup.config.js
@@ -20,7 +20,7 @@ export default {
         "@ungap/trim": "./node_modules/@ungap/degap/trim.js"
       },
     }),
-    resolve({module: true}),
+    resolve(),
     terser()
   ],
   context: 'null',

--- a/frameworks/non-keyed/lighterhtml/src/index.js
+++ b/frameworks/non-keyed/lighterhtml/src/index.js
@@ -81,7 +81,7 @@ function update(
     <div class="jumbotron">
       <div class="row">
         <div class="col-md-6">
-          <h1>lighterhtml</h1>
+          <h1>lighterhtml non-keyed</h1>
         </div>
         <div class="col-md-6">
           <div class="row">


### PR DESCRIPTION
Thanks to _domdiff_ investigation and benchmarks, I've eventually found out what was making _lighterhtml_ way slower on the "_select rows_" part of the benchmark, and not only.

Turns out, a single `WeakMap` could compromise this benchmark [extra miles](https://jsperf.com/weakmaps-vs-arrays), and it's only via _domdiff_ PR that I could see where was my main bottleneck.

Meanwhile, both _domdiff_ and _domtagger_ has been updated to produce best possible results, so that _lighterhtml_ 2.0.6 should be (hopefully) right beside _lit-html_, as it uses a single WeakMap too.

This update would like to place _lighterhtml_ in a more fair place, so I hope it will get merged at some point.

Thanks again for your patience, and effort, with this project 👍
