### PR TITLE
Fixed MobX benchmark after upgrading by swapping minifier and enabling batching

### DIFF
--- a/frameworks/keyed/react-mobX/package.json
+++ b/frameworks/keyed/react-mobX/package.json
@@ -30,13 +30,14 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "jsx-loader": "0.13.2",
+    "terser-webpack-plugin": "^3.0.6",
     "webpack": "4.16.3",
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {
-    "mobx": "5.0.3",
-    "mobx-react": "5.2.3",
-    "react": "16.4.1",
-    "react-dom": "16.4.1"
+    "mobx": "5.15.4",
+    "mobx-react": "6.2.2",
+    "react": "16.13.1",
+    "react-dom": "16.13.1"
   }
 }

--- a/frameworks/keyed/react-mobX/src/Main.jsx
+++ b/frameworks/keyed/react-mobX/src/Main.jsx
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var ReactDOM = require('react-dom');
+require('mobx-react/batchingForReactDom');
 const {Row} = require('./Row');
 var {observer} = require("mobx-react");
 var {observable, computed} = require ("mobx");

--- a/frameworks/keyed/react-mobX/webpack.config.js
+++ b/frameworks/keyed/react-mobX/webpack.config.js
@@ -1,49 +1,50 @@
-'use strict';
-require("babel-plugin-syntax-jsx")
-var path = require('path')
-var webpack = require('webpack')
+"use strict";
+require("babel-plugin-syntax-jsx");
+var path = require("path");
+var webpack = require("webpack");
+var TerserPlugin = require("terser-webpack-plugin");
 var cache = {};
 var loaders = [
-	{
-		test: /\.jsx$/,
-		loader: 'babel-loader'
-	},
-	{
-		test: /\.es6\.js$/,
-		loader: 'babel-loader'
-	},
-	{
-		test: /\.css$/,
-		loader: 'style-loader!css-loader'
-	}
+  {
+    test: /\.jsx$/,
+    loader: "babel-loader",
+  },
+  {
+    test: /\.es6\.js$/,
+    loader: "babel-loader",
+  },
+  {
+    test: /\.css$/,
+    loader: "style-loader!css-loader",
+  },
 ];
-var extensions = [
-	'.js', '.jsx', '.es6.js'
-];
+var extensions = [".js", ".jsx", ".es6.js"];
 
-module.exports = [{
-	cache: cache,
-	module: {
-		rules: loaders
-	},
-	entry: {
-		main: './src/Main.jsx',
-	},
-	output: {
-		path: path.resolve(__dirname, "dist"),
-		filename: '[name].js'
-	},
-	resolve: {
-		extensions: extensions,
-		modules: [
-			__dirname,
-			path.resolve(__dirname, "src"),
-			"node_modules"
-		]
-	},
-	plugins: [
-		new webpack.DefinePlugin({
-			'process.env.NODE_ENV': '"production"'
-		})
-	]
-}];
+module.exports = [
+  {
+    cache: cache,
+    module: {
+      rules: loaders,
+    },
+    entry: {
+      main: "./src/Main.jsx",
+    },
+    output: {
+      path: path.resolve(__dirname, "dist"),
+      filename: "[name].js",
+    },
+    resolve: {
+      extensions: extensions,
+      modules: [__dirname, path.resolve(__dirname, "src"), "node_modules"],
+    },
+    optimization: {
+      minimize: true,
+      minimizer: [new TerserPlugin()],
+    },
+    plugins: [
+      new webpack.DefinePlugin({
+        "process.env.NODE_ENV": '"production"',
+      }),
+    ],
+  },
+];


### PR DESCRIPTION
This fixes: https://github.com/mobxjs/mobx-react/issues/877

React became really slow after upgrading to 16.6+, which is caused by a bug in the default webpack minifier (https://github.com/facebook/react/issues/13987). This might apply to other React based frameworks as well. 

Also enabled ReactDOM batching support according to best practice. 