### PR TITLE
Update Preact, Vue, Riot and others

### DIFF
--- a/frameworks/keyed/alpine/package.json
+++ b/frameworks/keyed/alpine/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "alpinejs": "2.8.0"
+    "alpinejs": "2.8.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "9.0.0",

--- a/frameworks/keyed/alpine/package.json
+++ b/frameworks/keyed/alpine/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "alpinejs": "2.7.0"
+    "alpinejs": "2.8.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "9.0.0",

--- a/frameworks/keyed/hyperapp/package.json
+++ b/frameworks/keyed/hyperapp/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "hyperapp-v2.0.4-js-benchmark",
+  "name": "hyperapp-v2.0.12-js-benchmark",
   "version": "1.0.0",
-  "description": "hyperapp v2.0.4 js benchmark",
+  "description": "hyperapp v2.0.12 js benchmark",
   "main": "index.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "hyperapp"
   },
   "dependencies": {
-    "hyperapp": "2.0.8"
+    "hyperapp": "2.0.12"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^7.1.3",

--- a/frameworks/keyed/inferno/package.json
+++ b/frameworks/keyed/inferno/package.json
@@ -32,6 +32,6 @@
     "rollup-plugin-terser": "5.1.1"
   },
   "dependencies": {
-    "inferno": "7.2.1"
+    "inferno": "7.4.8"
   }
 }

--- a/frameworks/keyed/preact/package.json
+++ b/frameworks/keyed/preact/package.json
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "7.10.4",
-    "preact": "10.5.5"
+    "preact": "10.5.12"
   }
 }

--- a/frameworks/keyed/reaml-preact/package.json
+++ b/frameworks/keyed/reaml-preact/package.json
@@ -11,7 +11,7 @@
   "author": "Utkarsh Kukreti",
   "license": "MIT",
   "dependencies": {
-    "preact": "10.5.5",
+    "preact": "10.5.12",
     "reaml": "0.15.0"
   },
   "devDependencies": {

--- a/frameworks/keyed/riot/package.json
+++ b/frameworks/keyed/riot/package.json
@@ -16,6 +16,6 @@
     "webpack-cli": "3.3.11"
   },
   "dependencies": {
-    "riot": "5.1.1"
+    "riot": "5.3.0"
   }
 }

--- a/frameworks/keyed/sinuous/package.json
+++ b/frameworks/keyed/sinuous/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "sinuous": "0.15.1"
+    "sinuous": "0.27.12"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",

--- a/frameworks/keyed/vue/package.json
+++ b/frameworks/keyed/vue/package.json
@@ -20,12 +20,12 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "@vue/compiler-sfc": "3.0.5",
+    "@vue/compiler-sfc": "3.0.6",
     "vue-loader": "16.1.2",
     "webpack": "4.41.4",
     "webpack-cli": "3.3.10"
   },
   "dependencies": {
-    "vue": "3.0.5"
+    "vue": "3.0.6"
   }
 }

--- a/frameworks/keyed/vue/package.json
+++ b/frameworks/keyed/vue/package.json
@@ -20,12 +20,12 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "@vue/compiler-sfc": "3.0.2",
-    "vue-loader": "16.0.0-rc.2",
+    "@vue/compiler-sfc": "3.0.5",
+    "vue-loader": "16.1.2",
     "webpack": "4.41.4",
     "webpack-cli": "3.3.10"
   },
   "dependencies": {
-    "vue": "3.0.2"
+    "vue": "3.0.5"
   }
 }

--- a/frameworks/non-keyed/inferno/package.json
+++ b/frameworks/non-keyed/inferno/package.json
@@ -32,6 +32,6 @@
     "rollup-plugin-terser": "5.1.1"
   },
   "dependencies": {
-    "inferno": "7.2.1"
+    "inferno": "7.4.8"
   }
 }

--- a/frameworks/non-keyed/riot/package.json
+++ b/frameworks/non-keyed/riot/package.json
@@ -16,6 +16,6 @@
     "webpack-cli": "3.3.11"
   },
   "dependencies": {
-    "riot": "5.1.1"
+    "riot": "5.3.0"
   }
 }

--- a/frameworks/non-keyed/vue/package.json
+++ b/frameworks/non-keyed/vue/package.json
@@ -20,12 +20,12 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "@vue/compiler-sfc": "3.0.5",
+    "@vue/compiler-sfc": "3.0.6",
     "vue-loader": "16.1.2",
     "webpack": "4.41.4",
     "webpack-cli": "3.3.10"
   },
   "dependencies": {
-    "vue": "^3.0.5"
+    "vue": "3.0.6"
   }
 }

--- a/frameworks/non-keyed/vue/package.json
+++ b/frameworks/non-keyed/vue/package.json
@@ -20,12 +20,12 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "@vue/compiler-sfc": "^3.0.2",
-    "vue-loader": "^16.0.0-rc.2",
-    "webpack": "^4.41.4",
-    "webpack-cli": "^3.3.10"
+    "@vue/compiler-sfc": "3.0.5",
+    "vue-loader": "16.1.2",
+    "webpack": "4.41.4",
+    "webpack-cli": "3.3.10"
   },
   "dependencies": {
-    "vue": "^3.0.2"
+    "vue": "^3.0.5"
   }
 }


### PR DESCRIPTION
Update `alpine`, `hyperapp`, `inferno`, `preact`, `riot`, `sinuous` and `vue` to latest version.