### PR TITLE
Remove Lit polyfill

### DIFF
--- a/frameworks/keyed/lit/index.html
+++ b/frameworks/keyed/lit/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <title>Lit</title>
   <link href="/css/currentStyle.css" rel="stylesheet"/>
-  <script src="https://unpkg.com/@webcomponents/webcomponentsjs@^2/webcomponents-loader.js"></script>
   <script async src="dist/main.js"></script>
 </head>
 <body>

--- a/frameworks/non-keyed/lit/index.html
+++ b/frameworks/non-keyed/lit/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <title>Lit</title>
   <link href="/css/currentStyle.css" rel="stylesheet"/>
-  <script src="https://unpkg.com/@webcomponents/webcomponentsjs@^2/webcomponents-loader.js"></script>
   <script async src="dist/main.js"></script>
 </head>
 <body>


### PR DESCRIPTION
PR to resolve this issue: https://github.com/lit/lit/issues/1855
Removed the polyfill.

Is there any reason we'd want to keep the polyfill?
 - In [many cases](https://lit.dev/docs/tools/requirements/#modern-browser-breakdown) it shouldn't be required.

### Testing

I ran `npm run check keyed/lit` and `npm run check non-keyed/lit`. I didn't benchmark the non-keyed/lit, but did benchmark keyed/lit.

### Screenshot

![image](https://user-images.githubusercontent.com/15080861/117527155-b9a0df00-af7e-11eb-857d-a9b6e13f5726.png)
