### PR TITLE
Add VueRX JSX

### DIFF
--- a/frameworks/keyed/vuerx-jsx/index.html
+++ b/frameworks/keyed/vuerx-jsx/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>VueRX JSX-keyed</title>
+    <link href="/css/currentStyle.css" rel="stylesheet"/>
+</head>
+<body>
+<div id='main'></div>
+<script src='dist/main.js'></script>
+</body>
+</html>

--- a/frameworks/keyed/vuerx-jsx/package.json
+++ b/frameworks/keyed/vuerx-jsx/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "js-framework-benchmark-solid",
+  "version": "0.0.2",
+  "main": "dist/main.js",
+  "js-framework-benchmark": {
+    "frameworkVersionFromPackage": "vuerx-jsx"
+  },
+  "scripts": {
+    "build-dev": "rollup -c -w",
+    "build-prod": "rollup -c --environment production"
+  },
+  "author": "Ryan Carniato",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "dependencies": {
+    "vuerx-jsx": "0.0.2",
+    "@vue/reactivity": "3.0.0-beta.13"
+  },
+  "devDependencies": {
+    "@babel/core": "7.9.0",
+    "@rollup/plugin-node-resolve": "7.1.1",
+    "@rollup/plugin-replace": "2.3.2",
+    "babel-plugin-jsx-dom-expressions": "0.18.1",
+    "rollup": "2.10.2",
+    "rollup-plugin-babel": "4.4.0",
+    "rollup-plugin-terser": "5.3.0"
+  }
+}

--- a/frameworks/keyed/vuerx-jsx/rollup.config.js
+++ b/frameworks/keyed/vuerx-jsx/rollup.config.js
@@ -1,0 +1,28 @@
+import resolve from "@rollup/plugin-node-resolve";
+import replace from "@rollup/plugin-replace";
+import babel from "rollup-plugin-babel";
+import { terser } from "rollup-plugin-terser";
+
+const plugins = [
+  replace({
+    "process.env.NODE_ENV": JSON.stringify("production")
+  }),
+  babel({
+    exclude: "node_modules/**",
+    plugins: [["jsx-dom-expressions", { moduleName: "vuerx-jsx" }]],
+  }),
+  resolve({ extensions: [".js", ".jsx"] }),
+];
+
+if (process.env.production) {
+  plugins.push(terser());
+}
+
+export default {
+  input: "src/main.jsx",
+  output: {
+    file: "dist/main.js",
+    format: "iife",
+  },
+  plugins
+};

--- a/frameworks/keyed/vuerx-jsx/src/main.jsx
+++ b/frameworks/keyed/vuerx-jsx/src/main.jsx
@@ -1,0 +1,118 @@
+import { ref, computed } from "@vue/reactivity";
+import { render, map, effect, untracked } from 'vuerx-jsx';
+
+let idCounter = 1;
+const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"],
+  colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"],
+  nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+
+function _random (max) { return Math.round(Math.random() * 1000) % max; };
+
+function buildData(count) {
+  let data = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const label = `${adjectives[_random(adjectives.length)]} ${colours[_random(colours.length)]} ${nouns[_random(nouns.length)]}`;
+    data[i] = {
+      id: idCounter++,
+      label
+    }
+  }
+  return data;
+}
+
+const Button = ({ id, text, fn }) =>
+  <div class='col-sm-6 smallpad'>
+    <button id={ id } class='btn btn-primary btn-block' type='button' onClick={ fn }>{ text }</button>
+  </div>
+
+const List = props => {
+  const mapped = computed(map(() => props.each, props.children));
+  effect(tr => {
+    let i, s = props.selected;
+    untracked(() => {
+      if (tr) tr.className = "";
+      if ((tr = s && (i = props.each.findIndex(el => el.id === s)) > -1 && mapped.value[i]))
+        tr.className = "danger";
+    });
+    return tr;
+  });
+  return () => mapped.value;
+};
+
+const App = () => {
+  let rowId;
+  const data = ref([]),
+    selected = ref(null);
+
+  return <div class='container'>
+    <div class='jumbotron'><div class='row'>
+      <div class='col-md-6'><h1>VueRX JSX Keyed</h1></div>
+      <div class='col-md-6'><div class='row'>
+        <Button id='run' text='Create 1,000 rows' fn={ run } />
+        <Button id='runlots' text='Create 10,000 rows' fn={ runLots } />
+        <Button id='add' text='Append 1,000 rows' fn={ add } />
+        <Button id='update' text='Update every 10th row' fn={ update } />
+        <Button id='clear' text='Clear' fn={ clear } />
+        <Button id='swaprows' text='Swap Rows' fn={ swapRows } />
+      </div></div>
+    </div></div>
+    <table class='table table-hover table-striped test-data'><tbody>
+      <List each={ data.value } selected={ selected.value }>{ row => (
+        rowId = row.id,
+        <tr>
+          <td class='col-md-1' textContent={ rowId } />
+          <td class='col-md-4'><a onClick={[setSelected, rowId]} textContent={ row.label } /></td>
+          <td class='col-md-1'><a onClick={[remove, rowId]}><span class='glyphicon glyphicon-remove' aria-hidden="true" /></a></td>
+          <td class='col-md-6'/>
+        </tr>
+      )}</List>
+    </tbody></table>
+    <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
+  </div>;
+
+  function setSelected(id) { selected.value = id; }
+
+  function remove(id) {
+    const d = data.value.slice();
+    d.splice(d.findIndex(d => d.id === id), 1);
+    data.value = d;
+  }
+
+  function run() {
+    data.value = buildData(1000);
+    selected.value = null;
+  }
+
+  function runLots() {
+    data.value = buildData(10000);
+    selected.value = null;
+  }
+
+  function add() { data.value = data.value.concat(buildData(1000)); }
+
+  function update() {
+    const d = data.value;
+    let index = 0;
+    while (index < d.length) {
+      d[index].label += ' !!!';
+      index += 10;
+    }
+  }
+
+  function swapRows() {
+    const d = data.value.slice();
+    if (d.length > 998) {
+      let tmp = d[1];
+      d[1] = d[998];
+      d[998] = tmp;
+      data.value = d;
+    }
+  }
+
+  function clear() {
+    data.value = [];
+    selected.value = null;
+  }
+}
+
+render(App, document.getElementById("main"));


### PR DESCRIPTION
@yyx990803 posted that Vue 3's Reactive library was stand-alone so I couldn't help myself. Let's see how it does when not tethered to Vue 3's hybrid VDOM solution. Introducing [VueRX JSX](https://github.com/ryansolid/vuerx-jsx) (Vue JSX was already taken). It uses the DOM Expressions library to compile JSX down to optimized DOM statements and reactive bindings.

Quick tests show this Vue variation outperforms MobX, but does it have what it takes to go up against the VDOM heavy-weights like Inferno or ivi? We shall see.