### PR TITLE
Update preact, riot and svelte to latest

### DIFF
--- a/frameworks/keyed/preact/package-lock.json
+++ b/frameworks/keyed/preact/package-lock.json
@@ -4429,9 +4429,9 @@
 			"dev": true
 		},
 		"preact": {
-			"version": "10.5.2",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.5.2.tgz",
-			"integrity": "sha512-4y2Q6kMiJtMONMJR7z+o8P5tGkMzVItyy77AXGrUdusv+dk4jwoS3KrpCBkFloY2xsScRJYwZQZrx89tTjDkOw=="
+			"version": "10.5.5",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.5.5.tgz",
+			"integrity": "sha512-5ONLNH1SXMzzbQoExZX4TELemNt+TEDb622xXFNfZngjjM9qtrzseJt+EfiUu4TZ6EJ95X5sE1ES4yqHFSIdhg=="
 		},
 		"private": {
 			"version": "0.1.8",

--- a/frameworks/keyed/preact/package.json
+++ b/frameworks/keyed/preact/package.json
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "7.10.4",
-    "preact": "10.5.2"
+    "preact": "^10.5.5"
   }
 }

--- a/frameworks/keyed/preact/src/Row.jsx
+++ b/frameworks/keyed/preact/src/Row.jsx
@@ -9,6 +9,7 @@ export class Row extends Component {
 		this.onDelete = this.onDelete.bind(this);
 		this.onClick = this.onClick.bind(this);
 	}
+
 	shouldComponentUpdate(nextProps, nextState) {
 		return nextProps.data !== this.props.data || nextProps.styleClass !== this.props.styleClass;
 	}
@@ -16,12 +17,13 @@ export class Row extends Component {
 	onDelete() {
 		this.props.onDelete(this.props.data.id);
 	}
+	
 	onClick() {
 		this.props.onClick(this.props.data.id);
 	}
 
 	render() {
-		let {styleClass, onClick, onDelete, data} = this.props;
+		let {styleClass, data} = this.props;
 		return (<tr className={styleClass}>
 			<td className="col-md-1">{data.id}</td>
 			<td className="col-md-4">

--- a/frameworks/keyed/reaml-preact/package-lock.json
+++ b/frameworks/keyed/reaml-preact/package-lock.json
@@ -386,9 +386,9 @@
       "dev": true
     },
     "preact": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.2.tgz",
-      "integrity": "sha512-4y2Q6kMiJtMONMJR7z+o8P5tGkMzVItyy77AXGrUdusv+dk4jwoS3KrpCBkFloY2xsScRJYwZQZrx89tTjDkOw=="
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.5.tgz",
+      "integrity": "sha512-5ONLNH1SXMzzbQoExZX4TELemNt+TEDb622xXFNfZngjjM9qtrzseJt+EfiUu4TZ6EJ95X5sE1ES4yqHFSIdhg=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/frameworks/keyed/reaml-preact/package.json
+++ b/frameworks/keyed/reaml-preact/package.json
@@ -11,7 +11,7 @@
   "author": "Utkarsh Kukreti",
   "license": "MIT",
   "dependencies": {
-    "preact": "10.5.2",
+    "preact": "^10.5.5",
     "reaml": "0.15.0"
   },
   "devDependencies": {

--- a/frameworks/keyed/riot/package-lock.json
+++ b/frameworks/keyed/riot/package-lock.json
@@ -60,27 +60,27 @@
 			}
 		},
 		"@riotjs/dom-bindings": {
-			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/@riotjs/dom-bindings/-/dom-bindings-4.8.1.tgz",
-			"integrity": "sha512-19cKHpdsVF4NKHSN60KL64ALC1UjpbJmJLdtuHgpyCZRt0DhFcEuZKjIFvgFdLNJbW18rrU+7TNRSDzuNC8wag==",
+			"version": "5.0.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@riotjs/dom-bindings/-/dom-bindings-5.0.0-alpha.2.tgz",
+			"integrity": "sha512-vvRIb6YchsnDOiO5kV1mppfttUhduf/oGDjfVPzdPbU5hRhf+tRktjIVLb2rO+b3J8v3oGqATLFAaQ3p0BdbPg==",
 			"requires": {
-				"@riotjs/util": "^1.3.1",
-				"domdiff": "^2.2.2"
+				"@riotjs/util": "^2.0.0"
 			}
 		},
 		"@riotjs/parser": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/@riotjs/parser/-/parser-4.2.1.tgz",
 			"integrity": "sha512-VOqX6Ne7Wt9ziV8GcAE/AARvV92HNiYeeIDzM7tPijduDkWYGKaFYlw+bcwAcg4DM8Pi4sExTceOHxAuqKH3dg==",
+			"dev": true,
 			"requires": {
 				"curri": "^1.0.1",
 				"dom-nodes": "^1.1.3"
 			}
 		},
 		"@riotjs/util": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@riotjs/util/-/util-1.3.1.tgz",
-			"integrity": "sha512-8MhO7mVyRGDY/oaH6X+Q6DCrtu9zWrLOySBA8S3Qe5AGyVInpCwvjiAWGKqNbz5r6GWm08/S9yN/hCdB3mTLWw=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@riotjs/util/-/util-2.0.0.tgz",
+			"integrity": "sha512-+FtbujwoRT/Gi2/tarL0I30GIBCFFLUGtuhEJbosT09cUcP839oML871Yc7w5Zxb/IHFV1GS0p1ZGWe3JeeEjw=="
 		},
 		"@riotjs/webpack-loader": {
 			"version": "4.0.3",
@@ -281,7 +281,8 @@
 		"acorn": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-			"integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
+			"integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.3",
@@ -418,7 +419,8 @@
 		"ast-types": {
 			"version": "0.13.3",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
-			"integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA=="
+			"integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==",
+			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.3",
@@ -1208,14 +1210,6 @@
 			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
 			"dev": true
 		},
-		"domdiff": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/domdiff/-/domdiff-2.2.2.tgz",
-			"integrity": "sha512-Pv7aH5JfjNIkLRKkah+T3Kd41Gy+7GU+5dmPsOZZXsCJ34QR1i7CCiWraUn1c/a40htShxAQ8mHJR2OqPd12+Q==",
-			"requires": {
-				"uarray": "^1.0.0"
-			}
-		},
 		"duplexify": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -1715,9 +1709,9 @@
 			}
 		},
 		"globals": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.1.0.tgz",
-			"integrity": "sha512-4N8AdK8YMcr4nLOUsCP62jhMVAaJVdrEevrmuqHQ/TTXCXVL8ywhd/whKrufcp1zGtKBqw4DHcvsokQ60khOJA==",
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.3.0.tgz",
+			"integrity": "sha512-RjuvsMnQXQWjVGClrHIVdKOkYZcP/4UrgrZxIFdEyp+NvradqD4bNtPmtTn4mv4NMvVqdFCzaJuGGA9QpKjZmA==",
 			"requires": {
 				"type-fest": "^0.8.1"
 			}
@@ -2672,7 +2666,8 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
 		},
 		"process": {
 			"version": "0.11.10",
@@ -2816,20 +2811,33 @@
 			}
 		},
 		"recast": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/recast/-/recast-0.19.1.tgz",
-			"integrity": "sha512-8FCjrBxjeEU2O6I+2hyHyBFH1siJbMBLwIRvVr1T3FD2cL754sOaJDsJ/8h3xYltasbJ8jqWRIhMuDGBSiSbjw==",
+			"version": "0.20.4",
+			"resolved": "https://registry.npmjs.org/recast/-/recast-0.20.4.tgz",
+			"integrity": "sha512-6qLIBGGRcwjrTZGIiBpJVC/NeuXpogXNyRQpqU1zWPUigCphvApoCs9KIwDYh1eDuJ6dAFlQoi/QUyE5KQ6RBQ==",
 			"requires": {
-				"ast-types": "0.13.3",
+				"ast-types": "0.14.2",
 				"esprima": "~4.0.0",
-				"private": "^0.1.8",
-				"source-map": "~0.6.1"
+				"source-map": "~0.6.1",
+				"tslib": "^2.0.1"
 			},
 			"dependencies": {
+				"ast-types": {
+					"version": "0.14.2",
+					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+					"integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+					"requires": {
+						"tslib": "^2.0.1"
+					}
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"tslib": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
 				}
 			}
 		},
@@ -2934,13 +2942,13 @@
 			}
 		},
 		"riot": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/riot/-/riot-4.12.0.tgz",
-			"integrity": "sha512-roMDW12GMxhXZBu2ncvjESB9NFCVWdcdGC7xDLCzekMqOLgHCeX5kva441JQi/2ofFNRJRNuv2N1WFFBSW3z8Q==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/riot/-/riot-5.0.0.tgz",
+			"integrity": "sha512-PO+z7YB4jhjEz/Z1wmou8KCBL+LNZttW5WOvf14ZWSoH0s1Rv46HzCEMxEWbUdQhSlYSNYhAyb/Z+tso5tkjsQ==",
 			"requires": {
-				"@riotjs/compiler": "^4.8.2",
-				"@riotjs/dom-bindings": "^4.8.1",
-				"@riotjs/util": "^1.3.1",
+				"@riotjs/compiler": "^5.0.0",
+				"@riotjs/dom-bindings": "5.0.0-alpha.2",
+				"@riotjs/util": "^2.0.0",
 				"bianco.attr": "^1.0.0",
 				"bianco.query": "^1.0.0",
 				"cumpa": "^1.0.1",
@@ -2948,21 +2956,35 @@
 			},
 			"dependencies": {
 				"@riotjs/compiler": {
-					"version": "4.9.3",
-					"resolved": "https://registry.npmjs.org/@riotjs/compiler/-/compiler-4.9.3.tgz",
-					"integrity": "sha512-YAXxcW9peioxDKbOcwkC61m0hL1gHY4iq2Ev57PvbfmdsQk/P0BsBSw3252A1BM13lfWnZp7rMY+UQf3jaBtOw==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/@riotjs/compiler/-/compiler-5.0.0.tgz",
+					"integrity": "sha512-/gdGhS7Jqyys+Z8eLT9WK5rTuN3DC2i9kL/Tt+4ttBq1YvOXrX3eMXm9VBtWXGGCZVMFWnfpu75S1MwvoUhFVg==",
 					"requires": {
-						"@riotjs/parser": "^4.2.1",
-						"@riotjs/util": "1.3.1",
-						"acorn": "^7.3.1",
+						"@riotjs/parser": "^4.3.1",
+						"@riotjs/util": "2.0.0",
+						"acorn": "^8.0.4",
 						"cssesc": "^3.0.0",
 						"cumpa": "^1.0.1",
 						"curri": "^1.0.1",
 						"dom-nodes": "^1.1.3",
-						"globals": "^13.1.0",
-						"recast": "^0.19.1",
+						"globals": "^13.2.0",
+						"recast": "^0.20.4",
 						"source-map": "^0.7.3"
 					}
+				},
+				"@riotjs/parser": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/@riotjs/parser/-/parser-4.3.1.tgz",
+					"integrity": "sha512-ZUeAcey3ShAtquHBwuHFLrtPL1j0iEeXoOQoaZMaqVp15vq5UqOBxBcOVNfCXbr9ZbhnVCEEmek/9YFt5Ni8bA==",
+					"requires": {
+						"curri": "^1.0.1",
+						"dom-nodes": "^1.1.3"
+					}
+				},
+				"acorn": {
+					"version": "8.0.4",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz",
+					"integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ=="
 				}
 			}
 		},
@@ -3514,11 +3536,6 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
-		},
-		"uarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/uarray/-/uarray-1.0.0.tgz",
-			"integrity": "sha512-LHmiAd5QuAv7pU2vbh+Zq9YOnqVK0H764p2Ozinpfy9ka58OID4IsGLiXsitqH7n0NAIDxvax1A/kDXpii/Ckg=="
 		},
 		"union-value": {
 			"version": "1.0.1",

--- a/frameworks/keyed/riot/package.json
+++ b/frameworks/keyed/riot/package.json
@@ -16,6 +16,6 @@
     "webpack-cli": "3.3.11"
   },
   "dependencies": {
-    "riot": "4.12.0"
+    "riot": "^5.0.0"
   }
 }

--- a/frameworks/keyed/svelte/package-lock.json
+++ b/frameworks/keyed/svelte/package-lock.json
@@ -1,0 +1,517 @@
+{
+  "name": "js-framework-benchmark-svelte",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@rollup/plugin-commonjs": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-13.0.2.tgz",
+      "integrity": "sha512-9JXf2k8xqvMYfqmhgtB6eCgMN9fbxwF1XDF3mGKJc6pkAmt0jnsqurxQ0tC1akQKNSXCm7c3unQxa3zuxtZ7mQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "commondir": "^1.0.1",
+        "estree-walker": "^1.0.1",
+        "glob": "^7.1.2",
+        "is-reference": "^1.1.2",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.11.0"
+      }
+    },
+    "@rollup/plugin-node-resolve": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.4.0.tgz",
+      "integrity": "sha512-LFqKdRLn0ShtQyf6SBYO69bGE1upV6wUhBX0vFOUnLAyzx5cwp8svA0eHUnu8+YU57XOkrMtfG63QOpQx25pHQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deep-freeze": "^0.0.1",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==",
+      "dev": true
+    },
+    "@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
+      "integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
+    "is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
+    },
+    "jest-worker": {
+      "version": "26.6.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.1.tgz",
+      "integrity": "sha512-R5IE3qSGz+QynJx8y+ICEkdI2OJ3RJjRQVEyCcFAd3yVhQSEtquziPO29Mlzgn07LOVE8u8jhJ1FqcwegiXWOw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+      "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.0.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "rollup": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.13.1.tgz",
+      "integrity": "sha512-EiICynxIO1DTFmFn+/98gfaqCToK2nbjPjHJLuNvpcwc+P035VrXmJxi3JsOhqkdty+0cOEhJ26ceGTY3UPMPQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      }
+    },
+    "rollup-plugin-svelte": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-5.2.2.tgz",
+      "integrity": "sha512-I+TJ2T+VLKGbKQcpeMJ4AR2ciROqTZNjxbiMiH4Cn1yByaB9OEuy3CnrgHHuWatQcPuF3yIViyKX7OlETWDKOQ==",
+      "dev": true,
+      "requires": {
+        "require-relative": "^0.8.7",
+        "rollup-pluginutils": "^2.8.2",
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "rollup-plugin-terser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-6.1.0.tgz",
+      "integrity": "sha512-4fB3M9nuoWxrwm39habpd4hvrbrde2W2GG4zEGPQg1YITNkM3Tqur5jSuXlWNzbv/2aMLJ+dZJaySc3GCD8oDw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "jest-worker": "^26.0.0",
+        "serialize-javascript": "^3.0.0",
+        "terser": "^4.7.0"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+          "dev": true
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+      "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "svelte": {
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.29.4.tgz",
+      "integrity": "sha512-oW0fGHlyFFMvzRtIvOs84b0fOc0gmZNQcL5Is3hxuTpvaYX3pfd8oHy4KnOvbq4Ca6SG6AHdRMk7OhApTo0NqA==",
+      "dev": true
+    },
+    "terser": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/frameworks/keyed/svelte/package.json
+++ b/frameworks/keyed/svelte/package.json
@@ -20,11 +20,11 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "rollup": "2.13.1",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^8.0.1",
+    "rollup": "2.13.1",
     "rollup-plugin-svelte": "5.2.2",
     "rollup-plugin-terser": "^6.1.0",
-    "svelte": "3.28.0"
+    "svelte": "^3.29.4"
   }
 }

--- a/frameworks/non-keyed/riot/package-lock.json
+++ b/frameworks/non-keyed/riot/package-lock.json
@@ -60,27 +60,27 @@
 			}
 		},
 		"@riotjs/dom-bindings": {
-			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/@riotjs/dom-bindings/-/dom-bindings-4.8.1.tgz",
-			"integrity": "sha512-19cKHpdsVF4NKHSN60KL64ALC1UjpbJmJLdtuHgpyCZRt0DhFcEuZKjIFvgFdLNJbW18rrU+7TNRSDzuNC8wag==",
+			"version": "5.0.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@riotjs/dom-bindings/-/dom-bindings-5.0.0-alpha.2.tgz",
+			"integrity": "sha512-vvRIb6YchsnDOiO5kV1mppfttUhduf/oGDjfVPzdPbU5hRhf+tRktjIVLb2rO+b3J8v3oGqATLFAaQ3p0BdbPg==",
 			"requires": {
-				"@riotjs/util": "^1.3.1",
-				"domdiff": "^2.2.2"
+				"@riotjs/util": "^2.0.0"
 			}
 		},
 		"@riotjs/parser": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/@riotjs/parser/-/parser-4.2.1.tgz",
 			"integrity": "sha512-VOqX6Ne7Wt9ziV8GcAE/AARvV92HNiYeeIDzM7tPijduDkWYGKaFYlw+bcwAcg4DM8Pi4sExTceOHxAuqKH3dg==",
+			"dev": true,
 			"requires": {
 				"curri": "^1.0.1",
 				"dom-nodes": "^1.1.3"
 			}
 		},
 		"@riotjs/util": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@riotjs/util/-/util-1.3.1.tgz",
-			"integrity": "sha512-8MhO7mVyRGDY/oaH6X+Q6DCrtu9zWrLOySBA8S3Qe5AGyVInpCwvjiAWGKqNbz5r6GWm08/S9yN/hCdB3mTLWw=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@riotjs/util/-/util-2.0.0.tgz",
+			"integrity": "sha512-+FtbujwoRT/Gi2/tarL0I30GIBCFFLUGtuhEJbosT09cUcP839oML871Yc7w5Zxb/IHFV1GS0p1ZGWe3JeeEjw=="
 		},
 		"@riotjs/webpack-loader": {
 			"version": "4.0.3",
@@ -281,7 +281,8 @@
 		"acorn": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-			"integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
+			"integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.3",
@@ -418,7 +419,8 @@
 		"ast-types": {
 			"version": "0.13.3",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
-			"integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA=="
+			"integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==",
+			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.3",
@@ -1208,14 +1210,6 @@
 			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
 			"dev": true
 		},
-		"domdiff": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/domdiff/-/domdiff-2.2.2.tgz",
-			"integrity": "sha512-Pv7aH5JfjNIkLRKkah+T3Kd41Gy+7GU+5dmPsOZZXsCJ34QR1i7CCiWraUn1c/a40htShxAQ8mHJR2OqPd12+Q==",
-			"requires": {
-				"uarray": "^1.0.0"
-			}
-		},
 		"duplexify": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -1715,9 +1709,9 @@
 			}
 		},
 		"globals": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.1.0.tgz",
-			"integrity": "sha512-4N8AdK8YMcr4nLOUsCP62jhMVAaJVdrEevrmuqHQ/TTXCXVL8ywhd/whKrufcp1zGtKBqw4DHcvsokQ60khOJA==",
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.3.0.tgz",
+			"integrity": "sha512-RjuvsMnQXQWjVGClrHIVdKOkYZcP/4UrgrZxIFdEyp+NvradqD4bNtPmtTn4mv4NMvVqdFCzaJuGGA9QpKjZmA==",
 			"requires": {
 				"type-fest": "^0.8.1"
 			}
@@ -2672,7 +2666,8 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
 		},
 		"process": {
 			"version": "0.11.10",
@@ -2816,20 +2811,33 @@
 			}
 		},
 		"recast": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/recast/-/recast-0.19.1.tgz",
-			"integrity": "sha512-8FCjrBxjeEU2O6I+2hyHyBFH1siJbMBLwIRvVr1T3FD2cL754sOaJDsJ/8h3xYltasbJ8jqWRIhMuDGBSiSbjw==",
+			"version": "0.20.4",
+			"resolved": "https://registry.npmjs.org/recast/-/recast-0.20.4.tgz",
+			"integrity": "sha512-6qLIBGGRcwjrTZGIiBpJVC/NeuXpogXNyRQpqU1zWPUigCphvApoCs9KIwDYh1eDuJ6dAFlQoi/QUyE5KQ6RBQ==",
 			"requires": {
-				"ast-types": "0.13.3",
+				"ast-types": "0.14.2",
 				"esprima": "~4.0.0",
-				"private": "^0.1.8",
-				"source-map": "~0.6.1"
+				"source-map": "~0.6.1",
+				"tslib": "^2.0.1"
 			},
 			"dependencies": {
+				"ast-types": {
+					"version": "0.14.2",
+					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+					"integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+					"requires": {
+						"tslib": "^2.0.1"
+					}
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"tslib": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
 				}
 			}
 		},
@@ -2934,13 +2942,13 @@
 			}
 		},
 		"riot": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/riot/-/riot-4.12.0.tgz",
-			"integrity": "sha512-roMDW12GMxhXZBu2ncvjESB9NFCVWdcdGC7xDLCzekMqOLgHCeX5kva441JQi/2ofFNRJRNuv2N1WFFBSW3z8Q==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/riot/-/riot-5.0.0.tgz",
+			"integrity": "sha512-PO+z7YB4jhjEz/Z1wmou8KCBL+LNZttW5WOvf14ZWSoH0s1Rv46HzCEMxEWbUdQhSlYSNYhAyb/Z+tso5tkjsQ==",
 			"requires": {
-				"@riotjs/compiler": "^4.8.2",
-				"@riotjs/dom-bindings": "^4.8.1",
-				"@riotjs/util": "^1.3.1",
+				"@riotjs/compiler": "^5.0.0",
+				"@riotjs/dom-bindings": "5.0.0-alpha.2",
+				"@riotjs/util": "^2.0.0",
 				"bianco.attr": "^1.0.0",
 				"bianco.query": "^1.0.0",
 				"cumpa": "^1.0.1",
@@ -2948,21 +2956,35 @@
 			},
 			"dependencies": {
 				"@riotjs/compiler": {
-					"version": "4.9.3",
-					"resolved": "https://registry.npmjs.org/@riotjs/compiler/-/compiler-4.9.3.tgz",
-					"integrity": "sha512-YAXxcW9peioxDKbOcwkC61m0hL1gHY4iq2Ev57PvbfmdsQk/P0BsBSw3252A1BM13lfWnZp7rMY+UQf3jaBtOw==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/@riotjs/compiler/-/compiler-5.0.0.tgz",
+					"integrity": "sha512-/gdGhS7Jqyys+Z8eLT9WK5rTuN3DC2i9kL/Tt+4ttBq1YvOXrX3eMXm9VBtWXGGCZVMFWnfpu75S1MwvoUhFVg==",
 					"requires": {
-						"@riotjs/parser": "^4.2.1",
-						"@riotjs/util": "1.3.1",
-						"acorn": "^7.3.1",
+						"@riotjs/parser": "^4.3.1",
+						"@riotjs/util": "2.0.0",
+						"acorn": "^8.0.4",
 						"cssesc": "^3.0.0",
 						"cumpa": "^1.0.1",
 						"curri": "^1.0.1",
 						"dom-nodes": "^1.1.3",
-						"globals": "^13.1.0",
-						"recast": "^0.19.1",
+						"globals": "^13.2.0",
+						"recast": "^0.20.4",
 						"source-map": "^0.7.3"
 					}
+				},
+				"@riotjs/parser": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/@riotjs/parser/-/parser-4.3.1.tgz",
+					"integrity": "sha512-ZUeAcey3ShAtquHBwuHFLrtPL1j0iEeXoOQoaZMaqVp15vq5UqOBxBcOVNfCXbr9ZbhnVCEEmek/9YFt5Ni8bA==",
+					"requires": {
+						"curri": "^1.0.1",
+						"dom-nodes": "^1.1.3"
+					}
+				},
+				"acorn": {
+					"version": "8.0.4",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz",
+					"integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ=="
 				}
 			}
 		},
@@ -3514,11 +3536,6 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
-		},
-		"uarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/uarray/-/uarray-1.0.0.tgz",
-			"integrity": "sha512-LHmiAd5QuAv7pU2vbh+Zq9YOnqVK0H764p2Ozinpfy9ka58OID4IsGLiXsitqH7n0NAIDxvax1A/kDXpii/Ckg=="
 		},
 		"union-value": {
 			"version": "1.0.1",

--- a/frameworks/non-keyed/riot/package.json
+++ b/frameworks/non-keyed/riot/package.json
@@ -16,6 +16,6 @@
     "webpack-cli": "3.3.11"
   },
   "dependencies": {
-    "riot": "4.12.0"
+    "riot": "^5.0.0"
   }
 }

--- a/frameworks/non-keyed/svelte/package-lock.json
+++ b/frameworks/non-keyed/svelte/package-lock.json
@@ -314,9 +314,9 @@
 			}
 		},
 		"svelte": {
-			"version": "3.18.1",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.18.1.tgz",
-			"integrity": "sha512-jl6VLGTytOjHu700LuXSX6LvwRKFLAxqT8McUD2f3NjMI6qakWXgXoVjT+/ZmXmr8DiwrN/074pA1o3Aye4bIA==",
+			"version": "3.29.4",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.29.4.tgz",
+			"integrity": "sha512-oW0fGHlyFFMvzRtIvOs84b0fOc0gmZNQcL5Is3hxuTpvaYX3pfd8oHy4KnOvbq4Ca6SG6AHdRMk7OhApTo0NqA==",
 			"dev": true
 		},
 		"terser": {

--- a/frameworks/non-keyed/svelte/package.json
+++ b/frameworks/non-keyed/svelte/package.json
@@ -25,6 +25,6 @@
     "rollup-plugin-node-resolve": "^5.0.3",
     "rollup-plugin-svelte": "5.1.0",
     "rollup-plugin-terser": "^5.0.0",
-    "svelte": "3.28.0"
+    "svelte": "^3.29.4"
   }
 }


### PR DESCRIPTION
Updated:
- preact & realm-preact to 10.5.5
- riot to 5.0.0
- svelte to 3.29.4