### PR TITLE
update ractive keyed row swap per #694

### DIFF
--- a/frameworks/keyed/ractive/src/main.ractive.html
+++ b/frameworks/keyed/ractive/src/main.ractive.html
@@ -92,10 +92,12 @@
                 that.set("selected", undefined);
             });
             this.on('swapRows', function (event) {
-                if(this.get('data').length > 998) {
-                    var a = this.get('data')[1];
-                    this.splice('data', 1, 1, this.get('data')[998]);
-                    this.splice('data', 998, 1, a);
+                const data = this.get('data');
+                if (data.length > 998) {
+                    const a = data[1];
+                    data.splice(1, 1, data[998]);
+                    data.splice(998, 1, a);
+                    this.set('data', data, { shuffle: true });
                 }
             });
         },


### PR DESCRIPTION
Prior to 0.10, ractive didn't really support moving more than one item at a time, which means that the row swap only really worked for one item and the other was recreated. This is now possible, though not exactly an optimized case.

See #694 