### PR TITLE
Use Riot.js shouldUpdate to avoid unecessary updates

### DIFF
--- a/frameworks/keyed/riot/package.json
+++ b/frameworks/keyed/riot/package.json
@@ -10,12 +10,12 @@
     "build-prod": "webpack -p"
   },
   "devDependencies": {
-    "@riotjs/compiler": "4.5.4",
+    "@riotjs/compiler": "4.5.5",
     "@riotjs/webpack-loader": "4.0.1",
-    "webpack": "4.41.4",
+    "webpack": "4.41.5",
     "webpack-cli": "3.3.10"
   },
   "dependencies": {
-    "riot": "4.8.0"
+    "riot": "4.8.2"
   }
 }

--- a/frameworks/keyed/riot/package.json
+++ b/frameworks/keyed/riot/package.json
@@ -16,6 +16,6 @@
     "webpack-cli": "3.3.10"
   },
   "dependencies": {
-    "riot": "4.8.2"
+    "riot": "4.8.3"
   }
 }

--- a/frameworks/keyed/riot/src/app.riot
+++ b/frameworks/keyed/riot/src/app.riot
@@ -41,22 +41,28 @@
     </div>
     <table class='table table-hover table-striped test-data'>
       <tbody>
-        <tr each={ row in state.rows } key={ row.id } class={ rowClass(row) }>
-          <td class='col-md-1'>{ row.id }</td>
-          <td class='col-md-4'>
-            <a onclick={ () => select(row) }>{ row.label }</a>
-          </td>
-          <td class='col-md-1'>
-            <a onclick={ () => remove(row) }><span class='glyphicon glyphicon-remove' aria-hidden='true'></span></a>
-          </td>
-          <td class='col-md-6'></td>
+        <tr
+          is='row'
+          each={row in state.rows}
+          key={row.id}
+          {...{
+            row,
+            removeRow: removeRow(row),
+            selectRow: selectRow(row),
+            class: rowClass(row)
+          }}
+          >
         </tr>
       </tbody>
     </table>
     <span class='preloadicon glyphicon glyphicon-remove' aria-hidden='true'></span>
   </div>
   <script>
+    import Row from './row.riot'
     export default {
+      components: {
+        Row
+      },
       onBeforeMount(props) {
         this.store = props.store
         this.state = {
@@ -79,17 +85,21 @@
         this.renderWithNewState()
         stopMeasure()
       },
-      remove(item) {
-        startMeasure('remove')
-        this.store.delete(item.id)
-        this.renderWithNewState()
-        stopMeasure()
+      removeRow(item) {
+        return () => {
+          startMeasure('remove')
+          this.store.delete(item.id)
+          this.renderWithNewState()
+          stopMeasure()
+        }
       },
-      select(item) {
-        startMeasure('select')
-        this.store.select(item.id)
-        this.renderWithNewState()
-        stopMeasure()
+      selectRow(item) {
+        return () => {
+          startMeasure('select')
+          this.store.select(item.id)
+          this.renderWithNewState()
+          stopMeasure()
+        }
       },
       run() {
         startMeasure('run')

--- a/frameworks/keyed/riot/src/app.riot
+++ b/frameworks/keyed/riot/src/app.riot
@@ -47,8 +47,8 @@
           key={row.id}
           {...{
             row,
-            removeRow: removeRow(row),
-            selectRow: selectRow(row),
+            remove,
+            select,
             class: rowClass(row)
           }}
           >
@@ -85,7 +85,7 @@
         this.renderWithNewState()
         stopMeasure()
       },
-      removeRow(item) {
+      remove(item) {
         return () => {
           startMeasure('remove')
           this.store.delete(item.id)
@@ -93,7 +93,7 @@
           stopMeasure()
         }
       },
-      selectRow(item) {
+      select(item) {
         return () => {
           startMeasure('select')
           this.store.select(item.id)

--- a/frameworks/keyed/riot/src/row.riot
+++ b/frameworks/keyed/riot/src/row.riot
@@ -1,10 +1,10 @@
 <row>
   <td class='col-md-1'>{ props.row.id }</td>
   <td class='col-md-4'>
-    <a onclick={ props.selectRow }>{ props.row.label }</a>
+    <a onclick={ props.select(props.row) }>{ props.row.label }</a>
   </td>
   <td class='col-md-1'>
-    <a onclick={ props.removeRow }><span class='glyphicon glyphicon-remove' aria-hidden='true'></span></a>
+    <a onclick={ props.remove(props.row) }><span class='glyphicon glyphicon-remove' aria-hidden='true'></span></a>
   </td>
   <td class='col-md-6'></td>
 

--- a/frameworks/keyed/riot/src/row.riot
+++ b/frameworks/keyed/riot/src/row.riot
@@ -1,0 +1,18 @@
+<row>
+  <td class='col-md-1'>{ props.row.id }</td>
+  <td class='col-md-4'>
+    <a onclick={ props.selectRow }>{ props.row.label }</a>
+  </td>
+  <td class='col-md-1'>
+    <a onclick={ props.removeRow }><span class='glyphicon glyphicon-remove' aria-hidden='true'></span></a>
+  </td>
+  <td class='col-md-6'></td>
+
+  <script>
+    export default {
+      shouldUpdate(oldProps, newProps) {
+        return oldProps.row !== newProps.row
+      }
+    }
+  </script>
+</row>

--- a/frameworks/non-keyed/riot/package.json
+++ b/frameworks/non-keyed/riot/package.json
@@ -10,12 +10,12 @@
     "build-prod": "webpack -p"
   },
   "devDependencies": {
-    "@riotjs/compiler": "4.5.4",
+    "@riotjs/compiler": "4.5.5",
     "@riotjs/webpack-loader": "4.0.1",
-    "webpack": "4.41.4",
+    "webpack": "4.41.5",
     "webpack-cli": "3.3.10"
   },
   "dependencies": {
-    "riot": "4.8.0"
+    "riot": "4.8.2"
   }
 }

--- a/frameworks/non-keyed/riot/package.json
+++ b/frameworks/non-keyed/riot/package.json
@@ -16,6 +16,6 @@
     "webpack-cli": "3.3.10"
   },
   "dependencies": {
-    "riot": "4.8.2"
+    "riot": "4.8.3"
   }
 }

--- a/frameworks/non-keyed/riot/src/app.riot
+++ b/frameworks/non-keyed/riot/src/app.riot
@@ -41,22 +41,28 @@
     </div>
     <table class='table table-hover table-striped test-data'>
       <tbody>
-        <tr each={ row in state.rows } class={ rowClass(row) }>
-          <td class='col-md-1'>{ row.id }</td>
-          <td class='col-md-4'>
-            <a onclick={ () => select(row) }>{ row.label }</a>
-          </td>
-          <td class='col-md-1'>
-            <a onclick={ () => remove(row) }><span class='glyphicon glyphicon-remove' aria-hidden='true'></span></a>
-          </td>
-          <td class='col-md-6'></td>
+        <tr
+          is='row'
+          each={row in state.rows}
+          key={row.id}
+          {...{
+            row,
+            removeRow: removeRow(row),
+            selectRow: selectRow(row),
+            class: rowClass(row)
+          }}
+          >
         </tr>
       </tbody>
     </table>
     <span class='preloadicon glyphicon glyphicon-remove' aria-hidden='true'></span>
   </div>
   <script>
+    import Row from './row.riot'
     export default {
+      components: {
+        Row
+      },
       onBeforeMount(props) {
         this.store = props.store
         this.state = {
@@ -79,17 +85,21 @@
         this.renderWithNewState()
         stopMeasure()
       },
-      remove(item) {
-        startMeasure('remove')
-        this.store.delete(item.id)
-        this.renderWithNewState()
-        stopMeasure()
+      removeRow(item) {
+        return () => {
+          startMeasure('remove')
+          this.store.delete(item.id)
+          this.renderWithNewState()
+          stopMeasure()
+        }
       },
-      select(item) {
-        startMeasure('select')
-        this.store.select(item.id)
-        this.renderWithNewState()
-        stopMeasure()
+      selectRow(item) {
+        return () => {
+          startMeasure('select')
+          this.store.select(item.id)
+          this.renderWithNewState()
+          stopMeasure()
+        }
       },
       run() {
         startMeasure('run')

--- a/frameworks/non-keyed/riot/src/app.riot
+++ b/frameworks/non-keyed/riot/src/app.riot
@@ -44,11 +44,10 @@
         <tr
           is='row'
           each={row in state.rows}
-          key={row.id}
           {...{
             row,
-            removeRow: removeRow(row),
-            selectRow: selectRow(row),
+            remove,
+            select,
             class: rowClass(row)
           }}
           >
@@ -85,7 +84,7 @@
         this.renderWithNewState()
         stopMeasure()
       },
-      removeRow(item) {
+      remove(item) {
         return () => {
           startMeasure('remove')
           this.store.delete(item.id)
@@ -93,7 +92,7 @@
           stopMeasure()
         }
       },
-      selectRow(item) {
+      select(item) {
         return () => {
           startMeasure('select')
           this.store.select(item.id)

--- a/frameworks/non-keyed/riot/src/row.riot
+++ b/frameworks/non-keyed/riot/src/row.riot
@@ -1,10 +1,10 @@
 <row>
   <td class='col-md-1'>{ props.row.id }</td>
   <td class='col-md-4'>
-    <a onclick={ props.selectRow }>{ props.row.label }</a>
+    <a onclick={ props.select(props.row) }>{ props.row.label }</a>
   </td>
   <td class='col-md-1'>
-    <a onclick={ props.removeRow }><span class='glyphicon glyphicon-remove' aria-hidden='true'></span></a>
+    <a onclick={ props.remove(props.row) }><span class='glyphicon glyphicon-remove' aria-hidden='true'></span></a>
   </td>
   <td class='col-md-6'></td>
 

--- a/frameworks/non-keyed/riot/src/row.riot
+++ b/frameworks/non-keyed/riot/src/row.riot
@@ -1,0 +1,18 @@
+<row>
+  <td class='col-md-1'>{ props.row.id }</td>
+  <td class='col-md-4'>
+    <a onclick={ props.selectRow }>{ props.row.label }</a>
+  </td>
+  <td class='col-md-1'>
+    <a onclick={ props.removeRow }><span class='glyphicon glyphicon-remove' aria-hidden='true'></span></a>
+  </td>
+  <td class='col-md-6'></td>
+
+  <script>
+    export default {
+      shouldUpdate(oldProps, newProps) {
+        return oldProps.row !== newProps.row
+      }
+    }
+  </script>
+</row>


### PR DESCRIPTION
I have seen that many other frameworks use the `shouldComponentUpdate`  to improve the rendering performance I thought it wasn't allowed so now I have implemented it in Riot.js as well.