### PR TITLE
update Mikado to latest + fix issues

### DIFF
--- a/frameworks/keyed/mikado/package-lock.json
+++ b/frameworks/keyed/mikado/package-lock.json
@@ -1,269 +1,262 @@
 {
-	"name": "js-framework-benchmark-mikado-proxy",
-	"requires": true,
-	"lockfileVersion": 1,
-	"dependencies": {
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"requires": {
-				"color-convert": "^1.9.0"
-			}
-		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			}
-		},
-		"clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-			"dev": true
-		},
-		"clone-buffer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-			"dev": true
-		},
-		"clone-stats": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-			"dev": true
-		},
-		"cloneable-readable": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
-			"integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"process-nextick-args": "^2.0.0",
-				"readable-stream": "^2.3.5"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
-		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
-		},
-		"google-closure-compiler": {
-			"version": "20191030.0.0-nightly",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20191030.0.0-nightly.tgz",
-			"integrity": "sha512-ot3KqrIG5SXAUiqjRmcSuCFWhH7Di8TJSOUn5JByKuSQh9Mku5PRWH+tK2lzYlCRyS21pxkujXn+1S56J6Whwg==",
-			"dev": true,
-			"requires": {
-				"chalk": "2.x",
-				"google-closure-compiler-java": "^20191030.0.0-nightly",
-				"google-closure-compiler-js": "^20191030.0.0-nightly",
-				"google-closure-compiler-linux": "^20191030.0.0-nightly",
-				"google-closure-compiler-osx": "^20191030.0.0-nightly",
-				"google-closure-compiler-windows": "^20191030.0.0-nightly",
-				"minimist": "1.x",
-				"vinyl": "2.x",
-				"vinyl-sourcemaps-apply": "^0.2.0"
-			}
-		},
-		"google-closure-compiler-java": {
-			"version": "20191030.0.0-nightly",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20191030.0.0-nightly.tgz",
-			"integrity": "sha512-soorf1BMGUjKhl7lFJSgAkEs3SwmRdV06s8P1hpu9gG5qjf8xw5eOI25Kn6TqZ10aBrHo3QqM11YQDw4VQ9Q/w==",
-			"dev": true
-		},
-		"google-closure-compiler-js": {
-			"version": "20191030.0.0-nightly",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-js/-/google-closure-compiler-js-20191030.0.0-nightly.tgz",
-			"integrity": "sha512-krViSgflt2VJA2932kedSWBrzcfepJL89uy0kV28EYaO/JTDy2XbSyqMqvX9nOvkCtaL8jkEZ2fTXemxHuYMDQ==",
-			"dev": true
-		},
-		"google-closure-compiler-linux": {
-			"version": "20191030.0.0-nightly",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20191030.0.0-nightly.tgz",
-			"integrity": "sha512-yXg2y8Fkq3kwVAbFX+KUU0iXADuSUIxxCupy5HJIISfEKbx1LNSswYG2vAtYqaloexmzOOmN2douuHWxVLoEUQ==",
-			"dev": true,
-			"optional": true
-		},
-		"google-closure-compiler-osx": {
-			"version": "20191030.0.0-nightly",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20191030.0.0-nightly.tgz",
-			"integrity": "sha512-oXoWcRDtGOmlkBDMG/09yObZ9pJ7PcA5GTaEafA3z/JKyPHd87apfzXj8erZ61P90nexa/IidihaetRUgXfgJg==",
-			"dev": true,
-			"optional": true
-		},
-		"google-closure-compiler-windows": {
-			"version": "20191030.0.0-nightly",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20191030.0.0-nightly.tgz",
-			"integrity": "sha512-6sgwVIsU7AZn2GEUmt52pP25NKErWmeeqp0xTJGRzvOfdI/1RansS+xZ3pK+DzwgsimHQEzH0WLz29TmZG1XFg==",
-			"dev": true,
-			"optional": true
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
-		},
-		"html2json": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/html2json/-/html2json-1.0.2.tgz",
-			"integrity": "sha1-ydbSAvplQCOGwgKzRc9RvOgO0e8=",
-			"dev": true
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
-		},
-		"mikado": {
-			"version": "0.7.57",
-			"resolved": "https://registry.npmjs.org/mikado/-/mikado-0.7.57.tgz",
-			"integrity": "sha512-cNMaMUTYdbl3IuIrbg7I4TrGb+MI5f0+xcPZ1zvd2w+kyR9M6wE1gl+CGiOCP3mU21pAsiztO12z1UAr5TlC6Q=="
-		},
-		"mikado-compile": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/mikado-compile/-/mikado-compile-0.6.5.tgz",
-			"integrity": "sha512-6W4BWhdoLrGGQAPTC5ndqeofFZXAEEnNo3ySN/JgwomruwBo8F1yHWGh8UI2H5oRHWwyGyyH9DBc2c6/+kN87A==",
-			"dev": true,
-			"requires": {
-				"html2json": "^1.0.2"
-			}
-		},
-		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
-		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
-		},
-		"readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
-		},
-		"replace-ext": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
-			"integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
-			"dev": true
-		},
-		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
-		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
-		},
-		"vinyl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-			"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-			"dev": true,
-			"requires": {
-				"clone": "^2.1.1",
-				"clone-buffer": "^1.0.0",
-				"clone-stats": "^1.0.0",
-				"cloneable-readable": "^1.0.0",
-				"remove-trailing-separator": "^1.0.1",
-				"replace-ext": "^1.0.0"
-			}
-		},
-		"vinyl-sourcemaps-apply": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-			"integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
-			"dev": true,
-			"requires": {
-				"source-map": "^0.5.1"
-			}
-		}
-	}
+  "name": "js-framework-benchmark-mikado",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
+    },
+    "clone-stats": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "dev": true
+    },
+    "cloneable-readable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "google-closure-compiler": {
+      "version": "20200925.0.0-nightly",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20200925.0.0-nightly.tgz",
+      "integrity": "sha512-PnUvpqw7cOlCOjWBr6mTOFx7K+fNN53c61np4ftFZ8XTl69OQ3JKHkQnu+ru3XUpREb7hCKHalhq/LB5JEkK6w==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.x",
+        "google-closure-compiler-java": "^20200925.0.0-nightly",
+        "google-closure-compiler-linux": "^20200925.0.0-nightly",
+        "google-closure-compiler-osx": "^20200925.0.0-nightly",
+        "google-closure-compiler-windows": "^20200925.0.0-nightly",
+        "minimist": "1.x",
+        "vinyl": "2.x",
+        "vinyl-sourcemaps-apply": "^0.2.0"
+      }
+    },
+    "google-closure-compiler-java": {
+      "version": "20200925.0.0-nightly",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20200925.0.0-nightly.tgz",
+      "integrity": "sha512-9jeciG4yZuSDpSfrGp4x3k+eZvTjwlasaMy6mX3ZRYA9B10bEH/T/hqBWzFLOi31eg+/IIYWZRZMasx7/LCHow==",
+      "dev": true
+    },
+    "google-closure-compiler-linux": {
+      "version": "20200925.0.0-nightly",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20200925.0.0-nightly.tgz",
+      "integrity": "sha512-E7yQRoDbB2ZI/iEME1P4n5MRch1ccRYiEFVU6MkQqNi3Q/vfZ5ltp3X2MEM+WR2JsDFxk9ORvyZ2IXB07TUSxw==",
+      "dev": true,
+      "optional": true
+    },
+    "google-closure-compiler-osx": {
+      "version": "20200925.0.0-nightly",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20200925.0.0-nightly.tgz",
+      "integrity": "sha512-t7C5tvgX68cFVVOAzMFjIicuoofNRfhiZ7nlvqcOKq1wgI3Z2g8cEvQcQvvclHD8xQxxcDRkx+3NDbXIF/SnPA==",
+      "dev": true,
+      "optional": true
+    },
+    "google-closure-compiler-windows": {
+      "version": "20200925.0.0-nightly",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20200925.0.0-nightly.tgz",
+      "integrity": "sha512-TwrJBaE5EdZF0DDGXWdYiemLNDPLt6oz8OkIzjeWLGyC0xa7KHU1546EW1IL0dGl0rLl8mqwzoUSay1upMr5pA==",
+      "dev": true,
+      "optional": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "html2json": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html2json/-/html2json-1.0.2.tgz",
+      "integrity": "sha1-ydbSAvplQCOGwgKzRc9RvOgO0e8=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "mikado": {
+      "version": "0.7.62",
+      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.7.62.tgz",
+      "integrity": "sha512-XBeReNxszxU4CRMT/W8bkCk79GMWQQCYcmEMl+KneW/sgoGevh84pyAr3GIzIjb63xWQqOR90YAXHbGj5/Zs8g=="
+    },
+    "mikado-compile": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mikado-compile/-/mikado-compile-0.6.5.tgz",
+      "integrity": "sha512-6W4BWhdoLrGGQAPTC5ndqeofFZXAEEnNo3ySN/JgwomruwBo8F1yHWGh8UI2H5oRHWwyGyyH9DBc2c6/+kN87A==",
+      "dev": true,
+      "requires": {
+        "html2json": "^1.0.2"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "replace-ext": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "vinyl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
+      "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
+      "dev": true,
+      "requires": {
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
+      }
+    },
+    "vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.5.1"
+      }
+    }
+  }
 }

--- a/frameworks/keyed/mikado/package.json
+++ b/frameworks/keyed/mikado/package.json
@@ -1,12 +1,11 @@
 {
   "private": true,
-  "name": "js-framework-benchmark-mikado-proxy",
+  "name": "js-framework-benchmark-mikado",
   "homepage": "https://github.com/nextapps-de/mikado/",
   "author": "Nextapps GmbH",
   "license": "Apache-2.0",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "mikado",
-    "issues": [694, 800]
+    "frameworkVersionFromPackage": "mikado"
   },
   "preferGlobal": false,
   "repository": {
@@ -15,14 +14,14 @@
   },
   "scripts": {
     "compile": "mikado-compile src/template/app.html && mikado-compile src/template/item.html && echo Compile Complete. && exit 0",
-    "build": "npm run compile && node task/build RELEASE=custom DEBUG=false USE_POLYFILL=false SUPPORT_CACHE=false SUPPORT_EVENTS=true SUPPORT_STORAGE=true SUPPORT_HELPERS=false SUPPORT_ASYNC=false SUPPORT_TRANSPORT=false SUPPORT_TEMPLATE_EXTENSION=false SUPPORT_REACTIVE=true SUPPORT_CACHE_HELPERS=false SUPPORT_KEYED=false SUPPORT_POOLS=false SUPPORT_CALLBACKS=false SUPPORT_COMPILE=false && exit 0",
+    "build": "npm run compile && node task/build RELEASE=custom DEBUG=false USE_POLYFILL=false SUPPORT_CACHE=false SUPPORT_EVENTS=true SUPPORT_STORAGE=false SUPPORT_HELPERS=false SUPPORT_ASYNC=false SUPPORT_TRANSPORT=false SUPPORT_TEMPLATE_EXTENSION=false SUPPORT_REACTIVE=false SUPPORT_CACHE_HELPERS=false SUPPORT_KEYED=true SUPPORT_POOLS=false SUPPORT_CALLBACKS=false SUPPORT_COMPILE=false && exit 0",
     "build-prod": "npm run build"
   },
   "dependencies": {
-    "mikado": "^0.7.51"
+    "mikado": "^0.7.62"
   },
   "devDependencies": {
-    "google-closure-compiler": "^20191030.0.0-nightly",
+    "google-closure-compiler": "^20200925.0.0-nightly",
     "mikado-compile": "0.6.5"
   }
 }

--- a/frameworks/keyed/mikado/src/data.js
+++ b/frameworks/keyed/mikado/src/data.js
@@ -6,18 +6,9 @@ const len_ADJECTIVES = ADJECTIVES.length;
 const len_COLOURS = COLOURS.length;
 const len_NOUNS = NOUNS.length;
 
-let _nextId = 1;
+let nextId = 1;
 
-export function buildData(count){
-
-    // if(count === 1){
-    //
-    //     return {
-    //
-    //         id: _nextId++,
-    //         label: ADJECTIVES[_random(len_ADJECTIVES)] + " " + COLOURS[_random(len_COLOURS)] + " " + NOUNS[_random(len_NOUNS)]
-    //     }
-    // }
+export default function(count){
 
     const data = new Array(count);
 
@@ -25,16 +16,15 @@ export function buildData(count){
 
         data[i] = {
 
-            "id": _nextId++,
-            "label": ADJECTIVES[_random(len_ADJECTIVES)] + " " + COLOURS[_random(len_COLOURS)] + " " + NOUNS[_random(len_NOUNS)],
-            "selected": ""
+            "id": nextId++,
+            "label": ADJECTIVES[random(len_ADJECTIVES)] + " " + COLOURS[random(len_COLOURS)] + " " + NOUNS[random(len_NOUNS)]
         };
     }
 
     return data;
 }
 
-function _random(max){
+function random(max){
 
     return (Math.random() * max) | 0;
 }

--- a/frameworks/keyed/mikado/src/main.js
+++ b/frameworks/keyed/mikado/src/main.js
@@ -1,32 +1,29 @@
 import Mikado from "../node_modules/mikado/src/mikado.js";
-import Array from "../node_modules/mikado/src/array.js";
-import app from "./template/app.es6.js";
-import item from "./template/item.es6.js";
-import { buildData } from "./data.js";
+import tpl_app from "./template/app.es6.js";
+import tpl_item from "./template/item.es6.js";
+import buildData from "./data.js";
 
-Mikado.once(document.getElementById("main"), app);
+Mikado.once(document.getElementById("main"), tpl_app);
 
-let selected = 0;
-const store = new Array();
-const view = new Mikado(document.getElementById("tbody"), item, {
-    "reuse": false, "store": store
-})
-.route("run", () => store.set(buildData(1000)))
-.route("runlots", () => store.set(buildData(10000)))
-.route("add", () => store.concat(buildData(1000)))
+let data = [];
+const root = document.getElementById("tbody");
+const view = new Mikado(root, tpl_item, { "reuse": false, "state": 0 })
+.route("run", () => view.render(data = buildData(1000)))
+.route("runlots", () => view.render(data = buildData(10000)))
+.route("add", () => view.append(buildData(1000)))
 .route("update", () => {
-    for(let i = 0, len = store.length; i < len; i += 10)
-        store[i].label += " !!!"
+    for(let i = 0; i < view.length; i += 10){
+        data[i].label += " !!!";
+        view.update(i, data[i]);
+    }
 })
-.route("clear", () => store.splice())
+.route("clear", () => view.clear())
 .route("swaprows", () => {
-    const tmp = store[998];
-    store[998] = store[1];
-    store[1] = tmp;
+    const tmp = data[1];
+    data[1] = data[998];
+    data[998] = tmp;
+    view.reconcile(data);
 })
-.route("remove", target => store.splice(view.index(target), 1))
-.route("select", target => {
-    store[selected]["selected"] = "";
-    store[selected = view.index(target)]["selected"] = "danger";
-})
+.route("remove", target => view.remove(target))
+.route("select", target => view.update(target, data[view.state = view.index(target)]))
 .listen("click");

--- a/frameworks/keyed/mikado/src/template/item.html
+++ b/frameworks/keyed/mikado/src/template/item.html
@@ -1,7 +1,7 @@
-<tr class="{{=data.selected}}" root>
-    <td class="col-md-1">{{=data.id}}</td>
+<tr key="data.id" class="{{( this.state === index ? 'danger' : '' )}}" root>
+    <td class="col-md-1">{{ data.id }}</td>
     <td class="col-md-4">
-        <a class="lbl" click="select:root">{{=data.label}}</a>
+        <a class="lbl" click="select:root">{{ data.label }}</a>
     </td>
     <td class="col-md-1">
         <a class="remove" click="remove:root">

--- a/frameworks/keyed/mikado/task/build.js
+++ b/frameworks/keyed/mikado/task/build.js
@@ -52,9 +52,9 @@ const parameter = (function(opt){
     compilation_level: "ADVANCED_OPTIMIZATIONS", //"WHITESPACE"
     use_types_for_optimization: true,
     //new_type_inf: true,
-    jscomp_warning: "newCheckTypes",
+    //jscomp_warning: "newCheckTypes",
     //jscomp_error: "strictCheckTypes",
-    jscomp_error: "newCheckTypesExtraChecks",
+    //jscomp_error: "newCheckTypesExtraChecks",
     generate_exports: true,
     export_local_property_definitions: true,
     language_in: "ECMASCRIPT6_STRICT",


### PR DESCRIPTION
Since the full proxy mode isn't allowed anymore for some reason, I changed the keyed implementation to non-proxy.

Passed Issues

- [x] 634 The HTML structure for the implementation is not fully correct.
- [x] 694 Keyed implementations must move the DOM nodes for swap rows
- [x] 772 Implementation uses manual DOM manipulations
- [x] 796 Implementation uses explicit requestAnimationFrame calls
- [x] 800 View state on the model
- [x] 801 Implementation uses manual event delegation