### PR TITLE
lighterhtml: final test-case update

### DIFF
--- a/frameworks/keyed/lighterhtml/package.json
+++ b/frameworks/keyed/lighterhtml/package.json
@@ -24,11 +24,12 @@
   },
   "homepage": "https://github.com/krausest/js-framework-benchmark#readme",
   "dependencies": {
-    "lighterhtml": "2.0.7"
+    "lighterhtml": "2.0.7",
+    "js-framework-benchmark-utils": "0.2.5"
   },
   "devDependencies": {
     "@ungap/degap": "^0.1.4",
-    "rollup": "^1.27.5",
+    "rollup": "^1.27.6",
     "rollup-plugin-includepaths": "^0.2.3",
     "rollup-plugin-minify-html-literals": "^1.2.2",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/frameworks/keyed/lighterhtml/rollup.config.js
+++ b/frameworks/keyed/lighterhtml/rollup.config.js
@@ -6,7 +6,13 @@ import { terser } from 'rollup-plugin-terser';
 export default {
   input: 'src/index.js',
   plugins: [
-    minifyHTML(),
+    minifyHTML({
+      options: {
+        minifyOptions: {
+          keepClosingSlash: true
+        }
+      }
+    }),
     includePaths({
       include: {
         "@ungap/create-content": "./node_modules/@ungap/degap/create-content.js",

--- a/frameworks/keyed/lighterhtml/src/index.js
+++ b/frameworks/keyed/lighterhtml/src/index.js
@@ -1,138 +1,19 @@
-import { html, render } from '../node_modules/lighterhtml/esm/index.js';
+import {State} from 'js-framework-benchmark-utils';
+import {html, render} from 'lighterhtml';
 
-let did = 1;
-const buildData = (count) => {
-    const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"];
-    const colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"];
-    const nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
-    const data = [];
-    for (let i = 0; i < count; i++) {
-        data.push({
-            id: did++,
-            label: adjectives[_random(adjectives.length)] + " " + colours[_random(colours.length)] + " " + nouns[_random(nouns.length)]
-        });
-    }
-    return data;
-};
+import Jumbotron from './jumbotron.js';
+import Table from './table.js';
 
-const _random = max => Math.round(Math.random() * 1000) % max;
-
-const scope = {
-    add() {
-        scope.data = scope.data.concat(buildData(1000));
-        update(main, scope);
-    },
-    run() {
-        scope.data = buildData(1000);
-        update(main, scope);
-    },
-    runLots() {
-        scope.data = buildData(10000);
-        update(main, scope);
-    },
-    clear() {
-        scope.data = [];
-        update(main, scope);
-    },
-    update() {
-        const {data} = scope;
-        for (let i = 0, {length} = data; i < length; i += 10)
-            data[i].label += ' !!!';
-        update(main, scope);
-    },
-    swapRows() {
-        const {data} = scope;
-        if (data.length > 998) {
-            const tmp = data[1];
-            data[1] = data[998];
-            data[998] = tmp;
-        }
-        update(main, scope);
-    },
-    interact(event) {
-      event.preventDefault();
-      const a = event.target.closest('a');
-      const id = parseInt(a.closest('tr').id, 10);
-      scope[a.dataset.action](id);
-    },
-    delete(id) {
-        const {data} = scope;
-        const idx = data.findIndex(d => d.id === id);
-        data.splice(idx, 1);
-        update(main, scope);
-    },
-    select(id) {
-        scope.selected = id;
-        update(main, scope);
-    },
-    selected: -1,
-    data: [],
-};
-
+const state = State(update);
 const main = document.getElementById('container');
-update(main, scope);
 
-function update(
-  where,
-  {data, selected, run, runLots, add, update, clear, swapRows, interact}
-) {
-  render(where, html`
+update(state);
+
+function update(state) {
+  render(main, html`
   <div class="container">
-    <div class="jumbotron">
-      <div class="row">
-        <div class="col-md-6">
-          <h1>lighterhtml keyed</h1>
-        </div>
-        <div class="col-md-6">
-          <div class="row">
-            <div class="col-sm-6 smallpad">
-              <button type="button" class="btn btn-primary btn-block"
-                      id="run" onclick=${run}>Create 1,000 rows</button>
-            </div>
-            <div class="col-sm-6 smallpad">
-              <button type="button" class="btn btn-primary btn-block"
-                      id="runlots" onclick=${runLots}>Create 10,000 rows</button>
-            </div>
-            <div class="col-sm-6 smallpad">
-              <button type="button" class="btn btn-primary btn-block"
-                      id="add" onclick=${add}>Append 1,000 rows</button>
-            </div>
-            <div class="col-sm-6 smallpad">
-              <button type="button" class="btn btn-primary btn-block"
-                      id="update" onclick=${update}>Update every 10th row</button>
-            </div>
-            <div class="col-sm-6 smallpad">
-              <button type="button" class="btn btn-primary btn-block"
-                      id="clear" onclick=${clear}>Clear</button>
-            </div>
-            <div class="col-sm-6 smallpad">
-              <button type="button" class="btn btn-primary btn-block"
-                      id="swaprows" onclick=${swapRows}>Swap Rows</button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <table onclick=${interact} class="table table-hover table-striped test-data">
-      <tbody>${
-      data.map(item => {
-        const {id, label} = item;
-        return html.for(item)`
-        <tr id=${id} class=${id === selected ? 'danger' : ''}>
-          <td class="col-md-1">${id}</td>
-          <td class="col-md-4">
-            <a data-action='select'>${label}</a>
-          </td>
-          <td class="col-md-1">
-            <a data-action='delete'>
-              <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-            </a>
-          </td>
-          <td class="col-md-6"></td>
-        </tr>`;
-      })
-      }</tbody>
-    </table>
-    <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
+    ${Jumbotron(state)}
+    ${Table(state)}
+    <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true" />
   </div>`);
 }

--- a/frameworks/keyed/lighterhtml/src/jumbotron.js
+++ b/frameworks/keyed/lighterhtml/src/jumbotron.js
@@ -1,0 +1,39 @@
+import {html} from 'lighterhtml';
+
+export default ({run, runLots, add, update, clear, swapRows}) => html`
+  <div class="jumbotron">
+    <div class="row">
+      <div class="col-md-6">
+        <h1>lighterhtml keyed</h1>
+      </div>
+      <div class="col-md-6">
+        <div class="row">
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block"
+                    id="run" onclick=${run}>Create 1,000 rows</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block"
+                    id="runlots" onclick=${runLots}>Create 10,000 rows</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block"
+                    id="add" onclick=${add}>Append 1,000 rows</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block"
+                    id="update" onclick=${update}>Update every 10th row</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block"
+                    id="clear" onclick=${clear}>Clear</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block"
+                    id="swaprows" onclick=${swapRows}>Swap Rows</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+`;

--- a/frameworks/keyed/lighterhtml/src/table.js
+++ b/frameworks/keyed/lighterhtml/src/table.js
@@ -1,0 +1,34 @@
+import {html} from 'lighterhtml';
+
+const click = ({currentTarget, target}) => {
+  const a = target.closest('a');
+  const {action} = a.dataset;
+  currentTarget.props[action](+a.closest('tr').id);
+};
+
+export default (state) => {
+  const {data, selected} = state;
+  return html`
+    <table onclick=${click} props=${state}
+      class="table table-hover table-striped test-data">
+      <tbody>${
+      data.map(item => {
+        const {id, label} = item;
+        return html.for(data, id)`
+        <tr id=${id} class=${id === selected ? 'danger' : ''}>
+          <td class="col-md-1">${id}</td>
+          <td class="col-md-4">
+            <a data-action="select">${label}</a>
+          </td>
+          <td class="col-md-1">
+            <a data-action="remove">
+              <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+            </a>
+          </td>
+          <td class="col-md-6" />
+        </tr>`;
+      })
+      }</tbody>
+    </table>
+  `;
+};

--- a/frameworks/non-keyed/lighterhtml/package.json
+++ b/frameworks/non-keyed/lighterhtml/package.json
@@ -24,11 +24,12 @@
   },
   "homepage": "https://github.com/krausest/js-framework-benchmark#readme",
   "dependencies": {
+    "js-framework-benchmark-utils": "0.2.5",
     "lighterhtml": "2.0.7"
   },
   "devDependencies": {
     "@ungap/degap": "^0.1.4",
-    "rollup": "^1.27.5",
+    "rollup": "^1.27.6",
     "rollup-plugin-includepaths": "^0.2.3",
     "rollup-plugin-minify-html-literals": "^1.2.2",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/frameworks/non-keyed/lighterhtml/rollup.config.js
+++ b/frameworks/non-keyed/lighterhtml/rollup.config.js
@@ -6,7 +6,13 @@ import { terser } from 'rollup-plugin-terser';
 export default {
   input: 'src/index.js',
   plugins: [
-    minifyHTML(),
+    minifyHTML({
+      options: {
+        minifyOptions: {
+          keepClosingSlash: true
+        }
+      }
+    }),
     includePaths({
       include: {
         "@ungap/create-content": "./node_modules/@ungap/degap/create-content.js",

--- a/frameworks/non-keyed/lighterhtml/src/index.js
+++ b/frameworks/non-keyed/lighterhtml/src/index.js
@@ -1,135 +1,19 @@
-import { html, render } from '../node_modules/lighterhtml/esm/index.js';
+import {State} from 'js-framework-benchmark-utils';
+import {html, render} from 'lighterhtml';
 
-let did = 1;
-const buildData = (count) => {
-    const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"];
-    const colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"];
-    const nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
-    const data = [];
-    for (let i = 0; i < count; i++) {
-        data.push({
-            id: did++,
-            label: adjectives[_random(adjectives.length)] + " " + colours[_random(colours.length)] + " " + nouns[_random(nouns.length)]
-        });
-    }
-    return data;
-};
+import Jumbotron from './jumbotron.js';
+import Table from './table.js';
 
-const _random = max => Math.round(Math.random() * 1000) % max;
-
-const scope = {
-    add() {
-        scope.data = scope.data.concat(buildData(1000));
-        update(main, scope);
-    },
-    run() {
-        scope.data = buildData(1000);
-        update(main, scope);
-    },
-    runLots() {
-        scope.data = buildData(10000);
-        update(main, scope);
-    },
-    clear() {
-        scope.data = [];
-        update(main, scope);
-    },
-    update() {
-        const {data} = scope;
-        for (let i = 0, {length} = data; i < length; i += 10)
-            data[i].label += ' !!!';
-        update(main, scope);
-    },
-    swapRows() {
-        const {data} = scope;
-        if (data.length > 998) {
-            const tmp = data[1];
-            data[1] = data[998];
-            data[998] = tmp;
-        }
-        update(main, scope);
-    },
-    interact(event) {
-      event.preventDefault();
-      const a = event.target.closest('a');
-      const id = parseInt(a.closest('tr').id, 10);
-      scope[a.dataset.action](id);
-    },
-    delete(id) {
-        const {data} = scope;
-        const idx = data.findIndex(d => d.id === id);
-        data.splice(idx, 1);
-        update(main, scope);
-    },
-    select(id) {
-        scope.selected = id;
-        update(main, scope);
-    },
-    selected: -1,
-    data: [],
-};
-
+const state = State(update);
 const main = document.getElementById('container');
-update(main, scope);
 
-function update(
-  where,
-  {data, selected, run, runLots, add, update, clear, swapRows, interact}
-) {
-  render(where, html`
+update(state);
+
+function update(state) {
+  render(main, html`
   <div class="container">
-    <div class="jumbotron">
-      <div class="row">
-        <div class="col-md-6">
-          <h1>lighterhtml non-keyed</h1>
-        </div>
-        <div class="col-md-6">
-          <div class="row">
-            <div class="col-sm-6 smallpad">
-              <button type="button" class="btn btn-primary btn-block"
-                      id="run" onclick=${run}>Create 1,000 rows</button>
-            </div>
-            <div class="col-sm-6 smallpad">
-              <button type="button" class="btn btn-primary btn-block"
-                      id="runlots" onclick=${runLots}>Create 10,000 rows</button>
-            </div>
-            <div class="col-sm-6 smallpad">
-              <button type="button" class="btn btn-primary btn-block"
-                      id="add" onclick=${add}>Append 1,000 rows</button>
-            </div>
-            <div class="col-sm-6 smallpad">
-              <button type="button" class="btn btn-primary btn-block"
-                      id="update" onclick=${update}>Update every 10th row</button>
-            </div>
-            <div class="col-sm-6 smallpad">
-              <button type="button" class="btn btn-primary btn-block"
-                      id="clear" onclick=${clear}>Clear</button>
-            </div>
-            <div class="col-sm-6 smallpad">
-              <button type="button" class="btn btn-primary btn-block"
-                      id="swaprows" onclick=${swapRows}>Swap Rows</button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <table onclick=${interact} class="table table-hover table-striped test-data">
-      <tbody>${data.map(({id, label}) => html`
-        <tr id=${id} class=${id === selected ? 'danger' : ''}>
-          <td class="col-md-1">${id}</td>
-          <td class="col-md-4">
-            <a data-action='select'>${label}</a>
-          </td>
-          <td class="col-md-1">
-            <a data-action='delete'>
-              <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-            </a>
-          </td>
-          <td class="col-md-6"></td>
-        </tr>`)
-      }
-      </tbody>
-    </table>
-    <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
+    ${Jumbotron(state)}
+    ${Table(state)}
+    <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true" />
   </div>`);
 }

--- a/frameworks/non-keyed/lighterhtml/src/jumbotron.js
+++ b/frameworks/non-keyed/lighterhtml/src/jumbotron.js
@@ -1,0 +1,39 @@
+import {html} from 'lighterhtml';
+
+export default ({run, runLots, add, update, clear, swapRows}) => html`
+  <div class="jumbotron">
+    <div class="row">
+      <div class="col-md-6">
+        <h1>lighterhtml non-keyed</h1>
+      </div>
+      <div class="col-md-6">
+        <div class="row">
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block"
+                    id="run" onclick=${run}>Create 1,000 rows</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block"
+                    id="runlots" onclick=${runLots}>Create 10,000 rows</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block"
+                    id="add" onclick=${add}>Append 1,000 rows</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block"
+                    id="update" onclick=${update}>Update every 10th row</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block"
+                    id="clear" onclick=${clear}>Clear</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block"
+                    id="swaprows" onclick=${swapRows}>Swap Rows</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+`;

--- a/frameworks/non-keyed/lighterhtml/src/table.js
+++ b/frameworks/non-keyed/lighterhtml/src/table.js
@@ -1,0 +1,32 @@
+import {html} from 'lighterhtml';
+
+const click = ({currentTarget, target}) => {
+  const a = target.closest('a');
+  const {action} = a.dataset;
+  currentTarget.props[action](+a.closest('tr').id);
+};
+
+export default (state) => {
+  const {data, selected} = state;
+  return html`
+    <table onclick=${click} props=${state}
+      class="table table-hover table-striped test-data">
+      <tbody>${
+      data.map(({id, label}) => html`
+        <tr id=${id} class=${id === selected ? 'danger' : ''}>
+          <td class="col-md-1">${id}</td>
+          <td class="col-md-4">
+            <a data-action="select">${label}</a>
+          </td>
+          <td class="col-md-1">
+            <a data-action="remove">
+              <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+            </a>
+          </td>
+          <td class="col-md-6" />
+        </tr>
+      `)
+      }</tbody>
+    </table>
+  `;
+};


### PR DESCRIPTION
This is the last thing I can change to have a better comparison (as in: more fair one).

As every other competing framework is using `item.id` to reference rows, and as each item lives as long as the database has it, I've finally found a way to not create O(n) WeakMap references, but just O(1) related to the data.

This provides the possibility to use the `item.id` in _lighterhtml_ too (and every other framework of mine, PRs will follow) so that instead of benchmarking WeakMap performance, we can now compare raw libraries logic/core/engines.

As result, and since there's literally nothing else I can do to make it faster so this is really my last update 'til 2020, the new keyed test drops the infamous _selectRow_ slowdown, placing _lighterhtml_ way up in the table.

![EKh5_EuWsAAkd5y](https://user-images.githubusercontent.com/85749/69858920-5a23a780-1293-11ea-9a7a-62d342a35363.png)

Once again, thanks a lot for this benchmark, as it gave me the opportunity to learn all possible bottlenecks to boost up real world applications (and as there's nothing else I can do, I won't torture you anymore with this library).

Best Regards.