### PR TITLE
Mark some 800/801s

### DIFF
--- a/frameworks/keyed/heresy/package.json
+++ b/frameworks/keyed/heresy/package.json
@@ -4,7 +4,8 @@
   "description": "heresy demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "heresy"
+    "frameworkVersionFromPackage": "heresy",
+    "issues": [801]
   },
   "scripts": {
     "build-dev": "rollup -c -w",

--- a/frameworks/keyed/hyperhtml/package.json
+++ b/frameworks/keyed/hyperhtml/package.json
@@ -4,7 +4,8 @@
   "description": "hyper(HTML) demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "hyperhtml"
+    "frameworkVersionFromPackage": "hyperhtml",
+    "issues": [801]
   },
   "scripts": {
     "build-dev": "rollup -c -w",

--- a/frameworks/keyed/lighterhtml/package.json
+++ b/frameworks/keyed/lighterhtml/package.json
@@ -4,7 +4,8 @@
   "description": "lighterhtml demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "lighterhtml"
+    "frameworkVersionFromPackage": "lighterhtml",
+    "issues": [801]
   },
   "scripts": {
     "build-dev": "rollup -c -w",

--- a/frameworks/keyed/lit-html/package.json
+++ b/frameworks/keyed/lit-html/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "lit-html",
-    "issues": [800]
+    "issues": [800, 801]
   },
   "scripts": {
     "build-dev": "rollup -c -w",

--- a/frameworks/keyed/s2/package.json
+++ b/frameworks/keyed/s2/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "s2 demo",
   "js-framework-benchmark": {
-    "frameworkVersion": "1.0.0"
+    "frameworkVersion": "1.0.0",
+    "issues": [800]
   },
   "scripts": {
     "build-dev": "echo 0",

--- a/frameworks/keyed/sifrr/package.json
+++ b/frameworks/keyed/sifrr/package.json
@@ -11,7 +11,7 @@
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "@sifrr/dom",
     "useShadowRoot": true,
-    "issues": [800]
+    "issues": [800, 801]
   },
   "repository": {
     "type": "git",

--- a/frameworks/keyed/sinuous/package.json
+++ b/frameworks/keyed/sinuous/package.json
@@ -4,7 +4,7 @@
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "sinuous",
-    "issues": [800]
+    "issues": [800, 801]
   },
   "scripts": {
     "build-dev": "rollup -c -w",

--- a/frameworks/keyed/uhtml/package.json
+++ b/frameworks/keyed/uhtml/package.json
@@ -4,7 +4,8 @@
   "description": "uhtml demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "uhtml"
+    "frameworkVersionFromPackage": "uhtml",
+    "issues": [801]
   },
   "scripts": {
     "build-dev": "rollup -c -w",


### PR DESCRIPTION
I'm not stoked about this PR but fair is fair. If we are going to mark some #801 we should mark them all. I only reviewed keyed implementations and skipped ones with 694 or 772 as I figure those can be re-eval'd should they change. And of course I skipped Marionette as it's basically a 772. I can see how the argument could be made otherwise since it doesn't manipulate the DOM but creates everything with DOM APIs, but there is no "template". It's also an 801 too as the events are definitely explicitly delegated but without template syntax or whatever I don't even know how to categorize it if isn't clearly 772. 