### PR TITLE
Dojo: Update to dojo 7 and fix non-keyed impl

### DIFF
--- a/frameworks/keyed/dojo/package.json
+++ b/frameworks/keyed/dojo/package.json
@@ -4,17 +4,19 @@
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "@dojo/framework",
     "customURL": "/output/dist",
-    "issues": [694]
+    "issues": [
+      694
+    ]
   },
   "scripts": {
     "build-prod": "./node_modules/.bin/dojo build"
   },
   "dependencies": {
-    "@dojo/framework": "^6.0.0"
+    "@dojo/framework": "^7.0.0"
   },
   "devDependencies": {
-    "@dojo/cli": "^6.0.0",
-    "@dojo/cli-build-app": "^6.0.0",
+    "@dojo/cli": "^7.0.0",
+    "@dojo/cli-build-app": "^7.0.0",
     "typescript": "3.5.2"
   }
 }

--- a/frameworks/keyed/dojo/src/Buttons.ts
+++ b/frameworks/keyed/dojo/src/Buttons.ts
@@ -1,4 +1,4 @@
-import { create, w, v } from '@dojo/framework/core/vdom'
+import { create, w, v, diffProperty } from '@dojo/framework/core/vdom'
 import Button from './Button';
 
 export interface ButtonConfig {
@@ -11,14 +11,15 @@ export interface ButtonsProperties {
 	buttonConfigs: ButtonConfig[];
 }
 
-const factory = create().properties<ButtonsProperties>();
+const factory = create({ diffProperty }).properties<ButtonsProperties>();
 
-export default factory(function Buttons({ properties }) {
+export default factory(function Buttons({ properties, middleware: { diffProperty } }) {
+	diffProperty('buttonConfigs', properties, () => {});
 	const { buttonConfigs } = properties();
 	return v('div', { classes: [ 'jumbotron' ] }, [
 		v('div', { classes: [ 'row' ] }, [
 			v('div', { classes: [ 'col-md-6' ] }, [
-				v('h1', ['Dojo v6.0.0'])
+				v('h1', ['Dojo v7'])
 			]),
 			v('div', { classes: [ 'col-md-6' ] }, buttonConfigs.map(({ id, label, onClick }) => {
 				return w(Button, { key: id, id, label, onClick });

--- a/frameworks/non-keyed/dojo/package.json
+++ b/frameworks/non-keyed/dojo/package.json
@@ -9,11 +9,11 @@
     "build-prod": "./node_modules/.bin/dojo build"
   },
   "dependencies": {
-    "@dojo/framework": "^6.0.0"
+    "@dojo/framework": "^7.0.0"
   },
   "devDependencies": {
-    "@dojo/cli": "^6.0.0",
-    "@dojo/cli-build-app": "^6.0.0",
+    "@dojo/cli": "^7.0.0",
+    "@dojo/cli-build-app": "^7.0.0",
     "typescript": "3.5.2"
   }
 }

--- a/frameworks/non-keyed/dojo/src/App.ts
+++ b/frameworks/non-keyed/dojo/src/App.ts
@@ -22,7 +22,7 @@ export default factory(function App({ middleware: { store }}) {
 			return null;
 		}
 		return w(Row, {
-			key,
+			key: item.id,
 			id: item.id,
 			label: item.label,
 			onSelect: store.select

--- a/frameworks/non-keyed/dojo/src/App.ts
+++ b/frameworks/non-keyed/dojo/src/App.ts
@@ -22,10 +22,9 @@ export default factory(function App({ middleware: { store }}) {
 			return null;
 		}
 		return w(Row, {
-			key: item.id,
+			key,
 			id: item.id,
-			label: item.label,
-			onSelect: store.select
+			label: item.label
 		});
 	});
 

--- a/frameworks/non-keyed/dojo/src/Buttons.ts
+++ b/frameworks/non-keyed/dojo/src/Buttons.ts
@@ -1,4 +1,4 @@
-import { create, w, v } from '@dojo/framework/core/vdom'
+import { create, w, v, diffProperty } from '@dojo/framework/core/vdom'
 import Button from './Button';
 
 export interface ButtonConfig {
@@ -11,14 +11,15 @@ export interface ButtonsProperties {
 	buttonConfigs: ButtonConfig[];
 }
 
-const factory = create().properties<ButtonsProperties>();
+const factory = create({ diffProperty }).properties<ButtonsProperties>();
 
-export default factory(function Buttons({ properties }) {
+export default factory(function Buttons({ properties, middleware: { diffProperty } }) {
+	diffProperty('buttonConfigs', properties, () =>{});
 	const { buttonConfigs } = properties();
 	return v('div', { classes: [ 'jumbotron' ] }, [
 		v('div', { classes: [ 'row' ] }, [
 			v('div', { classes: [ 'col-md-6' ] }, [
-				v('h1', ['Dojo v6.0.0'])
+				v('h1', ['Dojo v7'])
 			]),
 			v('div', { classes: [ 'col-md-6' ] }, buttonConfigs.map(({ id, label, onClick }) => {
 				return w(Button, { key: id, id, label, onClick });

--- a/frameworks/non-keyed/dojo/src/Row.ts
+++ b/frameworks/non-keyed/dojo/src/Row.ts
@@ -2,7 +2,6 @@ import { create, v } from '@dojo/framework/core/vdom';
 import store from './Store';
 
 export interface RowProperties {
-	onSelect: Function;
 	id: number;
 	label: string;
 }
@@ -10,15 +9,15 @@ export interface RowProperties {
 const factory = create({ store }).properties<RowProperties>();
 
 export default factory(function Row({ properties, middleware: { store } }) {
-	const { id, label, onSelect } = properties();
+	const { id, key = id, label } = properties();
 
 	return v('tr', {
-		classes: [ store.selected === id && 'danger' ]
+		classes: [ store.selected === key && 'danger' ]
 	}, [
 		v('td', { classes: [ 'col-md-1' ] }, [ `${id}` ]),
 		v('td', { classes: [ 'col-md-4' ] }, [
 			v('a', { onclick: () => {
-				onSelect(id);
+				store.select();
 			} }, [ label ])
 		]),
 		v('td', { classes: [ 'col-md-1' ] }, [

--- a/frameworks/non-keyed/dojo/src/Store.ts
+++ b/frameworks/non-keyed/dojo/src/Store.ts
@@ -153,10 +153,12 @@ export default factory(({ properties, middleware: { invalidator } }) => {
       }
       invalidate();
     },
-    select: (id: number) => {
-      selected && invalidate(selected);
-      invalidate(id);
-      selected = id;
+    select: () => {
+      if (typeof widgetKey === "number") {
+        selected && invalidate(selected);
+        selected = widgetKey;
+        invalidate(widgetKey);
+      }
     },
     runLots: () => {
       idx = 0;
@@ -182,6 +184,7 @@ export default factory(({ properties, middleware: { invalidator } }) => {
         const row = data[second];
         data[second] = data[last];
         data[last] = row;
+        selected = selected === 1 ? 998 : selected === 998 ? 1 : selected;
       }
       ids = new Set(idArray);
       invalidate();


### PR DESCRIPTION
Fixes the non-keyed version of Dojo and also upgrades both version to the latest release (7.0.0).

cc @krausest 

With regards to https://github.com/krausest/js-framework-benchmark/issues/742#issuecomment-634919576, we are working on improving the core support in the rendering engine which hopefully will be available  soon. I tested a draft implementation with the keyed check and it passed so should resolve the issue.

Resolves #742 