### PR TITLE
build & install implementations using lerna

### DIFF
--- a/frameworks/keyed/angular-ng/package.json
+++ b/frameworks/keyed/angular-ng/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular-ng",
+  "name": "js-framework-benchmark-angular-ng",
   "version": "0.0.0",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "@angular/core",

--- a/frameworks/keyed/angular-noopzone/package.json
+++ b/frameworks/keyed/angular-noopzone/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular-closure",
+  "name": "js-framework-benchmark-angular-noopzone",
   "version": "1.0.0",
   "description": "An angular app using closure compiler",
   "js-framework-benchmark": {

--- a/frameworks/keyed/angular-optimized/package.json
+++ b/frameworks/keyed/angular-optimized/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular-closure",
+  "name": "js-framework-benchmark-angular-optimized",
   "version": "1.0.0",
   "description": "An angular app using closure compiler",
   "js-framework-benchmark": {

--- a/frameworks/keyed/angular/package.json
+++ b/frameworks/keyed/angular/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular-closure",
+  "name": "js-framework-benchmark-angular",
   "version": "1.0.0",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "@angular/core"

--- a/frameworks/keyed/angularjs/package.json
+++ b/frameworks/keyed/angularjs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-angular",
+  "name": "js-framework-benchmark-angularjs",
   "version": "1.0.0",
   "description": "Boilerplate for Angular.js",
   "js-framework-benchmark": {

--- a/frameworks/keyed/helix/package.json
+++ b/frameworks/keyed/helix/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "helix",
   "private": true,
   "js-framework-benchmark": {
     "frameworkVersion": "0.0.10"

--- a/frameworks/keyed/marionette-jquery/package.json
+++ b/frameworks/keyed/marionette-jquery/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-marionette",
+  "name": "js-framework-benchmark-marionette-jquery",
   "version": "1.0.0",
   "description": "Marionette v4.0.0 with jQuery",
   "main": "index.js",

--- a/frameworks/keyed/nervjs/package.json
+++ b/frameworks/keyed/nervjs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-react-lite",
+  "name": "js-framework-benchmark-nervjs",
   "version": "1.0.0",
   "description": "Benchmark for react-lite framework",
   "js-framework-benchmark": {

--- a/frameworks/keyed/preact/package.json
+++ b/frameworks/keyed/preact/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-react-lite",
+  "name": "js-framework-benchmark-preact",
   "version": "1.0.0",
   "description": "Benchmark for react-lite framework",
   "js-framework-benchmark": {

--- a/frameworks/keyed/react-djinn/package.json
+++ b/frameworks/keyed/react-djinn/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-react",
+  "name": "js-framework-benchmark-react-djinn",
   "version": "1.1.1",
   "description": "React + djinn-state demo",
   "main": "index.js",

--- a/frameworks/keyed/react-mobX/package.json
+++ b/frameworks/keyed/react-mobX/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-react",
+  "name": "js-framework-benchmark-react-mobx",
   "version": "1.1.1",
   "description": "React demo",
   "main": "index.js",

--- a/frameworks/keyed/react-redux-combiner/package.json
+++ b/frameworks/keyed/react-redux-combiner/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-react",
+  "name": "js-framework-benchmark-react-redux-combiner",
   "version": "1.0.0",
   "description": "React+redux-combiner demo",
   "main": "index.js",

--- a/frameworks/keyed/react-redux-hooks/package.json
+++ b/frameworks/keyed/react-redux-hooks/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-react",
+  "name": "js-framework-benchmark-react-redux-hooks",
   "version": "1.1.1",
   "description": "React demo",
   "main": "index.js",

--- a/frameworks/keyed/react-redux/package.json
+++ b/frameworks/keyed/react-redux/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-react",
+  "name": "js-framework-benchmark-react-redux",
   "version": "1.1.1",
   "description": "React demo",
   "main": "index.js",

--- a/frameworks/keyed/reagent/package.json
+++ b/frameworks/keyed/reagent/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "reagent",
   "private": true,
   "js-framework-benchmark": {
     "frameworkVersion": "0.10"

--- a/frameworks/keyed/vanillajs-1/package.json
+++ b/frameworks/keyed/vanillajs-1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-vanillajs",
+  "name": "js-framework-benchmark-vanillajs-1",
   "version": "1.1.1",
   "description": "Vanilla.JS demo",
   "main": "index.js",

--- a/frameworks/keyed/vanillajs/index.html
+++ b/frameworks/keyed/vanillajs/index.html
@@ -44,6 +44,6 @@
         <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
     </div>
 </div>
-<script src='dist/main.js'></script>
+<script src='src/Main.js'></script>
 </body>
 </html>

--- a/frameworks/keyed/vue-next/package.json
+++ b/frameworks/keyed/vue-next/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-vue",
+  "name": "js-framework-benchmark-vue-next",
   "version": "1.0.0",
   "description": "Benchmark for vue.js framework",
   "js-framework-benchmark": {

--- a/frameworks/keyed/vuerx-jsx/package.json
+++ b/frameworks/keyed/vuerx-jsx/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-solid",
+  "name": "js-framework-benchmark-vuerx-jsx",
   "version": "0.0.2",
   "main": "dist/main.js",
   "js-framework-benchmark": {

--- a/frameworks/keyed/yew/package.json
+++ b/frameworks/keyed/yew/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-yew",
+  "name": "js-framework-benchmark-non-keyed-yew",
   "version": "1.0.0",
   "description": "Benchmark for Yew",
   "license": "ISC",

--- a/frameworks/non-keyed/angular/package.json
+++ b/frameworks/non-keyed/angular/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular-closure",
+  "name": "js-framework-benchmark-non-keyed-angular",
   "version": "1.0.0",
   "description": "An angular app using closure compiler",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/apprun/package.json
+++ b/frameworks/non-keyed/apprun/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-apprun-v2.23.10",
+  "name": "js-framework-benchmark-non-keyed-apprun-v2.23.10",
   "version": "1.0.0",
   "description": "AppRun demo",
   "main": "index.js",

--- a/frameworks/non-keyed/aurelia/package.json
+++ b/frameworks/non-keyed/aurelia/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-aurelia",
+  "name": "js-framework-benchmark-non-keyed-aurelia",
   "version": "1.0.0",
   "description": "Benchmark for aurelia framework",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/cyclejs-dom/package.json
+++ b/frameworks/non-keyed/cyclejs-dom/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-cyclejs",
+  "name": "js-framework-benchmark-non-keyed-cyclejs",
   "version": "1.0.0",
   "description": "Benchmark for Cycle.js framework",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/domc/package.json
+++ b/frameworks/non-keyed/domc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-domc",
+  "name": "js-framework-benchmark-non-keyed-domc",
   "version": "1.0.0",
   "description": "domc demo",
   "main": "dist/app.min.js",

--- a/frameworks/non-keyed/domdiff/package.json
+++ b/frameworks/non-keyed/domdiff/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-domdiff",
+  "name": "js-framework-benchmark-non-keyed-domdiff",
   "version": "1.0.0",
   "description": "domdiff demo",
   "main": "index.js",

--- a/frameworks/non-keyed/domvm/package.json
+++ b/frameworks/non-keyed/domvm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-domvm-non-keyed",
+  "name": "js-framework-benchmark-non-keyed-domvm-non-keyed",
   "version": "3.4.12-non-keyed",
   "description": "Benchmark for domvm framework (non-keyed)",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/doz/package.json
+++ b/frameworks/non-keyed/doz/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-doz",
+  "name": "js-framework-benchmark-non-keyed-doz",
   "version": "1.0.0",
   "description": "Doz demo",
   "main": "index.js",

--- a/frameworks/non-keyed/elm/package.json
+++ b/frameworks/non-keyed/elm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-elm",
+  "name": "js-framework-benchmark-non-keyed-elm",
   "version": "1.0.0",
   "description": "Elm demo",
   "main": "index.js",

--- a/frameworks/non-keyed/endorphin/package.json
+++ b/frameworks/non-keyed/endorphin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-endorphin",
+  "name": "js-framework-benchmark-non-keyed-endorphin",
   "version": "1.0.0",
   "description": "Boilerplate for endorphin",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/etch/package.json
+++ b/frameworks/non-keyed/etch/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-etch-non-keyed",
+  "name": "js-framework-benchmark-non-keyed-etch-non-keyed",
   "version": "1.0.0",
   "description": "Etch non-keyed demo",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/gruu/package.json
+++ b/frameworks/non-keyed/gruu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-gruu",
+  "name": "js-framework-benchmark-non-keyed-gruu",
   "version": "1.0.0",
   "description": "Gruu demo",
   "main": "src/main.es6.js",

--- a/frameworks/non-keyed/halogen/package.json
+++ b/frameworks/non-keyed/halogen/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-halogen",
+  "name": "js-framework-benchmark-non-keyed-halogen",
   "version": "1.0.0",
   "description": "Purescript Halogen JS Benchmark",
   "main": "index.js",

--- a/frameworks/non-keyed/heresy/package.json
+++ b/frameworks/non-keyed/heresy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-heresy",
+  "name": "js-framework-benchmark-non-keyed-heresy",
   "version": "1.0.0",
   "description": "heresy demo",
   "main": "index.js",

--- a/frameworks/non-keyed/hullo/package.json
+++ b/frameworks/non-keyed/hullo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-hullo",
+  "name": "js-framework-benchmark-non-keyed-hullo",
   "version": "0.8.2",
   "description": "Hullo demo",
   "main": "index.js",

--- a/frameworks/non-keyed/imba/package.json
+++ b/frameworks/non-keyed/imba/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-imba",
+  "name": "js-framework-benchmark-non-keyed-imba",
   "version": "1.0.1",
   "description": "Imba demo",
   "main": "index.js",

--- a/frameworks/non-keyed/incr_dom/package.json
+++ b/frameworks/non-keyed/incr_dom/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-incr_dom",
+  "name": "js-framework-benchmark-non-keyed-incr_dom",
   "version": "1.0.0",
   "description": "Incr_dom version of benchmark",
   "author": "Michael Boulton",

--- a/frameworks/non-keyed/inferno/package.json
+++ b/frameworks/non-keyed/inferno/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-inferno",
+  "name": "js-framework-benchmark-non-keyed-inferno",
   "version": "1.0.0",
   "description": "Benchmark for inferno framework",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/lighterhtml/package.json
+++ b/frameworks/non-keyed/lighterhtml/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-lighterhtml",
+  "name": "js-framework-benchmark-non-keyed-lighterhtml",
   "version": "1.0.0",
   "description": "lighterhtml demo",
   "main": "index.js",

--- a/frameworks/non-keyed/lit-element/package.json
+++ b/frameworks/non-keyed/lit-element/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-lit-element",
+  "name": "js-framework-benchmark-non-keyed-lit-element",
   "version": "1.1.0",
   "description": "lit-element demo",
   "main": "index.js",

--- a/frameworks/non-keyed/lit-html/package.json
+++ b/frameworks/non-keyed/lit-html/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-lit-html",
+  "name": "js-framework-benchmark-non-keyed-lit-html",
   "version": "1.1.0",
   "description": "Lit-HTML demo",
   "main": "index.js",

--- a/frameworks/non-keyed/lite-html/package.json
+++ b/frameworks/non-keyed/lite-html/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-lit-html",
+  "name": "js-framework-benchmark-non-keyed-lite-html",
   "version": "1.0.1",
   "description": "Lite-HTML demo",
   "main": "index.js",

--- a/frameworks/non-keyed/literaljs/package.json
+++ b/frameworks/non-keyed/literaljs/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "js-framework-benchmark-literaljs",
+	"name": "js-framework-benchmark-non-keyed-literaljs",
 	"version": "1.0.0",
 	"description": "Benchmark for LiteralJS framework",
 	"js-framework-benchmark": {

--- a/frameworks/non-keyed/mikado/package.json
+++ b/frameworks/non-keyed/mikado/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "js-framework-benchmark-mikado",
+  "name": "js-framework-benchmark-non-keyed-mikado",
   "homepage": "https://github.com/nextapps-de/mikado/",
   "author": "Nextapps GmbH",
   "license": "Apache-2.0",

--- a/frameworks/non-keyed/miso/package.json
+++ b/frameworks/non-keyed/miso/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-miso-non-keyed",
+  "name": "js-framework-benchmark-non-keyed-miso-non-keyed",
   "version": "1.0.0",
   "description": "Benchmark for miso",
   "author": "Saurabh Nanda",

--- a/frameworks/non-keyed/moon/package.json
+++ b/frameworks/non-keyed/moon/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "js-framework-benchmark-moon",
+	"name": "js-framework-benchmark-non-keyed-moon",
 	"version": "1.0.0",
 	"description": "Benchmark for Moon framework",
 	"js-framework-benchmark": {

--- a/frameworks/non-keyed/neverland/package.json
+++ b/frameworks/non-keyed/neverland/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-neverland",
+  "name": "js-framework-benchmark-non-keyed-neverland",
   "version": "1.0.0",
   "description": "neverland demo",
   "main": "index.js",

--- a/frameworks/non-keyed/polymer/package.json
+++ b/frameworks/non-keyed/polymer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-polymer",
+  "name": "js-framework-benchmark-non-keyed-polymer",
   "version": "1.0.0",
   "description": "Boilerplate for Polymer",
   "scripts": {

--- a/frameworks/non-keyed/ractive/package.json
+++ b/frameworks/non-keyed/ractive/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-ractive",
+  "name": "js-framework-benchmark-non-keyed-ractive",
   "version": "1.0.0",
   "description": "Boilerplate for Ractive.js",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/rawact/package.json
+++ b/frameworks/non-keyed/rawact/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-rawact",
+  "name": "js-framework-benchmark-non-keyed-rawact",
   "version": "1.1.1",
   "description": "Rawact demo",
   "main": "index.js",

--- a/frameworks/non-keyed/react/package.json
+++ b/frameworks/non-keyed/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-react",
+  "name": "js-framework-benchmark-non-keyed-react",
   "version": "1.1.1",
   "description": "React demo",
   "main": "index.js",

--- a/frameworks/non-keyed/redom/package.json
+++ b/frameworks/non-keyed/redom/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-redom",
+  "name": "js-framework-benchmark-non-keyed-redom",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/frameworks/non-keyed/riot/package.json
+++ b/frameworks/non-keyed/riot/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-riot",
+  "name": "js-framework-benchmark-non-keyed-riot",
   "version": "1.0.0",
   "description": "Benchmark for riot framework",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/san/package.json
+++ b/frameworks/non-keyed/san/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-san",
+  "name": "js-framework-benchmark-non-keyed-san",
   "version": "3.9.0",
   "description": "Benchmark for san framework",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/scarletsframe/package.json
+++ b/frameworks/non-keyed/scarletsframe/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-scarletsframe",
+  "name": "js-framework-benchmark-non-keyed-scarletsframe",
   "version": "1.0.2",
   "description": "ScarletsFrame demo",
   "main": "index.js",

--- a/frameworks/non-keyed/seed/package.json
+++ b/frameworks/non-keyed/seed/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-seed",
+  "name": "js-framework-benchmark-non-keyed-seed",
   "version": "1.0.0",
   "description": "Benchmark for Seed",
   "license": "ISC",
@@ -7,9 +7,9 @@
     "frameworkVersion": "0.6.0"
   },
   "scripts": {
-    "build-dev": "rimraf bundled-dist && wasm-pack build --dev --target web --out-name js-framework-benchmark-seed --out-dir bundled-dist && cpr index.html bundled-dist/index.html && rimraf bundled-dist/.gitignore",
+    "build-dev": "rimraf bundled-dist && wasm-pack build --dev --target web --out-name js-framework-benchmark-non-keyed-seed --out-dir bundled-dist && cpr index.html bundled-dist/index.html && rimraf bundled-dist/.gitignore",
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",
-    "build-prod-force": "rustup target add wasm32-unknown-unknown && cargo install wasm-pack && rimraf bundled-dist && wasm-pack build --release --target web --out-name js-framework-benchmark-seed --out-dir bundled-dist && cpr index.html bundled-dist/index.html && rimraf bundled-dist/.gitignore"
+    "build-prod-force": "rustup target add wasm32-unknown-unknown && cargo install wasm-pack && rimraf bundled-dist && wasm-pack build --release --target web --out-name js-framework-benchmark-non-keyed-seed --out-dir bundled-dist && cpr index.html bundled-dist/index.html && rimraf bundled-dist/.gitignore"
   },
   "repository": {
     "type": "git",

--- a/frameworks/non-keyed/sifrr/package.json
+++ b/frameworks/non-keyed/sifrr/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-sifrr",
+  "name": "js-framework-benchmark-non-keyed-sifrr",
   "version": "1.0.0",
   "description": "sifrr demo",
   "main": "dist/app.min.js",

--- a/frameworks/non-keyed/simi/package.json
+++ b/frameworks/non-keyed/simi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-simi",
+  "name": "js-framework-benchmark-non-keyed-simi",
   "version": "0.1.0",
   "description": "Benchmark for Simi",
   "license": "ISC",

--- a/frameworks/non-keyed/simulacra/package.json
+++ b/frameworks/non-keyed/simulacra/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-simulacra",
+  "name": "js-framework-benchmark-non-keyed-simulacra",
   "version": "1.0.0",
   "description": "Benchmark for simulacra.js",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/stage0/package.json
+++ b/frameworks/non-keyed/stage0/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-stage0",
+  "name": "js-framework-benchmark-non-keyed-stage0",
   "version": "1.0.0",
   "description": "stage0 demo",
   "main": "dist/app.min.js",

--- a/frameworks/non-keyed/stdweb/package.json
+++ b/frameworks/non-keyed/stdweb/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-stdweb",
+  "name": "js-framework-benchmark-non-keyed-stdweb",
   "version": "1.0.0",
   "description": "Benchmark for stdweb",
   "license": "ISC",

--- a/frameworks/non-keyed/surplus/package.json
+++ b/frameworks/non-keyed/surplus/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-surplus",
+  "name": "js-framework-benchmark-non-keyed-surplus",
   "version": "0.4.0",
   "description": "Surplus js-framework-benchmark implementation",
   "main": "dist/main.js",

--- a/frameworks/non-keyed/svelte/package.json
+++ b/frameworks/non-keyed/svelte/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-svelte",
+  "name": "js-framework-benchmark-non-keyed-svelte",
   "version": "1.0.0",
   "description": "Boilerplate for Svelte",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/uhtml/package.json
+++ b/frameworks/non-keyed/uhtml/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-uhtml",
+  "name": "js-framework-benchmark-non-keyed-uhtml",
   "version": "1.0.0",
   "description": "uhtml demo",
   "main": "index.js",

--- a/frameworks/non-keyed/vanilla-dom-framework/package.json
+++ b/frameworks/non-keyed/vanilla-dom-framework/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-vanilla-dom",
+  "name": "js-framework-benchmark-non-keyed-vanilla-dom",
   "version": "1.0.0",
   "description": "vanilla-dom demo",
   "main": "index.js",

--- a/frameworks/non-keyed/vanillajs-1/index.html
+++ b/frameworks/non-keyed/vanillajs-1/index.html
@@ -43,6 +43,6 @@
         <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
     </div>
 </div>
-<script src='dist/main.js'></script>
+<script src='src/Main.js'></script>
 </body>
 </html>

--- a/frameworks/non-keyed/vanillajs-1/package.json
+++ b/frameworks/non-keyed/vanillajs-1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-vanillajs",
+  "name": "js-framework-benchmark-non-keyed-vanillajs-1",
   "version": "1.1.1",
   "description": "Vanilla.JS demo",
   "main": "index.js",
@@ -7,8 +7,8 @@
     "frameworkVersion": ""
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
-    "build-prod": "rollup -c --environment production"
+    "build-dev": "echo 0",
+    "build-prod": "echo 0"
   },
   "keywords": [],
   "author": "Stefan Krause",
@@ -17,12 +17,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/krausest/js-framework-benchmark.git"
-  },
-  "devDependencies": {
-    "@babel/core": "7.1.2",
-    "@babel/preset-env": "7.1.0",
-    "rollup": "1.15.6",
-    "rollup-plugin-babel": "4.0.3",
-    "rollup-plugin-terser": "5.0.0"
   }
 }

--- a/frameworks/non-keyed/vanillajs/index.html
+++ b/frameworks/non-keyed/vanillajs/index.html
@@ -44,6 +44,6 @@
         <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
     </div>
 </div>
-<script src='dist/main.js'></script>
+<script src='src/Main.js'></script>
 </body>
 </html>

--- a/frameworks/non-keyed/vanillajs/package.json
+++ b/frameworks/non-keyed/vanillajs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-vanillajs",
+  "name": "js-framework-benchmark-non-keyed-vanillajs",
   "version": "1.1.1",
   "description": "Vanilla.JS demo",
   "main": "index.js",
@@ -7,8 +7,8 @@
     "frameworkVersion": ""
   },
   "scripts": {
-    "build-dev": "webpack -w -d",
-    "build-prod": "webpack -p"
+    "build-dev": "echo 0",
+    "build-prod": "echo 0"
   },
   "keywords": [
     "react",
@@ -20,11 +20,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/krausest/js-framework-benchmark.git"
-  },
-  "devDependencies": {
-    "babel-core": "6.24.1",
-    "babel-loader": "7.0.0",
-    "babel-preset-es2015": "6.24.1",
-    "webpack": "2.5.1"
   }
 }

--- a/frameworks/non-keyed/vue-next/package.json
+++ b/frameworks/non-keyed/vue-next/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-vue",
+  "name": "js-framework-benchmark-non-keyed-vue-next",
   "version": "1.0.0",
   "description": "Benchmark for vue.js framework",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/vue/package.json
+++ b/frameworks/non-keyed/vue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-vue",
+  "name": "js-framework-benchmark-non-keyed-vue",
   "version": "1.0.0",
   "description": "Benchmark for vue.js framework",
   "js-framework-benchmark": {

--- a/frameworks/non-keyed/vuera/package.json
+++ b/frameworks/non-keyed/vuera/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-framework-benchmark-react",
+  "name": "js-framework-benchmark-non-keyed-vuera",
   "version": "1.1.1",
   "description": "React demo",
   "main": "index.js",

--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,7 @@
+{
+  "packages": [
+    "frameworks/keyed/*",
+    "frameworks/non-keyed/*"
+  ],
+  "version": "0.0.0"
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "docker-bench": "docker exec -it -w /build/webdriver-ts js-framework-benchmark node dist/benchmarkRunner.js --headless",
     "docker-results": "docker exec -it -w /build/webdriver-ts js-framework-benchmark npm run results",
     "docker-shell": "docker exec -it js-framework-benchmark /bin/bash",
-    "docker-dev-webdriver": "npm run docker-sync && docker exec -it -w /build/webdriver-ts js-framework-benchmark npm run compile && docker exec -it -w /build/webdriver-ts js-framework-benchmark node dist/benchmarkRunner.js --headless"
+    "docker-dev-webdriver": "npm run docker-sync && docker exec -it -w /build/webdriver-ts js-framework-benchmark npm run compile && docker exec -it -w /build/webdriver-ts js-framework-benchmark node dist/benchmarkRunner.js --headless",
+    "bootstrap": "lerna bootstrap",
+    "build-all": "lerna run build-prod"
   },
   "keywords": [
     "benchmark",
@@ -52,5 +54,8 @@
     "lodash": "^4.17.15",
     "rimraf": "^3.0.2",
     "yargs": "^15.3.1"
+  },
+  "devDependencies": {
+    "lerna": "^3.22.1"
   }
 }


### PR DESCRIPTION
Add two new scripts using lerna in order to ease examples' dependencies install & build:
- `npm run bootstrap`: install all implementations' dependencies
- `npm run build-all -- --scope <glob>`: build implementations, filtered by their package names
    - example: `npm run build-all -- --scope "*vanillajs*"`

This required to rename most packages in order to avoid conflicts, as some haven't been updated after copy.

> FYI lerna can't be used if several packages have the same name.


