### PR TITLE
Update DOM Expression Libraries and Remove all hacks

### DIFF
--- a/frameworks/keyed/ko-jsx/package-lock.json
+++ b/frameworks/keyed/ko-jsx/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "js-framework-benchmark-ko-jsx",
-	"version": "0.12.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -14,36 +14,36 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+			"integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.0",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helpers": "^7.9.0",
-				"@babel/parser": "^7.9.0",
-				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0",
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.11.6",
+				"@babel/helper-module-transforms": "^7.11.0",
+				"@babel/helpers": "^7.10.4",
+				"@babel/parser": "^7.11.5",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.11.5",
+				"@babel/types": "^7.11.5",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
 				"json5": "^2.1.2",
-				"lodash": "^4.17.13",
+				"lodash": "^4.17.19",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-			"integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+			"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.5",
+				"@babel/types": "^7.11.5",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			}
@@ -69,12 +69,12 @@
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-			"integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+			"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.5"
+				"@babel/types": "^7.11.0"
 			}
 		},
 		"@babel/helper-module-imports": {
@@ -86,17 +86,17 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-			"integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+			"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.10.4",
 				"@babel/helper-replace-supers": "^7.10.4",
 				"@babel/helper-simple-access": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
 				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.5",
+				"@babel/types": "^7.11.0",
 				"lodash": "^4.17.19"
 			}
 		},
@@ -137,12 +137,12 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-			"integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.11.0"
 			}
 		},
 		"@babel/helper-validator-identifier": {
@@ -173,9 +173,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-			"integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+			"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
 			"dev": true
 		},
 		"@babel/plugin-syntax-jsx": {
@@ -198,56 +198,77 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-			"integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+			"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.10.5",
+				"@babel/generator": "^7.11.5",
 				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
-				"@babel/parser": "^7.10.5",
-				"@babel/types": "^7.10.5",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/parser": "^7.11.5",
+				"@babel/types": "^7.11.5",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.19"
 			}
 		},
 		"@babel/types": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-			"integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+			"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.10.4",
 				"lodash": "^4.17.19",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@rollup/plugin-commonjs": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-11.0.2.tgz",
-			"integrity": "sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==",
+		"@rollup/plugin-babel": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.1.tgz",
+			"integrity": "sha512-Jd7oqFR2dzZJ3NWANDyBjwTtX/lYbZpVcmkHrfQcpvawHs9E4c0nYk5U2mfZ6I/DZcIvy506KZJi54XK/jxH7A==",
 			"dev": true,
 			"requires": {
-				"@rollup/pluginutils": "^3.0.0",
-				"estree-walker": "^1.0.1",
-				"is-reference": "^1.1.2",
-				"magic-string": "^0.25.2",
-				"resolve": "^1.11.0"
+				"@babel/helper-module-imports": "^7.10.4",
+				"@rollup/pluginutils": "^3.1.0"
+			}
+		},
+		"@rollup/plugin-commonjs": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.1.0.tgz",
+			"integrity": "sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"commondir": "^1.0.1",
+				"estree-walker": "^2.0.1",
+				"glob": "^7.1.6",
+				"is-reference": "^1.2.1",
+				"magic-string": "^0.25.7",
+				"resolve": "^1.17.0"
+			},
+			"dependencies": {
+				"estree-walker": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
+					"integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
+					"dev": true
+				}
 			}
 		},
 		"@rollup/plugin-node-resolve": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.1.tgz",
-			"integrity": "sha512-14ddhD7TnemeHE97a4rLOhobfYvUVcaYuqTnL8Ti7Jxi9V9Jr5LY7Gko4HZ5k4h4vqQM0gBQt6tsp9xXW94WPA==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz",
+			"integrity": "sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==",
 			"dev": true,
 			"requires": {
-				"@rollup/pluginutils": "^3.0.6",
-				"@types/resolve": "0.0.8",
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
 				"builtin-modules": "^3.1.0",
+				"deepmerge": "^4.2.2",
 				"is-module": "^1.0.0",
-				"resolve": "^1.14.2"
+				"resolve": "^1.17.0"
 			}
 		},
 		"@rollup/pluginutils": {
@@ -268,15 +289,15 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.0.24",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.24.tgz",
-			"integrity": "sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==",
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
 			"dev": true
 		},
 		"@types/resolve": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-			"integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -292,12 +313,28 @@
 			}
 		},
 		"babel-plugin-jsx-dom-expressions": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.17.0.tgz",
-			"integrity": "sha512-uJpnywglB0cwDQQGYuOkFOnxfcKy33n5kYghhw97PftxpzkiebgPk+wFHQkoPx6RhSWmc3DNxh+BhOFsG8tA8Q==",
+			"version": "0.20.8",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.20.8.tgz",
+			"integrity": "sha512-rh+n0WqdwW/bEiND+u4IhJAEifP/lLTF42/B8BYmUiE7dvf3ONTPHzgkgq2Gn3B3uZEv2pg2D4ebRaR5g27SHA==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/plugin-syntax-jsx": "^7.8.3"
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/plugin-syntax-jsx": "^7.10.4"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
 			}
 		},
 		"buffer-from": {
@@ -344,6 +381,18 @@
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
 		"convert-source-map": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -354,13 +403,19 @@
 			}
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 			"dev": true,
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
+		},
+		"deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -372,6 +427,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
 			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+			"dev": true
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
 		"fsevents": {
@@ -387,6 +448,20 @@
 			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
 			"dev": true
 		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -397,6 +472,22 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
 		"is-module": {
@@ -415,22 +506,29 @@
 			}
 		},
 		"jest-worker": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+			"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
 			"dev": true,
 			"requires": {
+				"@types/node": "*",
 				"merge-stream": "^2.0.0",
-				"supports-color": "^6.1.0"
+				"supports-color": "^7.0.0"
 			},
 			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
 				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -462,14 +560,14 @@
 			"integrity": "sha512-wRJ9I4az0QcsH7A4v4l0enUpkS++MBx0BnL/68KaLzJg7x1qmbjSlwEoCNol7KTYZ+pmtI7Eh2J0Nu6/2Z5J/Q=="
 		},
 		"ko-jsx": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/ko-jsx/-/ko-jsx-0.12.0.tgz",
-			"integrity": "sha512-d1FyFO+ZVdZ70GMVXz/hOHMUtiIXBy7UjeR97pWdPVh9rV0chQiyhTH9X721agfiqu9yANlhPiU3t+bJTBmQyw=="
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/ko-jsx/-/ko-jsx-0.14.1.tgz",
+			"integrity": "sha512-V7RKVkk9IFJUgaDdkjz0nBlEIBjsoUXR2jVkD5xJtk1HYm2VHa8IpGKEpJ+vinvCKscen5Yb526daDnHv9aNwQ=="
 		},
 		"lodash": {
-			"version": "4.17.19",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"magic-string": {
 			"version": "0.25.7",
@@ -486,6 +584,15 @@
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
 		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
@@ -496,6 +603,21 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
 		"path-parse": {
@@ -510,6 +632,15 @@
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
 		"resolve": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -520,52 +651,24 @@
 			}
 		},
 		"rollup": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.1.0.tgz",
-			"integrity": "sha512-gfE1455AEazVVTJoeQtcOq/U6GSxwoj4XPSWVsuWmgIxj7sBQNLDOSA82PbdMe+cP8ql8fR1jogPFe8Wg8g4SQ==",
+			"version": "2.28.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
+			"integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.1.2"
 			}
 		},
-		"rollup-plugin-babel": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
-			"integrity": "sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"rollup-pluginutils": "^2.8.1"
-			}
-		},
 		"rollup-plugin-terser": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
-			"integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+			"integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"jest-worker": "^24.9.0",
-				"rollup-pluginutils": "^2.8.2",
-				"serialize-javascript": "^2.1.2",
-				"terser": "^4.6.2"
-			}
-		},
-		"rollup-pluginutils": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-			"dev": true,
-			"requires": {
-				"estree-walker": "^0.6.1"
-			},
-			"dependencies": {
-				"estree-walker": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-					"dev": true
-				}
+				"@babel/code-frame": "^7.10.4",
+				"jest-worker": "^26.2.1",
+				"serialize-javascript": "^4.0.0",
+				"terser": "^5.0.0"
 			}
 		},
 		"safe-buffer": {
@@ -581,10 +684,13 @@
 			"dev": true
 		},
 		"serialize-javascript": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-			"dev": true
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
 		},
 		"source-map": {
 			"version": "0.5.7",
@@ -626,9 +732,9 @@
 			}
 		},
 		"terser": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-			"integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.3.2.tgz",
+			"integrity": "sha512-H67sydwBz5jCUA32ZRL319ULu+Su1cAoZnnc+lXnenGRYWyLE3Scgkt8mNoAsMx0h5kdo758zdoS0LG9rYZXDQ==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -648,6 +754,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
 			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		}
 	}
 }

--- a/frameworks/keyed/ko-jsx/package.json
+++ b/frameworks/keyed/ko-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-ko-jsx",
-  "version": "0.12.0",
+  "version": "0.14.1",
   "main": "index.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "ko-jsx"
@@ -17,16 +17,16 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.17.0",
+    "babel-plugin-jsx-dom-expressions": "0.20.8",
     "knockout": "3.5.1",
-    "ko-jsx": "0.12.0"
+    "ko-jsx": "0.14.1"
   },
   "devDependencies": {
-    "@babel/core": "7.9.0",
-    "rollup": "2.1.0",
-    "rollup-plugin-babel": "4.4.0",
-    "@rollup/plugin-commonjs": "11.0.2",
-    "@rollup/plugin-node-resolve": "7.1.1",
-    "rollup-plugin-terser": "5.3.0"
+    "@babel/core": "7.11.6",
+    "@rollup/plugin-babel": "5.2.1",
+    "@rollup/plugin-commonjs": "15.1.0",
+    "@rollup/plugin-node-resolve": "9.0.0",
+    "rollup": "2.28.2",
+    "rollup-plugin-terser": "7.0.2"
   }
 }

--- a/frameworks/keyed/ko-jsx/rollup.config.js
+++ b/frameworks/keyed/ko-jsx/rollup.config.js
@@ -1,34 +1,29 @@
-import resolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
-import babel from 'rollup-plugin-babel';
-import { terser } from 'rollup-plugin-terser';
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import babel from "@rollup/plugin-babel";
+import { terser } from "rollup-plugin-terser";
 
 const plugins = [
-	babel({
-		exclude: 'node_modules/**',
-		plugins: [["jsx-dom-expressions", {moduleName: 'ko-jsx'}]]
+  babel({
+    exclude: "node_modules/**",
+    babelHelpers: "bundled",
+    plugins: [["jsx-dom-expressions", { moduleName: "ko-jsx" }]],
   }),
-	resolve({ extensions: ['.js', '.jsx'] }),
-	commonjs({
-    include: 'node_modules/**',
-    namedExports: {
-      'node_modules/knockout/build/output/knockout-latest.js': [
-        'ignoreDependencies', 'observable', 'observableArray',
-        'computed', 'subscribable'
-      ]
-    }
-	})
+  resolve({ extensions: [".js", ".jsx"] }),
+  commonjs({
+    include: "node_modules/**",
+  }),
 ];
 
 if (process.env.production) {
-	plugins.push(terser());
+  plugins.push(terser({ output: { comments: false } }));
 }
 
 export default {
-	input: 'src/Main.js',
-	output: {
-		file: 'dist/main.js',
-		format: 'iife'
-	},
-	plugins
+  input: "src/Main.js",
+  output: {
+    file: "dist/main.js",
+    format: "iife",
+  },
+  plugins,
 };

--- a/frameworks/keyed/ko-jsx/src/Main.js
+++ b/frameworks/keyed/ko-jsx/src/Main.js
@@ -4,14 +4,14 @@ import template from './template';
 
 function _random(max) { return Math.round(Math.random() * 1000) % max; }
 
-var rowId = 1;
-var adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"];
-var colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"];
-var nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+let rowId = 1;
+let adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"];
+let colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"];
+let nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
 
 function buildData(count) {
-  var data = [];
-  for (var i = 0; i < count; i++) {
+  let data = [];
+  for (let i = 0; i < count; i++) {
     data.push({
       id: rowId++,
       label: observable(adjectives[_random(adjectives.length)] + " " + colours[_random(colours.length)] + " " + nouns[_random(nouns.length)])
@@ -20,7 +20,7 @@ function buildData(count) {
   return data;
 }
 
-var HomeViewModel = function () {
+function HomeViewModel() {
   const selected = observable(null),
     data = observableArray();
 
@@ -39,7 +39,7 @@ var HomeViewModel = function () {
       data.push.apply(data, buildData(1000));
     },
     update () {
-      var tmp = data();
+      let tmp = data();
       for (let i = 0; i < tmp.length; i += 10) {
         tmp[i].label(tmp[i].label() + ' !!!');
       }
@@ -49,16 +49,16 @@ var HomeViewModel = function () {
       selected(null);
     },
     swapRows () {
-      var tmp = data();
+      let tmp = data();
       if (tmp.length > 998) {
-        var a = tmp[1];
+        let a = tmp[1];
         tmp[1] = tmp[998];
         tmp[998] = a;
         data(tmp);
       }
     },
     remove(id) {
-      var tmp = data();
+      let tmp = data();
       const idx = tmp.findIndex(d => d.id === id);
       data.splice(idx, 1);
     }

--- a/frameworks/keyed/ko-jsx/src/template.jsx
+++ b/frameworks/keyed/ko-jsx/src/template.jsx
@@ -1,27 +1,20 @@
-import { ignoreDependencies, computed } from "knockout";
-import { wrap } from "ko-jsx";
-
-const Button = ({id, text, fn}) =>
+const Button = ({id, text, fn}) => (
   <div class='col-sm-6 smallpad'>
     <button id={id} class='btn btn-primary btn-block' type='button' onClick={fn}>{text}</button>
   </div>
-
-const List = props => {
-  const mapped = computed(props.each.memoMap(props.children));
-  wrap(tr => {
-    let i, s = props.selected();
-    ignoreDependencies(() => {
-      if (tr) tr.className = "";
-      if ((tr = s && (i = props.each().findIndex(el => el.id === s)) > -1 && mapped()[i]))
-        tr.className = "danger";
-    });
-    return tr;
-  });
-  return mapped;
-};
+)
 
 export default function({data, selected, run, runLots, add, update, clear, swapRows, remove}) {
-  let rowId;
+  const list = data.memoMap(row => {
+    const rowId = row.id;
+    return <tr class={selected() === rowId ? "danger" : ""}>
+      <td class='col-md-1' textContent={ rowId } />
+      <td class='col-md-4'><a onClick={[selected, rowId]} textContent={ row.label() } /></td>
+      <td class='col-md-1'><a onClick={[remove, rowId]}><span class='glyphicon glyphicon-remove' aria-hidden="true" /></a></td>
+      <td class='col-md-6'/>
+    </tr>
+  });
+
   return <div class='container'>
     <div class='jumbotron'><div class='row'>
       <div class='col-md-6'><h1>KnockoutJSX-keyed</h1></div>
@@ -35,15 +28,7 @@ export default function({data, selected, run, runLots, add, update, clear, swapR
       </div></div>
     </div></div>
     <table class='table table-hover table-striped test-data'><tbody>
-      <List each={ data } selected={ selected }>{ row => (
-        rowId = row.id,
-        <tr>
-          <td class='col-md-1' textContent={ rowId } />
-          <td class='col-md-4'><a onClick={[selected, rowId]} textContent={ row.label() } /></td>
-          <td class='col-md-1'><a onClick={[remove, rowId]}><span class='glyphicon glyphicon-remove' aria-hidden="true" /></a></td>
-          <td class='col-md-6'/>
-        </tr>
-      )}</List>
+      {list}
     </tbody></table>
     <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
   </div>

--- a/frameworks/keyed/mobx-jsx/package-lock.json
+++ b/frameworks/keyed/mobx-jsx/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "js-framework-benchmark-mobx-jsx",
-	"version": "0.10.0",
+	"version": "0.12.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -14,36 +14,36 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+			"integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.0",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helpers": "^7.9.0",
-				"@babel/parser": "^7.9.0",
-				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0",
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.11.6",
+				"@babel/helper-module-transforms": "^7.11.0",
+				"@babel/helpers": "^7.10.4",
+				"@babel/parser": "^7.11.5",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.11.5",
+				"@babel/types": "^7.11.5",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
 				"json5": "^2.1.2",
-				"lodash": "^4.17.13",
+				"lodash": "^4.17.19",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-			"integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+			"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.5",
+				"@babel/types": "^7.11.5",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			}
@@ -83,12 +83,12 @@
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-			"integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+			"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.5"
+				"@babel/types": "^7.11.0"
 			}
 		},
 		"@babel/helper-module-imports": {
@@ -100,17 +100,17 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-			"integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+			"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.10.4",
 				"@babel/helper-replace-supers": "^7.10.4",
 				"@babel/helper-simple-access": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
 				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.5",
+				"@babel/types": "^7.11.0",
 				"lodash": "^4.17.19"
 			}
 		},
@@ -151,12 +151,12 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-			"integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.11.0"
 			}
 		},
 		"@babel/helper-validator-identifier": {
@@ -187,30 +187,30 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-			"integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+			"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz",
-			"integrity": "sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
+			"integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-create-class-features-plugin": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-proposal-decorators": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.8.3.tgz",
-			"integrity": "sha512-e3RvdvS4qPJVTe288DlXjwKflpfy1hr0j5dz5WpIYYeP7vQZg2WfAEIp8k5/Lwis/m5REXEteIz6rrcDtXXG7w==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.10.5.tgz",
+			"integrity": "sha512-Sc5TAQSZuLzgY0664mMDn24Vw2P8g/VhyLyGPaWiHahhgLqeZvcGeyBZOrJW0oSKIK2mvQ22a1ENXBIQLhrEiQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-syntax-decorators": "^7.8.3"
+				"@babel/helper-create-class-features-plugin": "^7.10.5",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-decorators": "^7.10.4"
 			}
 		},
 		"@babel/plugin-syntax-decorators": {
@@ -242,43 +242,87 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-			"integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+			"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.10.5",
+				"@babel/generator": "^7.11.5",
 				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
-				"@babel/parser": "^7.10.5",
-				"@babel/types": "^7.10.5",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/parser": "^7.11.5",
+				"@babel/types": "^7.11.5",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.19"
 			}
 		},
 		"@babel/types": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-			"integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+			"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.10.4",
 				"lodash": "^4.17.19",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@rollup/plugin-node-resolve": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.1.tgz",
-			"integrity": "sha512-14ddhD7TnemeHE97a4rLOhobfYvUVcaYuqTnL8Ti7Jxi9V9Jr5LY7Gko4HZ5k4h4vqQM0gBQt6tsp9xXW94WPA==",
+		"@rollup/plugin-babel": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.1.tgz",
+			"integrity": "sha512-Jd7oqFR2dzZJ3NWANDyBjwTtX/lYbZpVcmkHrfQcpvawHs9E4c0nYk5U2mfZ6I/DZcIvy506KZJi54XK/jxH7A==",
 			"dev": true,
 			"requires": {
-				"@rollup/pluginutils": "^3.0.6",
-				"@types/resolve": "0.0.8",
+				"@babel/helper-module-imports": "^7.10.4",
+				"@rollup/pluginutils": "^3.1.0"
+			}
+		},
+		"@rollup/plugin-commonjs": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.1.0.tgz",
+			"integrity": "sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"commondir": "^1.0.1",
+				"estree-walker": "^2.0.1",
+				"glob": "^7.1.6",
+				"is-reference": "^1.2.1",
+				"magic-string": "^0.25.7",
+				"resolve": "^1.17.0"
+			},
+			"dependencies": {
+				"estree-walker": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
+					"integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
+					"dev": true
+				}
+			}
+		},
+		"@rollup/plugin-node-resolve": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz",
+			"integrity": "sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
 				"builtin-modules": "^3.1.0",
+				"deepmerge": "^4.2.2",
 				"is-module": "^1.0.0",
-				"resolve": "^1.14.2"
+				"resolve": "^1.17.0"
+			}
+		},
+		"@rollup/plugin-replace": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.3.tgz",
+			"integrity": "sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.0.8",
+				"magic-string": "^0.25.5"
 			}
 		},
 		"@rollup/pluginutils": {
@@ -299,15 +343,15 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.0.24",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.24.tgz",
-			"integrity": "sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==",
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
 			"dev": true
 		},
 		"@types/resolve": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-			"integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -323,12 +367,28 @@
 			}
 		},
 		"babel-plugin-jsx-dom-expressions": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.17.0.tgz",
-			"integrity": "sha512-uJpnywglB0cwDQQGYuOkFOnxfcKy33n5kYghhw97PftxpzkiebgPk+wFHQkoPx6RhSWmc3DNxh+BhOFsG8tA8Q==",
+			"version": "0.20.8",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.20.8.tgz",
+			"integrity": "sha512-rh+n0WqdwW/bEiND+u4IhJAEifP/lLTF42/B8BYmUiE7dvf3ONTPHzgkgq2Gn3B3uZEv2pg2D4ebRaR5g27SHA==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/plugin-syntax-jsx": "^7.8.3"
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/plugin-syntax-jsx": "^7.10.4"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
 			}
 		},
 		"buffer-from": {
@@ -375,6 +435,18 @@
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
 		"convert-source-map": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -385,13 +457,19 @@
 			}
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 			"dev": true,
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
+		},
+		"deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -403,6 +481,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
 			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+			"dev": true
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
 		"fsevents": {
@@ -418,6 +502,20 @@
 			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
 			"dev": true
 		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -430,29 +528,61 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
 			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
 			"dev": true
 		},
-		"jest-worker": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+		"is-reference": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
 			"dev": true,
 			"requires": {
+				"@types/estree": "*"
+			}
+		},
+		"jest-worker": {
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+			"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
 				"merge-stream": "^2.0.0",
-				"supports-color": "^6.1.0"
+				"supports-color": "^7.0.0"
 			},
 			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
 				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -479,9 +609,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.19",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"magic-string": {
 			"version": "0.25.7",
@@ -498,6 +628,15 @@
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
 		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
@@ -505,19 +644,34 @@
 			"dev": true
 		},
 		"mobx": {
-			"version": "5.15.4",
-			"resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.4.tgz",
-			"integrity": "sha512-xRFJxSU2Im3nrGCdjSuOTFmxVDGeqOHL+TyADCGbT0k4HHqGmx5u2yaHNryvoORpI4DfbzjJ5jPmuv+d7sioFw=="
+			"version": "5.15.7",
+			"resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.7.tgz",
+			"integrity": "sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw=="
 		},
 		"mobx-jsx": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/mobx-jsx/-/mobx-jsx-0.10.0.tgz",
-			"integrity": "sha512-2eWT7sU7PiZGNyewDWeQjkKpg5W2g4ZjojeXJK9QjDZJYvpGkOyKHhk75RIGfIEDfsCqnzZATNPii/iusNOOUw=="
+			"version": "0.12.4",
+			"resolved": "https://registry.npmjs.org/mobx-jsx/-/mobx-jsx-0.12.4.tgz",
+			"integrity": "sha512-H1WC43sHilhinYBN5GuFKHOCBYepVy5ad3IAYxeIXNZlqYDrMLQwkKSYlx1CvN04hSf6I6YcJWkvMeJPt095WA=="
 		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
 		"path-parse": {
@@ -532,6 +686,15 @@
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
 		"resolve": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -542,62 +705,24 @@
 			}
 		},
 		"rollup": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.1.0.tgz",
-			"integrity": "sha512-gfE1455AEazVVTJoeQtcOq/U6GSxwoj4XPSWVsuWmgIxj7sBQNLDOSA82PbdMe+cP8ql8fR1jogPFe8Wg8g4SQ==",
+			"version": "2.28.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
+			"integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.1.2"
 			}
 		},
-		"rollup-plugin-babel": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
-			"integrity": "sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"rollup-pluginutils": "^2.8.1"
-			}
-		},
-		"rollup-plugin-replace": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz",
-			"integrity": "sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==",
-			"dev": true,
-			"requires": {
-				"magic-string": "^0.25.2",
-				"rollup-pluginutils": "^2.6.0"
-			}
-		},
 		"rollup-plugin-terser": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
-			"integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+			"integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"jest-worker": "^24.9.0",
-				"rollup-pluginutils": "^2.8.2",
-				"serialize-javascript": "^2.1.2",
-				"terser": "^4.6.2"
-			}
-		},
-		"rollup-pluginutils": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-			"dev": true,
-			"requires": {
-				"estree-walker": "^0.6.1"
-			},
-			"dependencies": {
-				"estree-walker": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-					"dev": true
-				}
+				"@babel/code-frame": "^7.10.4",
+				"jest-worker": "^26.2.1",
+				"serialize-javascript": "^4.0.0",
+				"terser": "^5.0.0"
 			}
 		},
 		"safe-buffer": {
@@ -613,10 +738,13 @@
 			"dev": true
 		},
 		"serialize-javascript": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-			"dev": true
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
 		},
 		"source-map": {
 			"version": "0.5.7",
@@ -658,9 +786,9 @@
 			}
 		},
 		"terser": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-			"integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.3.2.tgz",
+			"integrity": "sha512-H67sydwBz5jCUA32ZRL319ULu+Su1cAoZnnc+lXnenGRYWyLE3Scgkt8mNoAsMx0h5kdo758zdoS0LG9rYZXDQ==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -680,6 +808,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
 			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		}
 	}
 }

--- a/frameworks/keyed/mobx-jsx/package.json
+++ b/frameworks/keyed/mobx-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-mobx-jsx",
-  "version": "0.10.0",
+  "version": "0.12.4",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "mobx-jsx"
@@ -17,18 +17,19 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "babel-plugin-jsx-dom-expressions": "0.17.0",
-    "mobx": "5.15.4",
-    "mobx-jsx": "0.10.0"
+    "babel-plugin-jsx-dom-expressions": "0.20.8",
+    "mobx": "5.15.7",
+    "mobx-jsx": "0.12.4"
   },
   "devDependencies": {
-    "@babel/core": "7.9.0",
-    "@babel/plugin-proposal-decorators": "7.8.3",
-    "@babel/plugin-proposal-class-properties": "7.8.3",
-    "rollup": "2.1.0",
-    "rollup-plugin-babel": "4.4.0",
-    "@rollup/plugin-node-resolve": "7.1.1",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "5.3.0"
+    "@babel/core": "7.11.6",
+    "@babel/plugin-proposal-decorators": "7.10.5",
+    "@babel/plugin-proposal-class-properties": "7.10.4",
+    "@rollup/plugin-babel": "5.2.1",
+    "@rollup/plugin-commonjs": "15.1.0",
+    "@rollup/plugin-node-resolve": "9.0.0",
+    "@rollup/plugin-replace": "2.3.3",
+    "rollup": "2.28.2",
+    "rollup-plugin-terser": "7.0.2"
   }
 }

--- a/frameworks/keyed/mobx-jsx/rollup.config.js
+++ b/frameworks/keyed/mobx-jsx/rollup.config.js
@@ -1,30 +1,31 @@
 import resolve from "@rollup/plugin-node-resolve";
-import replace from "rollup-plugin-replace";
-import babel from "rollup-plugin-babel";
+import replace from "@rollup/plugin-replace";
+import babel from "@rollup/plugin-babel";
 import { terser } from "rollup-plugin-terser";
 
 const plugins = [
   babel({
     exclude: "node_modules/**",
+    babelHelpers: "bundled",
     plugins: [
       ["jsx-dom-expressions", { moduleName: "mobx-jsx" }],
       ["@babel/plugin-proposal-decorators", { legacy: true }],
-      ["@babel/plugin-proposal-class-properties", { loose: true }]
-    ]
+      ["@babel/plugin-proposal-class-properties", { loose: true }],
+    ],
   }),
   resolve({ extensions: [".js", ".jsx"] }),
-  replace({ "process.env.NODE_ENV": "'production'" })
+  replace({ "process.env.NODE_ENV": "'production'" }),
 ];
 
 if (process.env.production) {
-  plugins.push(terser());
+  plugins.push(terser({ output: { comments: false } }));
 }
 
 export default {
   input: "src/main.jsx",
   output: {
     file: "dist/main.js",
-    format: "iife"
+    format: "iife",
   },
-  plugins
+  plugins,
 };

--- a/frameworks/keyed/mobx-jsx/src/main.jsx
+++ b/frameworks/keyed/mobx-jsx/src/main.jsx
@@ -1,5 +1,5 @@
-import { observable, action, autorun, untracked } from 'mobx';
-import { Component, map, render, wrap } from 'mobx-jsx';
+import { observable, action } from 'mobx';
+import { Component, map, render } from 'mobx-jsx';
 
 function _random (max) { return Math.round(Math.random() * 1000) % max; };
 
@@ -23,22 +23,6 @@ const Button = ({ id, text, fn }) =>
   <div class='col-sm-6 smallpad'>
     <button id={ id } class='btn btn-primary btn-block' type='button' onClick={ fn }>{ text }</button>
   </div>
-
-const List = props => {
-  const mapped = map(props.each, props.children),
-    cache = observable.box();
-  autorun(() => cache.set(mapped()));
-  wrap(tr => {
-    let i, s = props.selected;
-    untracked(() => {
-      if (tr) tr.className = "";
-      if ((tr = s && (i = props.each.findIndex(el => el.id === s)) > -1 && cache.get()[i]))
-        tr.className = "danger";
-    });
-    return tr;
-  });
-  return cache.get.bind(cache);
-};
 
 class App extends Component {
   @observable data = [];
@@ -74,8 +58,17 @@ class App extends Component {
   @action.bound select(itemId) { this.selected = itemId };
 
   render() {
-    let rowId;
     const { run, runLots, add, update, clear, swapRows, select, remove } = this;
+
+    const list = map(this.data, row => {
+      const rowId = row.id;
+      return <tr class={this.selected === rowId ? "danger" : ""}>
+        <td class='col-md-1' textContent={ rowId } />
+        <td class='col-md-4'><a onClick={[select, rowId]} textContent={ row.label } /></td>
+        <td class='col-md-1'><a onClick={[remove, row]}><span class='glyphicon glyphicon-remove' aria-hidden="true" /></a></td>
+        <td class='col-md-6'/>
+      </tr>
+    });
 
     return <div class='container'>
       <div class='jumbotron'><div class='row'>
@@ -90,15 +83,7 @@ class App extends Component {
         </div></div>
       </div></div>
       <table class='table table-hover table-striped test-data'><tbody>
-        <List each={ this.data } selected={ this.selected }>{ row => (
-          rowId = row.id,
-          <tr>
-            <td class='col-md-1' textContent={ rowId } />
-            <td class='col-md-4'><a onClick={[select, rowId]} textContent={ row.label } /></td>
-            <td class='col-md-1'><a onClick={[remove, row]}><span class='glyphicon glyphicon-remove' aria-hidden="true" /></a></td>
-            <td class='col-md-6'/>
-          </tr>
-        )}</List>
+        {list}
       </tbody></table>
       <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
     </div>

--- a/frameworks/keyed/solid-state/package-lock.json
+++ b/frameworks/keyed/solid-state/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "js-framework-benchmark-solid-state",
-	"version": "0.17.2",
+	"version": "0.20.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -14,36 +14,36 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+			"integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.0",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helpers": "^7.9.0",
-				"@babel/parser": "^7.9.0",
-				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0",
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.11.6",
+				"@babel/helper-module-transforms": "^7.11.0",
+				"@babel/helpers": "^7.10.4",
+				"@babel/parser": "^7.11.5",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.11.5",
+				"@babel/types": "^7.11.5",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
 				"json5": "^2.1.2",
-				"lodash": "^4.17.13",
+				"lodash": "^4.17.19",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-			"integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+			"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.5",
+				"@babel/types": "^7.11.5",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			}
@@ -69,12 +69,12 @@
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-			"integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+			"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.5"
+				"@babel/types": "^7.11.0"
 			}
 		},
 		"@babel/helper-module-imports": {
@@ -87,17 +87,17 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-			"integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+			"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.10.4",
 				"@babel/helper-replace-supers": "^7.10.4",
 				"@babel/helper-simple-access": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
 				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.5",
+				"@babel/types": "^7.11.0",
 				"lodash": "^4.17.19"
 			}
 		},
@@ -139,12 +139,12 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-			"integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.11.0"
 			}
 		},
 		"@babel/helper-validator-identifier": {
@@ -176,9 +176,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-			"integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+			"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
 			"dev": true
 		},
 		"@babel/plugin-syntax-jsx": {
@@ -202,26 +202,26 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-			"integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+			"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.10.5",
+				"@babel/generator": "^7.11.5",
 				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
-				"@babel/parser": "^7.10.5",
-				"@babel/types": "^7.10.5",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/parser": "^7.11.5",
+				"@babel/types": "^7.11.5",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.19"
 			}
 		},
 		"@babel/types": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-			"integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+			"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.10.4",
@@ -229,17 +229,28 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@rollup/plugin-node-resolve": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.1.tgz",
-			"integrity": "sha512-14ddhD7TnemeHE97a4rLOhobfYvUVcaYuqTnL8Ti7Jxi9V9Jr5LY7Gko4HZ5k4h4vqQM0gBQt6tsp9xXW94WPA==",
+		"@rollup/plugin-babel": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.1.tgz",
+			"integrity": "sha512-Jd7oqFR2dzZJ3NWANDyBjwTtX/lYbZpVcmkHrfQcpvawHs9E4c0nYk5U2mfZ6I/DZcIvy506KZJi54XK/jxH7A==",
 			"dev": true,
 			"requires": {
-				"@rollup/pluginutils": "^3.0.6",
-				"@types/resolve": "0.0.8",
+				"@babel/helper-module-imports": "^7.10.4",
+				"@rollup/pluginutils": "^3.1.0"
+			}
+		},
+		"@rollup/plugin-node-resolve": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz",
+			"integrity": "sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
 				"builtin-modules": "^3.1.0",
+				"deepmerge": "^4.2.2",
 				"is-module": "^1.0.0",
-				"resolve": "^1.14.2"
+				"resolve": "^1.17.0"
 			}
 		},
 		"@rollup/pluginutils": {
@@ -260,15 +271,15 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.0.24",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.24.tgz",
-			"integrity": "sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==",
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
 			"dev": true
 		},
 		"@types/resolve": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-			"integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -284,22 +295,29 @@
 			}
 		},
 		"babel-plugin-jsx-dom-expressions": {
-			"version": "0.17.5",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.17.5.tgz",
-			"integrity": "sha512-hNSyICVET4i1xymDlPn0iwwrkoIsZGp/CkrBo7NUxljhNnVncHoSWMSJo/7VrggV2yh/5vJ5UfxJOxJCuUDE2g==",
+			"version": "0.20.8",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.20.8.tgz",
+			"integrity": "sha512-rh+n0WqdwW/bEiND+u4IhJAEifP/lLTF42/B8BYmUiE7dvf3ONTPHzgkgq2Gn3B3uZEv2pg2D4ebRaR5g27SHA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/plugin-syntax-jsx": "^7.8.3"
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/plugin-syntax-jsx": "^7.10.4"
 			}
 		},
+		"babel-plugin-transform-rename-import": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-rename-import/-/babel-plugin-transform-rename-import-2.3.0.tgz",
+			"integrity": "sha512-dPgJoT57XC0PqSnLgl2FwNvxFrWlspatX2dkk7yjKQj5HHGw071vAcOf+hqW8ClqcBDMvEbm6mevn5yHAD8mlQ==",
+			"dev": true
+		},
 		"babel-preset-solid": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-0.17.0.tgz",
-			"integrity": "sha512-Q1h14CD3Hv46tnxFljXZ3k6ayQfTTiHHW+rPCHW1tvOJQ/fp4QUOw8RQH04QguZwOEfTnviV0GTzZ5SIdk3AKw==",
+			"version": "0.20.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-0.20.0.tgz",
+			"integrity": "sha512-sSc9vVYq9gGsdm8ASYE+CyBSfotcPijrheiFKhGt+BE0wk/vGGK7lES6YqrH/EjXvAJXZWplS6A0s2w21aCFZA==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jsx-dom-expressions": "~0.17.0"
+				"babel-plugin-jsx-dom-expressions": "~0.20.8",
+				"babel-plugin-transform-rename-import": "^2.3.0"
 			}
 		},
 		"buffer-from": {
@@ -356,13 +374,19 @@
 			}
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 			"dev": true,
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
+		},
+		"deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -408,22 +432,29 @@
 			"dev": true
 		},
 		"jest-worker": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+			"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
 			"dev": true,
 			"requires": {
+				"@types/node": "*",
 				"merge-stream": "^2.0.0",
-				"supports-color": "^6.1.0"
+				"supports-color": "^7.0.0"
 			},
 			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
 				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -450,9 +481,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.19",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 			"dev": true
 		},
 		"merge-stream": {
@@ -485,6 +516,15 @@
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
 		"resolve": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -495,52 +535,24 @@
 			}
 		},
 		"rollup": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.1.0.tgz",
-			"integrity": "sha512-gfE1455AEazVVTJoeQtcOq/U6GSxwoj4XPSWVsuWmgIxj7sBQNLDOSA82PbdMe+cP8ql8fR1jogPFe8Wg8g4SQ==",
+			"version": "2.28.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
+			"integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.1.2"
 			}
 		},
-		"rollup-plugin-babel": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
-			"integrity": "sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"rollup-pluginutils": "^2.8.1"
-			}
-		},
 		"rollup-plugin-terser": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
-			"integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+			"integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"jest-worker": "^24.9.0",
-				"rollup-pluginutils": "^2.8.2",
-				"serialize-javascript": "^2.1.2",
-				"terser": "^4.6.2"
-			}
-		},
-		"rollup-pluginutils": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-			"dev": true,
-			"requires": {
-				"estree-walker": "^0.6.1"
-			},
-			"dependencies": {
-				"estree-walker": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-					"dev": true
-				}
+				"@babel/code-frame": "^7.10.4",
+				"jest-worker": "^26.2.1",
+				"serialize-javascript": "^4.0.0",
+				"terser": "^5.0.0"
 			}
 		},
 		"safe-buffer": {
@@ -556,15 +568,18 @@
 			"dev": true
 		},
 		"serialize-javascript": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-			"dev": true
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
 		},
 		"solid-js": {
-			"version": "0.17.2",
-			"resolved": "https://registry.npmjs.org/solid-js/-/solid-js-0.17.2.tgz",
-			"integrity": "sha512-uU3/DV9j9zaJ8LYZ2kNhJI05pJBPx4eg3z2SpflNgRG+HQ6Il7Staid+AgjArm4CFuQR4VDvl8Ojqsvlb9smWA=="
+			"version": "0.20.0",
+			"resolved": "https://registry.npmjs.org/solid-js/-/solid-js-0.20.0.tgz",
+			"integrity": "sha512-/N3AcyS3r5ead90WvEqx68g45JaxTyCsIM6Lglsrgl9psHEbvv9vuu2gobm0cjFltKTsnqNZPWappDDMiGobZw=="
 		},
 		"source-map": {
 			"version": "0.5.7",
@@ -600,9 +615,9 @@
 			}
 		},
 		"terser": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-			"integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.3.2.tgz",
+			"integrity": "sha512-H67sydwBz5jCUA32ZRL319ULu+Su1cAoZnnc+lXnenGRYWyLE3Scgkt8mNoAsMx0h5kdo758zdoS0LG9rYZXDQ==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",

--- a/frameworks/keyed/solid-state/package.json
+++ b/frameworks/keyed/solid-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-solid-state",
-  "version": "0.17.2",
+  "version": "0.20.0",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "solid-js"
@@ -17,14 +17,14 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "solid-js": "0.17.2"
+    "solid-js": "0.20.0"
   },
   "devDependencies": {
-    "@babel/core": "7.9.0",
-    "@rollup/plugin-node-resolve": "7.1.1",
-    "babel-preset-solid": "0.17.0",
-    "rollup": "2.1.0",
-    "rollup-plugin-babel": "4.4.0",
-    "rollup-plugin-terser": "5.3.0"
+    "@babel/core": "7.11.6",
+    "@rollup/plugin-babel": "5.2.1",
+    "@rollup/plugin-node-resolve": "9.0.0",
+    "babel-preset-solid": "0.20.0",
+    "rollup": "2.28.2",
+    "rollup-plugin-terser": "7.0.2"
   }
 }

--- a/frameworks/keyed/solid-state/rollup.config.js
+++ b/frameworks/keyed/solid-state/rollup.config.js
@@ -1,24 +1,25 @@
-import resolve from '@rollup/plugin-node-resolve';
-import babel from 'rollup-plugin-babel';
-import { terser } from 'rollup-plugin-terser';
+import resolve from "@rollup/plugin-node-resolve";
+import babel from "@rollup/plugin-babel";
+import { terser } from "rollup-plugin-terser";
 
 const plugins = [
-	babel({
-    exclude: 'node_modules/**',
-    presets: ['solid']
+  babel({
+    babelHelpers: "bundled",
+    exclude: "node_modules/**",
+    presets: ["solid"],
   }),
-	resolve({ extensions: ['.js', '.jsx'] })
+  resolve({ extensions: [".js", ".jsx"] }),
 ];
 
 if (process.env.production) {
-	plugins.push(terser());
+  plugins.push(terser({ output: { comments: false } }));
 }
 
 export default {
-	input: 'src/main.jsx',
-	output: {
-		file: 'dist/main.js',
-		format: 'iife'
-	},
-	plugins
+  input: "src/main.jsx",
+  output: {
+    file: "dist/main.js",
+    format: "iife",
+  },
+  plugins,
 };

--- a/frameworks/keyed/solid-state/src/main.jsx
+++ b/frameworks/keyed/solid-state/src/main.jsx
@@ -1,4 +1,4 @@
-import { createState, createMemo, createEffect, mapArray, sample, $RAW } from 'solid-js';
+import { createState, createSelector } from 'solid-js';
 import { render } from 'solid-js/dom';
 
 let idCounter = 1;
@@ -24,23 +24,8 @@ const Button = ({ id, text, fn }) =>
     <button id={ id } class='btn btn-primary btn-block' type='button' onClick={ fn }>{ text }</button>
   </div>
 
-const List = props => {
-  const mapped = createMemo(mapArray(() => props.each, props.children));
-  createEffect(tr => {
-    let i, s = props.selected;
-    sample(() => {
-      if (tr) tr.className = "";
-      if ((tr = s && (i = props.each[$RAW].findIndex(el => el.id === s)) > -1 && mapped()[i]))
-        tr.className = "danger";
-    });
-    return tr;
-  });
-  return mapped;
-};
-
 const App = () => {
-  let rowId;
-  const [ state, setState ] = createState({ data: [], selected: null }),
+  const [state, setState] = createState({ data: [], selected: null }),
     run = () => setState({ data: buildData(1000), selected: null }),
     runLots = () => setState({ data: buildData(10000), selected: null }),
     add = () => setState('data', d => [...d, ...buildData(1000)]),
@@ -51,7 +36,8 @@ const App = () => {
     remove = id => setState('data', d => {
       const idx = d.findIndex(d => d.id === id);
       return [...d.slice(0, idx), ...d.slice(idx + 1)];
-    });
+    }),
+    isSelected = createSelector(() => state.selected);
 
   return <div class='container'>
     <div class='jumbotron'><div class='row'>
@@ -66,15 +52,15 @@ const App = () => {
       </div></div>
     </div></div>
     <table class='table table-hover table-striped test-data'><tbody>
-      <List each={ state.data } selected={ state.selected }>{ row => (
-        rowId = row.id,
-        <tr>
+      <For each={ state.data }>{ row => {
+        const rowId = row.id;
+        return <tr class={isSelected(rowId) ? "danger": ""}>
           <td class='col-md-1' textContent={ rowId } />
           <td class='col-md-4'><a onClick={[select, rowId]} textContent={ row.label } /></td>
           <td class='col-md-1'><a onClick={[remove, rowId]}><span class='glyphicon glyphicon-remove' aria-hidden="true" /></a></td>
           <td class='col-md-6'/>
         </tr>
-      )}</List>
+      }}</For>
     </tbody></table>
     <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
   </div>

--- a/frameworks/keyed/solid/package-lock.json
+++ b/frameworks/keyed/solid/package-lock.json
@@ -1,628 +1,643 @@
 {
-	"name": "js-framework-benchmark-solid",
-	"version": "0.17.2",
-	"lockfileVersion": 1,
-	"requires": true,
-	"dependencies": {
-		"@babel/code-frame": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-			"dev": true,
-			"requires": {
-				"@babel/highlight": "^7.10.4"
-			}
-		},
-		"@babel/core": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.0",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helpers": "^7.9.0",
-				"@babel/parser": "^7.9.0",
-				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0",
-				"convert-source-map": "^1.7.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.1",
-				"json5": "^2.1.2",
-				"lodash": "^4.17.13",
-				"resolve": "^1.3.2",
-				"semver": "^5.4.1",
-				"source-map": "^0.5.0"
-			}
-		},
-		"@babel/generator": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-			"integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.10.5",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
-			}
-		},
-		"@babel/helper-function-name": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-get-function-arity": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-member-expression-to-functions": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-			"integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.10.5"
-			}
-		},
-		"@babel/helper-module-imports": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-			"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-module-transforms": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-			"integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4",
-				"@babel/helper-simple-access": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.5",
-				"lodash": "^4.17.19"
-			}
-		},
-		"@babel/helper-optimise-call-expression": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-			"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-plugin-utils": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-			"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
-			"dev": true
-		},
-		"@babel/helper-replace-supers": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-			"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.10.4",
-				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-simple-access": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-			"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
-			"dev": true,
-			"requires": {
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-split-export-declaration": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-			"integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-validator-identifier": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-			"dev": true
-		},
-		"@babel/helpers": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-			"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
-			"dev": true,
-			"requires": {
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/highlight": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
-			}
-		},
-		"@babel/parser": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-			"integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
-			"dev": true
-		},
-		"@babel/plugin-syntax-jsx": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
-			"integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
-			}
-		},
-		"@babel/template": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/parser": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/traverse": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-			"integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.10.5",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
-				"@babel/parser": "^7.10.5",
-				"@babel/types": "^7.10.5",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.19"
-			}
-		},
-		"@babel/types": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-			"integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
-		"@rollup/plugin-node-resolve": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.1.tgz",
-			"integrity": "sha512-14ddhD7TnemeHE97a4rLOhobfYvUVcaYuqTnL8Ti7Jxi9V9Jr5LY7Gko4HZ5k4h4vqQM0gBQt6tsp9xXW94WPA==",
-			"dev": true,
-			"requires": {
-				"@rollup/pluginutils": "^3.0.6",
-				"@types/resolve": "0.0.8",
-				"builtin-modules": "^3.1.0",
-				"is-module": "^1.0.0",
-				"resolve": "^1.14.2"
-			}
-		},
-		"@rollup/pluginutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-			"dev": true,
-			"requires": {
-				"@types/estree": "0.0.39",
-				"estree-walker": "^1.0.1",
-				"picomatch": "^2.2.2"
-			}
-		},
-		"@types/estree": {
-			"version": "0.0.39",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-			"dev": true
-		},
-		"@types/node": {
-			"version": "14.0.24",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.24.tgz",
-			"integrity": "sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==",
-			"dev": true
-		},
-		"@types/resolve": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-			"integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"requires": {
-				"color-convert": "^1.9.0"
-			}
-		},
-		"babel-plugin-jsx-dom-expressions": {
-			"version": "0.17.5",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.17.5.tgz",
-			"integrity": "sha512-hNSyICVET4i1xymDlPn0iwwrkoIsZGp/CkrBo7NUxljhNnVncHoSWMSJo/7VrggV2yh/5vJ5UfxJOxJCuUDE2g==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/plugin-syntax-jsx": "^7.8.3"
-			}
-		},
-		"babel-preset-solid": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-0.17.0.tgz",
-			"integrity": "sha512-Q1h14CD3Hv46tnxFljXZ3k6ayQfTTiHHW+rPCHW1tvOJQ/fp4QUOw8RQH04QguZwOEfTnviV0GTzZ5SIdk3AKw==",
-			"dev": true,
-			"requires": {
-				"babel-plugin-jsx-dom-expressions": "~0.17.0"
-			}
-		},
-		"buffer-from": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
-		},
-		"builtin-modules": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-			"integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
-			"dev": true
-		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
-		},
-		"commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
-		},
-		"convert-source-map": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.1.1"
-			}
-		},
-		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-			"dev": true,
-			"requires": {
-				"ms": "^2.1.1"
-			}
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
-		},
-		"estree-walker": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-			"dev": true
-		},
-		"fsevents": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-			"dev": true,
-			"optional": true
-		},
-		"gensync": {
-			"version": "1.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
-			"dev": true
-		},
-		"globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
-		},
-		"is-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-			"dev": true
-		},
-		"jest-worker": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
-			"dev": true,
-			"requires": {
-				"merge-stream": "^2.0.0",
-				"supports-color": "^6.1.0"
-			},
-			"dependencies": {
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
-		},
-		"jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true
-		},
-		"json5": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.5"
-			}
-		},
-		"lodash": {
-			"version": "4.17.19",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-			"dev": true
-		},
-		"merge-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"dev": true
-		},
-		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
-		},
-		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
-		},
-		"picomatch": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-			"dev": true
-		},
-		"resolve": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-			"dev": true,
-			"requires": {
-				"path-parse": "^1.0.6"
-			}
-		},
-		"rollup": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.1.0.tgz",
-			"integrity": "sha512-gfE1455AEazVVTJoeQtcOq/U6GSxwoj4XPSWVsuWmgIxj7sBQNLDOSA82PbdMe+cP8ql8fR1jogPFe8Wg8g4SQ==",
-			"dev": true,
-			"requires": {
-				"fsevents": "~2.1.2"
-			}
-		},
-		"rollup-plugin-babel": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
-			"integrity": "sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"rollup-pluginutils": "^2.8.1"
-			}
-		},
-		"rollup-plugin-terser": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
-			"integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"jest-worker": "^24.9.0",
-				"rollup-pluginutils": "^2.8.2",
-				"serialize-javascript": "^2.1.2",
-				"terser": "^4.6.2"
-			}
-		},
-		"rollup-pluginutils": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-			"dev": true,
-			"requires": {
-				"estree-walker": "^0.6.1"
-			},
-			"dependencies": {
-				"estree-walker": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-					"dev": true
-				}
-			}
-		},
-		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
-		},
-		"serialize-javascript": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-			"dev": true
-		},
-		"solid-js": {
-			"version": "0.17.2",
-			"resolved": "https://registry.npmjs.org/solid-js/-/solid-js-0.17.2.tgz",
-			"integrity": "sha512-uU3/DV9j9zaJ8LYZ2kNhJI05pJBPx4eg3z2SpflNgRG+HQ6Il7Staid+AgjArm4CFuQR4VDvl8Ojqsvlb9smWA=="
-		},
-		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
-		},
-		"source-map-support": {
-			"version": "0.5.19",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-			"dev": true,
-			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
-		"terser": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-			"integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
-			"dev": true,
-			"requires": {
-				"commander": "^2.20.0",
-				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.12"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
-		}
-	}
+  "name": "js-framework-benchmark-solid",
+  "version": "0.20.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/core": {
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+      "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.11.6",
+        "@babel/helper-module-transforms": "^7.11.0",
+        "@babel/helpers": "^7.10.4",
+        "@babel/parser": "^7.11.5",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.11.5",
+        "@babel/types": "^7.11.5",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+      "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.5",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+      "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+      "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+      "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-simple-access": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.11.0",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+      "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+      "dev": true
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+      "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+      "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+      "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+      "dev": true
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
+      "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/template": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+      "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+      "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.11.5",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.11.5",
+        "@babel/types": "^7.11.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/types": {
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+      "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@rollup/plugin-babel": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.1.tgz",
+      "integrity": "sha512-Jd7oqFR2dzZJ3NWANDyBjwTtX/lYbZpVcmkHrfQcpvawHs9E4c0nYk5U2mfZ6I/DZcIvy506KZJi54XK/jxH7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@rollup/pluginutils": "^3.1.0"
+      }
+    },
+    "@rollup/plugin-node-resolve": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz",
+      "integrity": "sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
+      "dev": true
+    },
+    "@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "babel-plugin-jsx-dom-expressions": {
+      "version": "0.20.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.20.8.tgz",
+      "integrity": "sha512-rh+n0WqdwW/bEiND+u4IhJAEifP/lLTF42/B8BYmUiE7dvf3ONTPHzgkgq2Gn3B3uZEv2pg2D4ebRaR5g27SHA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/plugin-syntax-jsx": "^7.10.4"
+      }
+    },
+    "babel-plugin-transform-rename-import": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-rename-import/-/babel-plugin-transform-rename-import-2.3.0.tgz",
+      "integrity": "sha512-dPgJoT57XC0PqSnLgl2FwNvxFrWlspatX2dkk7yjKQj5HHGw071vAcOf+hqW8ClqcBDMvEbm6mevn5yHAD8mlQ==",
+      "dev": true
+    },
+    "babel-preset-solid": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-0.20.0.tgz",
+      "integrity": "sha512-sSc9vVYq9gGsdm8ASYE+CyBSfotcPijrheiFKhGt+BE0wk/vGGK7lES6YqrH/EjXvAJXZWplS6A0s2w21aCFZA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jsx-dom-expressions": "~0.20.8",
+        "babel-plugin-transform-rename-import": "^2.3.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "debug": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
+    "jest-worker": {
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+      "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json5": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "rollup": {
+      "version": "2.28.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
+      "integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      }
+    },
+    "rollup-plugin-terser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "solid-js": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-0.20.0.tgz",
+      "integrity": "sha512-/N3AcyS3r5ead90WvEqx68g45JaxTyCsIM6Lglsrgl9psHEbvv9vuu2gobm0cjFltKTsnqNZPWappDDMiGobZw=="
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "terser": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.2.tgz",
+      "integrity": "sha512-H67sydwBz5jCUA32ZRL319ULu+Su1cAoZnnc+lXnenGRYWyLE3Scgkt8mNoAsMx0h5kdo758zdoS0LG9rYZXDQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    }
+  }
 }

--- a/frameworks/keyed/solid/package.json
+++ b/frameworks/keyed/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-solid",
-  "version": "0.17.2",
+  "version": "0.20.0",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "solid-js"
@@ -17,14 +17,14 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "solid-js": "0.17.2"
+    "solid-js": "0.20.0"
   },
   "devDependencies": {
-    "@babel/core": "7.9.0",
-    "@rollup/plugin-node-resolve": "7.1.1",
-    "babel-preset-solid": "0.17.0",
-    "rollup": "2.1.0",
-    "rollup-plugin-babel": "4.4.0",
-    "rollup-plugin-terser": "5.3.0"
+    "@babel/core": "7.11.6",
+    "@rollup/plugin-babel": "5.2.1",
+    "@rollup/plugin-node-resolve": "9.0.0",
+    "babel-preset-solid": "0.20.0",
+    "rollup": "2.28.2",
+    "rollup-plugin-terser": "7.0.2"
   }
 }

--- a/frameworks/keyed/solid/rollup.config.js
+++ b/frameworks/keyed/solid/rollup.config.js
@@ -1,24 +1,25 @@
-import resolve from '@rollup/plugin-node-resolve';
-import babel from 'rollup-plugin-babel';
-import { terser } from 'rollup-plugin-terser';
+import resolve from "@rollup/plugin-node-resolve";
+import babel from "@rollup/plugin-babel";
+import { terser } from "rollup-plugin-terser";
 
 const plugins = [
-	babel({
-		exclude: 'node_modules/**',
-		presets: ['solid']
+  babel({
+    babelHelpers: "bundled",
+    exclude: "node_modules/**",
+    presets: ["solid"],
   }),
-	resolve({ extensions: ['.js', '.jsx'] })
+  resolve({ extensions: [".js", ".jsx"] }),
 ];
 
 if (process.env.production) {
-	plugins.push(terser());
+  plugins.push(terser({ output: { comments: false } }));
 }
 
 export default {
-	input: 'src/main.jsx',
-	output: {
-		file: 'dist/main.js',
-		format: 'iife'
-	},
-	plugins
+  input: "src/main.jsx",
+  output: {
+    file: "dist/main.js",
+    format: "iife",
+  },
+  plugins,
 };

--- a/frameworks/keyed/vuerx-jsx/package-lock.json
+++ b/frameworks/keyed/vuerx-jsx/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "js-framework-benchmark-vuerx-jsx",
-	"version": "0.0.2",
+	"version": "0.0.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -14,36 +14,36 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+			"integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.0",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helpers": "^7.9.0",
-				"@babel/parser": "^7.9.0",
-				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0",
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.11.6",
+				"@babel/helper-module-transforms": "^7.11.0",
+				"@babel/helpers": "^7.10.4",
+				"@babel/parser": "^7.11.5",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.11.5",
+				"@babel/types": "^7.11.5",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
 				"json5": "^2.1.2",
-				"lodash": "^4.17.13",
+				"lodash": "^4.17.19",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-			"integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+			"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.5",
+				"@babel/types": "^7.11.5",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			}
@@ -69,12 +69,12 @@
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-			"integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+			"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.5"
+				"@babel/types": "^7.11.0"
 			}
 		},
 		"@babel/helper-module-imports": {
@@ -87,17 +87,17 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-			"integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+			"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.10.4",
 				"@babel/helper-replace-supers": "^7.10.4",
 				"@babel/helper-simple-access": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
 				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.5",
+				"@babel/types": "^7.11.0",
 				"lodash": "^4.17.19"
 			}
 		},
@@ -139,12 +139,12 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-			"integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.11.0"
 			}
 		},
 		"@babel/helper-validator-identifier": {
@@ -176,9 +176,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-			"integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+			"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
 			"dev": true
 		},
 		"@babel/plugin-syntax-jsx": {
@@ -202,26 +202,26 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-			"integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+			"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.10.5",
+				"@babel/generator": "^7.11.5",
 				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
-				"@babel/parser": "^7.10.5",
-				"@babel/types": "^7.10.5",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/parser": "^7.11.5",
+				"@babel/types": "^7.11.5",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.19"
 			}
 		},
 		"@babel/types": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-			"integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+			"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.10.4",
@@ -229,17 +229,28 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@rollup/plugin-node-resolve": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.1.tgz",
-			"integrity": "sha512-14ddhD7TnemeHE97a4rLOhobfYvUVcaYuqTnL8Ti7Jxi9V9Jr5LY7Gko4HZ5k4h4vqQM0gBQt6tsp9xXW94WPA==",
+		"@rollup/plugin-babel": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.1.tgz",
+			"integrity": "sha512-Jd7oqFR2dzZJ3NWANDyBjwTtX/lYbZpVcmkHrfQcpvawHs9E4c0nYk5U2mfZ6I/DZcIvy506KZJi54XK/jxH7A==",
 			"dev": true,
 			"requires": {
-				"@rollup/pluginutils": "^3.0.6",
-				"@types/resolve": "0.0.8",
+				"@babel/helper-module-imports": "^7.10.4",
+				"@rollup/pluginutils": "^3.1.0"
+			}
+		},
+		"@rollup/plugin-node-resolve": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz",
+			"integrity": "sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
 				"builtin-modules": "^3.1.0",
+				"deepmerge": "^4.2.2",
 				"is-module": "^1.0.0",
-				"resolve": "^1.14.2"
+				"resolve": "^1.17.0"
 			}
 		},
 		"@rollup/plugin-replace": {
@@ -270,32 +281,32 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.0.24",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.24.tgz",
-			"integrity": "sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==",
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
 			"dev": true
 		},
 		"@types/resolve": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-			"integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@vue/reactivity": {
-			"version": "3.0.0-beta.13",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.0-beta.13.tgz",
-			"integrity": "sha512-hP/Qa2LIyJA0UNq1+eyFRTyPXarZcdCtxLLlWziXbeoe/GgO6FWivnkDmVSJ5CqWE8ptw0cXDx/htUSn7P/u/g==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.0.tgz",
+			"integrity": "sha512-mEGkztGQrAPZRhV7C6PorrpT3+NtuA4dY2QjMzzrW31noKhssWTajRZTwpLF39NBRrF5UU6cp9+1I0FfavMgEQ==",
 			"requires": {
-				"@vue/shared": "3.0.0-beta.13"
+				"@vue/shared": "3.0.0"
 			}
 		},
 		"@vue/shared": {
-			"version": "3.0.0-beta.13",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.0-beta.13.tgz",
-			"integrity": "sha512-93g7tJH6tziqITygPh24XDJWnjrROI0wftCfFLSQu2hWoyd6OA5bdJI2n3HFv382o2sqMptGDXouKJRsQxMLmw=="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.0.tgz",
+			"integrity": "sha512-4XWL/avABGxU2E2ZF1eZq3Tj7fvksCMssDZUHOykBIMmh5d+KcAnQMC5XHMhtnA0NAvktYsA2YpdsVwVmhWzvA=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -307,13 +318,13 @@
 			}
 		},
 		"babel-plugin-jsx-dom-expressions": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.18.1.tgz",
-			"integrity": "sha512-/zsW7DnUQzgodhyqZPqeqOBZAG6icttalnSZDCHNSysOU2Y46gEWot56CsPTOFglv9H3vMMgA8D5Roi5pMIoPQ==",
+			"version": "0.20.8",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.20.8.tgz",
+			"integrity": "sha512-rh+n0WqdwW/bEiND+u4IhJAEifP/lLTF42/B8BYmUiE7dvf3ONTPHzgkgq2Gn3B3uZEv2pg2D4ebRaR5g27SHA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/plugin-syntax-jsx": "^7.8.3"
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/plugin-syntax-jsx": "^7.10.4"
 			}
 		},
 		"buffer-from": {
@@ -370,13 +381,19 @@
 			}
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 			"dev": true,
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
+		},
+		"deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -422,22 +439,29 @@
 			"dev": true
 		},
 		"jest-worker": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+			"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
 			"dev": true,
 			"requires": {
+				"@types/node": "*",
 				"merge-stream": "^2.0.0",
-				"supports-color": "^6.1.0"
+				"supports-color": "^7.0.0"
 			},
 			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
 				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -464,9 +488,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.19",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 			"dev": true
 		},
 		"magic-string": {
@@ -508,6 +532,15 @@
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
 		"resolve": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -518,52 +551,24 @@
 			}
 		},
 		"rollup": {
-			"version": "2.10.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.10.2.tgz",
-			"integrity": "sha512-tivFM8UXBlYOUqpBYD3pRktYpZvK/eiCQ190eYlrAyrpE/lzkyG2gbawroNdbwmzyUc7Y4eT297xfzv0BDh9qw==",
+			"version": "2.28.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
+			"integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.1.2"
 			}
 		},
-		"rollup-plugin-babel": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
-			"integrity": "sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"rollup-pluginutils": "^2.8.1"
-			}
-		},
 		"rollup-plugin-terser": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
-			"integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+			"integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"jest-worker": "^24.9.0",
-				"rollup-pluginutils": "^2.8.2",
-				"serialize-javascript": "^2.1.2",
-				"terser": "^4.6.2"
-			}
-		},
-		"rollup-pluginutils": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-			"dev": true,
-			"requires": {
-				"estree-walker": "^0.6.1"
-			},
-			"dependencies": {
-				"estree-walker": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-					"dev": true
-				}
+				"@babel/code-frame": "^7.10.4",
+				"jest-worker": "^26.2.1",
+				"serialize-javascript": "^4.0.0",
+				"terser": "^5.0.0"
 			}
 		},
 		"safe-buffer": {
@@ -579,10 +584,13 @@
 			"dev": true
 		},
 		"serialize-javascript": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-			"dev": true
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
 		},
 		"source-map": {
 			"version": "0.5.7",
@@ -624,9 +632,9 @@
 			}
 		},
 		"terser": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-			"integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.3.2.tgz",
+			"integrity": "sha512-H67sydwBz5jCUA32ZRL319ULu+Su1cAoZnnc+lXnenGRYWyLE3Scgkt8mNoAsMx0h5kdo758zdoS0LG9rYZXDQ==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -649,9 +657,9 @@
 			"dev": true
 		},
 		"vuerx-jsx": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/vuerx-jsx/-/vuerx-jsx-0.0.2.tgz",
-			"integrity": "sha512-pJICfdKZUVa/HJfYQyvtc3u7zuhPHGJN8zOlq6YfWs52Mz14LTZOL2ulq1K7HYSK/i6LeYuLtMSg4cO9XVIaLQ=="
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/vuerx-jsx/-/vuerx-jsx-0.0.8.tgz",
+			"integrity": "sha512-nqK99qk7rYqJOhhe4rT2hdYeORkuKtzndkvx7U8OkSLveEcyxiIqMdluqKmHO8v/GlQKl8YtzLsGlFq92Rg2Nw=="
 		}
 	}
 }

--- a/frameworks/keyed/vuerx-jsx/package.json
+++ b/frameworks/keyed/vuerx-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-vuerx-jsx",
-  "version": "0.0.2",
+  "version": "0.0.8",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "vuerx-jsx"
@@ -17,16 +17,16 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "vuerx-jsx": "0.0.2",
-    "@vue/reactivity": "3.0.0-beta.13"
+    "vuerx-jsx": "0.0.8",
+    "@vue/reactivity": "3.0.0"
   },
   "devDependencies": {
-    "@babel/core": "7.9.0",
-    "@rollup/plugin-node-resolve": "7.1.1",
+    "@babel/core": "7.11.6",
+    "@rollup/plugin-babel": "5.2.1",
+    "@rollup/plugin-node-resolve": "9.0.0",
     "@rollup/plugin-replace": "2.3.2",
-    "babel-plugin-jsx-dom-expressions": "0.18.1",
-    "rollup": "2.10.2",
-    "rollup-plugin-babel": "4.4.0",
-    "rollup-plugin-terser": "5.3.0"
+    "rollup": "2.28.2",
+    "rollup-plugin-terser": "7.0.2",
+    "babel-plugin-jsx-dom-expressions": "0.20.8"
   }
 }

--- a/frameworks/keyed/vuerx-jsx/rollup.config.js
+++ b/frameworks/keyed/vuerx-jsx/rollup.config.js
@@ -1,21 +1,22 @@
 import resolve from "@rollup/plugin-node-resolve";
 import replace from "@rollup/plugin-replace";
-import babel from "rollup-plugin-babel";
+import babel from "@rollup/plugin-babel";
 import { terser } from "rollup-plugin-terser";
 
 const plugins = [
   replace({
-    "process.env.NODE_ENV": JSON.stringify("production")
+    "process.env.NODE_ENV": JSON.stringify("production"),
   }),
   babel({
     exclude: "node_modules/**",
+    babelHelpers: "bundled",
     plugins: [["jsx-dom-expressions", { moduleName: "vuerx-jsx" }]],
   }),
   resolve({ extensions: [".js", ".jsx"] }),
 ];
 
 if (process.env.production) {
-  plugins.push(terser());
+  plugins.push(terser({ output: { comments: false } }));
 }
 
 export default {
@@ -24,5 +25,5 @@ export default {
     file: "dist/main.js",
     format: "iife",
   },
-  plugins
+  plugins,
 };

--- a/frameworks/keyed/vuerx-jsx/src/main.jsx
+++ b/frameworks/keyed/vuerx-jsx/src/main.jsx
@@ -1,5 +1,5 @@
-import { ref, computed } from "@vue/reactivity";
-import { render, map, effect, untracked } from 'vuerx-jsx';
+import { ref } from "@vue/reactivity";
+import { render, map } from 'vuerx-jsx';
 
 let idCounter = 1;
 const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"],
@@ -25,24 +25,19 @@ const Button = ({ id, text, fn }) =>
     <button id={ id } class='btn btn-primary btn-block' type='button' onClick={ fn }>{ text }</button>
   </div>
 
-const List = props => {
-  const mapped = computed(map(() => props.each, props.children));
-  effect(tr => {
-    let i, s = props.selected;
-    untracked(() => {
-      if (tr) tr.className = "";
-      if ((tr = s && (i = props.each.findIndex(el => el.id === s)) > -1 && mapped.value[i]))
-        tr.className = "danger";
-    });
-    return tr;
-  });
-  return () => mapped.value;
-};
-
 const App = () => {
-  let rowId;
   const data = ref([]),
     selected = ref(null);
+
+  const list = map(() => data.value, row => {
+    const rowId = row.id;
+    return <tr class={selected.value === rowId ? "danger" : ""}>
+      <td class='col-md-1' textContent={ rowId } />
+      <td class='col-md-4'><a onClick={[setSelected, rowId]} textContent={ row.label } /></td>
+      <td class='col-md-1'><a onClick={[remove, rowId]}><span class='glyphicon glyphicon-remove' aria-hidden="true" /></a></td>
+      <td class='col-md-6'/>
+    </tr>
+  })
 
   return <div class='container'>
     <div class='jumbotron'><div class='row'>
@@ -57,15 +52,7 @@ const App = () => {
       </div></div>
     </div></div>
     <table class='table table-hover table-striped test-data'><tbody>
-      <List each={ data.value } selected={ selected.value }>{ row => (
-        rowId = row.id,
-        <tr>
-          <td class='col-md-1' textContent={ rowId } />
-          <td class='col-md-4'><a onClick={[setSelected, rowId]} textContent={ row.label } /></td>
-          <td class='col-md-1'><a onClick={[remove, rowId]}><span class='glyphicon glyphicon-remove' aria-hidden="true" /></a></td>
-          <td class='col-md-6'/>
-        </tr>
-      )}</List>
+      {list}
     </tbody></table>
     <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
   </div>;


### PR DESCRIPTION
With this PR I remove all direct DOM manipulation. No `el.className = "danger"` anywhere. No clever DOM node caching using reactive memorization. Not even shortcutting the test by dirtying the data model with a selected on each row. All my libraries will be doing an inline `class={selected() === id ? "danger" : ""}` or equivalent from now on.

By doing so all my libraries will take a performance hit. But the front end of this benchmark has gotten a bit ridiculous with bending the expectation. I hope with this I can encourage others to remove shady not in the spirit of the test implementation pieces. But if not at least they can serve as an example.

----------------------------

That being said I'm looking forward to testing a new technique I've developed. Inspired by Recoil's `selectorFamily`, I've developed a new reactive primitive for propagating change conditionally. It creates a keyed signal that only updates when the key matches without creating additional computations.

 `class={selected(id) ? "danger" : ""}`

It is completely generic and has no knowledge of the DOM and can be leveraged like a normal signal in any data-binding or effect. It allows O(1) updates in these selection cases instead of O(n) and leverages the granularity to pull it off efficiently.

So far only Solid can leverage this technique though as I don't get the level of access I need in other libraries.