### PR TITLE
Vue.next updated to 3.0.2

### DIFF
--- a/frameworks/keyed/vue-next/index.html
+++ b/frameworks/keyed/vue-next/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Vue.js</title>
+  <title>Vue.js 3</title>
   <link href="/css/currentStyle.css" rel="stylesheet"/>
 </head>
 <body>

--- a/frameworks/keyed/vue-next/package.json
+++ b/frameworks/keyed/vue-next/package.json
@@ -20,12 +20,12 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "@vue/compiler-sfc": "^3.0.0-beta.2",
-    "vue-loader": "^16.0.0-alpha.1",
+    "@vue/compiler-sfc": "^3.0.2",
+    "vue-loader": "^16.0.0-rc.2",
     "webpack": "^4.41.4",
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
-    "vue": "^3.0.0-beta.2"
+    "vue": "^3.0.2"
   }
 }

--- a/frameworks/keyed/vue-next/src/App.vue
+++ b/frameworks/keyed/vue-next/src/App.vue
@@ -2,7 +2,7 @@
     <div class="jumbotron">
         <div class="row">
             <div class="col-md-6">
-                <h1>Vue.js 3.0.0-beta2 (keyed)</h1>
+                <h1>Vue.js 3.0.2 (keyed)</h1>
             </div>
             <div class="col-md-6">
                 <div class="row">

--- a/frameworks/non-keyed/vue-next/index.html
+++ b/frameworks/non-keyed/vue-next/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Vue.js</title>
+  <title>Vue.js 3</title>
   <link href="/css/currentStyle.css" rel="stylesheet"/>
 </head>
 <body>

--- a/frameworks/non-keyed/vue-next/package.json
+++ b/frameworks/non-keyed/vue-next/package.json
@@ -20,12 +20,12 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "@vue/compiler-sfc": "^3.0.0-beta.2",
-    "vue-loader": "^16.0.0-alpha.1",
+    "@vue/compiler-sfc": "^3.0.2",
+    "vue-loader": "^16.0.0-rc.2",
     "webpack": "^4.41.4",
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
-    "vue": "^3.0.0-beta.2"
+    "vue": "^3.0.2"
   }
 }

--- a/frameworks/non-keyed/vue-next/src/App.vue
+++ b/frameworks/non-keyed/vue-next/src/App.vue
@@ -2,7 +2,7 @@
     <div class="jumbotron">
         <div class="row">
             <div class="col-md-6">
-                <h1>Vue.js 3.0.0-beta2 (non-keyed)</h1>
+                <h1>Vue.js 3.0.2 (non-keyed)</h1>
             </div>
             <div class="col-md-6">
                 <div class="row">


### PR DESCRIPTION
Existing tests were based beta version and since then Vue 3 has been released, with many improvements. This patch upgrades yo latest Vue3