### PR TITLE
Fix explicit use of requestAnimationFrame in BDC

### DIFF
--- a/frameworks/keyed/bdc/package.json
+++ b/frameworks/keyed/bdc/package.json
@@ -9,8 +9,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "bdc",
-    "issues": [796]
+    "frameworkVersionFromPackage": "bdc"
   },
   "dependencies": {
     "bdc": "0.3.0"

--- a/frameworks/keyed/bdc/src/app.js
+++ b/frameworks/keyed/bdc/src/app.js
@@ -173,16 +173,9 @@ function render() {
 }
 
 let $root;
-let redrawQueued = false;
 
 function redraw() {
-  if (!redrawQueued) {
-    redrawQueued = true;
-    window.requestAnimationFrame(() => {
-      redrawQueued = false;
-      clobber($root, render());
-    });
-  }
+  clobber($root, render());
 }
 
 export function install($newRoot) {

--- a/frameworks/non-keyed/bdc/package.json
+++ b/frameworks/non-keyed/bdc/package.json
@@ -9,8 +9,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "bdc",
-    "issues": [796]
+    "frameworkVersionFromPackage": "bdc"
   },
   "dependencies": {
     "bdc": "0.3.0"

--- a/frameworks/non-keyed/bdc/src/app.js
+++ b/frameworks/non-keyed/bdc/src/app.js
@@ -172,16 +172,9 @@ function render() {
 }
 
 let $root;
-let redrawQueued = false;
 
 function redraw() {
-  if (!redrawQueued) {
-    redrawQueued = true;
-    window.requestAnimationFrame(() => {
-      redrawQueued = false;
-      clobber($root, render());
-    });
-  }
+  clobber($root, render());
 }
 
 export function install($newRoot) {


### PR DESCRIPTION
There was no good excuse for having this in before.