### PR TITLE
React + @grammarly/focal@0.8.5 benchmark

### DIFF
--- a/frameworks/keyed/react-focal/.prettierrc
+++ b/frameworks/keyed/react-focal/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "arrowParens": "avoid",
+  "printWidth": 100
+}

--- a/frameworks/keyed/react-focal/index.html
+++ b/frameworks/keyed/react-focal/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>React + Focal 0.8.5</title>
+    <link href="/css/currentStyle.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="main"></div>
+    <script src="dist/main.js"></script>
+  </body>
+</html>

--- a/frameworks/keyed/react-focal/package-lock.json
+++ b/frameworks/keyed/react-focal/package-lock.json
@@ -1,0 +1,1253 @@
+{
+  "name": "js-framework-benchmark-react-rxjs",
+  "version": "1.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@discoveryjs/json-ext": {
+      "version": "0.5.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
+      "integrity": "sha1-jwOiKgTeQ3JU6M6MyEujlokoh1I=",
+      "dev": true
+    },
+    "@grammarly/focal": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@grammarly/focal/-/focal-0.8.5.tgz",
+      "integrity": "sha512-jwUCFSkWwecvpwvWXN6SQsxzKbn4ej4NnIoRR4biNemXe0tkjPQWrp/w/iedDrkMdjHQ+9XUywsCjHOs7/ufwg=="
+    },
+    "@types/eslint": {
+      "version": "7.2.10",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@types/eslint/-/eslint-7.2.10.tgz",
+      "integrity": "sha1-S3qTaNRsD4zVQIwjKIpZqiOU2Rc=",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "@types/eslint-scope": {
+      "version": "3.7.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@types/eslint-scope/-/eslint-scope-3.7.0.tgz",
+      "integrity": "sha1-R5KBbjERnr1QaQKkgsrsSVH6vYY=",
+      "dev": true,
+      "requires": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.47",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@types/estree/-/estree-0.0.47.tgz",
+      "integrity": "sha1-16Udsg8GUO/sJM0EmU9SPZMXLtQ=",
+      "dev": true
+    },
+    "@types/json-schema": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "15.0.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@types/node/-/node-15.0.2.tgz",
+      "integrity": "sha1-UenAkg0bRZNuoENBqj4uWNM5+2c=",
+      "dev": true
+    },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha1-KrDV2i5YFflLC51LldHl8kOrLKc=",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "17.0.5",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@types/react/-/react-17.0.5.tgz",
+      "integrity": "sha1-PYh1cMRIkBH3Wj/I+WW/h9CaG+o=",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "17.0.4",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@types/react-dom/-/react-dom-17.0.4.tgz",
+      "integrity": "sha1-1lFZqEesoqD8h6dUSi+P7Oh1TQQ=",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha1-GIRSBehv8AOFF6q3oYpiprn3EnU=",
+      "dev": true
+    },
+    "@webassemblyjs/ast": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/ast/-/ast-1.11.0.tgz",
+      "integrity": "sha1-papnnv3J5RcHpCBxOdpXkgVVlh8=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/helper-numbers": "1.11.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.0"
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.0.tgz",
+      "integrity": "sha1-NNYgUvRTzUMQHXLqtJZqAiWHlHw=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-api-error": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.0.tgz",
+      "integrity": "sha1-quqPs7kj9KqptRL/VBsBP/to0tQ=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.0.tgz",
+      "integrity": "sha1-0CbCXRdeOIp9valpTpHnQ8vptkI=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-numbers": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.0.tgz",
+      "integrity": "sha1-erBBctVOMSzG6kKG19n6J8iM1Pk=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/floating-point-hex-parser": "1.11.0",
+        "@webassemblyjs/helper-api-error": "1.11.0",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.0.tgz",
+      "integrity": "sha1-hf3NpBKZAv6G+Bq/fnI2lT7FpOE=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.0.tgz",
+      "integrity": "sha1-nOLMiTACYlCcgBtK8RPRyiXBp1s=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.11.0",
+        "@webassemblyjs/helper-buffer": "1.11.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
+        "@webassemblyjs/wasm-gen": "1.11.0"
+      }
+    },
+    "@webassemblyjs/ieee754": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/ieee754/-/ieee754-1.11.0.tgz",
+      "integrity": "sha1-RpddWD+YKPXQlKwhDiGUQcTm9c8=",
+      "dev": true,
+      "requires": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/leb128/-/leb128-1.11.0.tgz",
+      "integrity": "sha1-9zU94d84qiAcup+4i0P0H3X/QDs=",
+      "dev": true,
+      "requires": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/utf8": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/utf8/-/utf8-1.11.0.tgz",
+      "integrity": "sha1-huSPlZz0ng5QkfBppwm4YvWiyt8=",
+      "dev": true
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.0.tgz",
+      "integrity": "sha1-7kpcn2dwRqIQVCrmOJcJTCAny3g=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.11.0",
+        "@webassemblyjs/helper-buffer": "1.11.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
+        "@webassemblyjs/helper-wasm-section": "1.11.0",
+        "@webassemblyjs/wasm-gen": "1.11.0",
+        "@webassemblyjs/wasm-opt": "1.11.0",
+        "@webassemblyjs/wasm-parser": "1.11.0",
+        "@webassemblyjs/wast-printer": "1.11.0"
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.0.tgz",
+      "integrity": "sha1-PNs15wCC1Co1FmmI3aZPJM65er4=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.11.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
+        "@webassemblyjs/ieee754": "1.11.0",
+        "@webassemblyjs/leb128": "1.11.0",
+        "@webassemblyjs/utf8": "1.11.0"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.0.tgz",
+      "integrity": "sha1-FjiuGIE39LsDH1aKQTzSTTL5KXg=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.11.0",
+        "@webassemblyjs/helper-buffer": "1.11.0",
+        "@webassemblyjs/wasm-gen": "1.11.0",
+        "@webassemblyjs/wasm-parser": "1.11.0"
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.0.tgz",
+      "integrity": "sha1-PmgLiDDVsT0eyGzELzjz1KdwB1Q=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.11.0",
+        "@webassemblyjs/helper-api-error": "1.11.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
+        "@webassemblyjs/ieee754": "1.11.0",
+        "@webassemblyjs/leb128": "1.11.0",
+        "@webassemblyjs/utf8": "1.11.0"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webassemblyjs/wast-printer/-/wast-printer-1.11.0.tgz",
+      "integrity": "sha1-aA0falNl1tQBl0qOlJ4FR04fq34=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.11.0",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webpack-cli/configtest": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webpack-cli/configtest/-/configtest-1.0.3.tgz",
+      "integrity": "sha1-IEvP+HzaPqSBCIH36pbl9TIbh7k=",
+      "dev": true
+    },
+    "@webpack-cli/info": {
+      "version": "1.2.4",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webpack-cli/info/-/info-1.2.4.tgz",
+      "integrity": "sha1-c4H9QclXey2PbCWU+tOX70mtVXM=",
+      "dev": true,
+      "requires": {
+        "envinfo": "^7.7.3"
+      }
+    },
+    "@webpack-cli/serve": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@webpack-cli/serve/-/serve-1.4.0.tgz",
+      "integrity": "sha1-+E/Qe8rO/lbOdikleYhxCS8PIo4=",
+      "dev": true
+    },
+    "@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
+      "dev": true
+    },
+    "@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
+      "dev": true
+    },
+    "acorn": {
+      "version": "8.2.4",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/acorn/-/acorn-8.2.4.tgz",
+      "integrity": "sha1-yroksIGFw7VuMWjpfRXtF/TTH9A=",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browserslist": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.1.tgz",
+      "integrity": "sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001173",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.634",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.69"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001179",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz",
+      "integrity": "sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha1-yAs/qyi/Y3HmhjMl7uZ+YYt35q0=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "chrome-trace-event": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha1-EBXs7UdB4V0GZkqVfbv1DQQeJqw=",
+      "dev": true
+    },
+    "clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha1-wZ/Zvbv4WUK0/ZechNz31fB8I4c=",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+      "dev": true
+    },
+    "colorette": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "csstype": {
+      "version": "3.0.8",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha1-0iZqeScp+yJ80hb7Vy9Dco4a00A=",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.642",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.642.tgz",
+      "integrity": "sha512-cev+jOrz/Zm1i+Yh334Hed6lQVOkkemk2wRozfMF4MtTR7pxf3r3L5Rbd7uX1zMcEqVJ7alJBnJL7+JffkC6FQ==",
+      "dev": true
+    },
+    "enhanced-resolve": {
+      "version": "5.8.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
+      "integrity": "sha1-Fd3HeTRcu3PpfGEc0AwBwee/TYs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      }
+    },
+    "envinfo": {
+      "version": "7.8.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/envinfo/-/envinfo-7.8.1.tgz",
+      "integrity": "sha1-Bjd+Pl9NN5/qesWS1a2JJ+DE1HU=",
+      "dev": true
+    },
+    "es-module-lexer": {
+      "version": "0.4.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
+      "integrity": "sha1-3ajGoU2PNAok40Mx4Pqwy1BDjg4=",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+      "dev": true
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/events/-/events-3.3.0.tgz",
+      "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
+      "dev": true
+    },
+    "execa": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/execa/-/execa-5.0.0.tgz",
+      "integrity": "sha1-QCmwAHmYqEH70QMuX03oajweM3Y=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+      "dev": true
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha1-mZD306iMxan/0fF0V0UlFwDUl+I=",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
+      "dev": true
+    },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha1-x1KXCHyFG5pXi9IX3VmpL1n+VG4=",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4=",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+      "dev": true
+    },
+    "human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
+      "dev": true
+    },
+    "import-local": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/import-local/-/import-local-3.0.2.tgz",
+      "integrity": "sha1-qM/QQx0d5KIZlwPQA+PmI2T6bbY=",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      }
+    },
+    "interpret": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha1-GnigtZZcQKVBbQB61vUK0nxBffk=",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha1-venDJoDW+uBBKdasnZIc54FfeOM=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "jest-worker": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha1-f3LLxNZDw2Xie5/XdfnQ6qnHqO0=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
+      "dev": true
+    },
+    "loader-runner": {
+      "version": "4.2.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/loader-runner/-/loader-runner-4.2.0.tgz",
+      "integrity": "sha1-1wIjgNZtFMX7HUlriYZOvP1Hg4Q=",
+      "dev": true
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      }
+    },
+    "mime-db": {
+      "version": "1.47.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha1-jLMT5Zll08Bc+/iYkVomevRqM1w=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.30",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha1-bnvotMR5gl+F7WMmaV23P5MF1i0=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.47.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "1.1.70",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.70.tgz",
+      "integrity": "sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.3",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/picomatch/-/picomatch-2.2.3.tgz",
+      "integrity": "sha1-RlVH81nMwgbTxI5Goby4m/fuYZ0=",
+      "dev": true
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      }
+    },
+    "prettier": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha1-tqW/EoQCauZA8X9/9WWKdWf8DRg=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "react": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
+      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "react-dom": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
+      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.7.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/rechoir/-/rechoir-0.7.0.tgz",
+      "integrity": "sha1-MmUP1SwhqyUqpdZbGTEEQcfgOso=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.9.0"
+      }
+    },
+    "resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+      "dev": true
+    },
+    "scheduler": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
+      "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "semver": {
+      "version": "7.3.5",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha1-eIbshIBJpGJGepfT2Rjrsqr5NPQ=",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha1-jymBrZJTH1UDWwH7IwdppA4C76M=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
+      "dev": true
+    },
+    "source-list-map": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/source-list-map/-/source-list-map-2.0.1.tgz",
+      "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "tapable": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/tapable/-/tapable-2.2.0.tgz",
+      "integrity": "sha1-XDc9KB2cZyhIIT0OA30cQWWrQms=",
+      "dev": true
+    },
+    "terser": {
+      "version": "5.7.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/terser/-/terser-5.7.0.tgz",
+      "integrity": "sha1-p2Hu7CBryHtgWrEwKYdurZOK5pM=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+          "dev": true
+        }
+      }
+    },
+    "terser-webpack-plugin": {
+      "version": "5.1.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/terser-webpack-plugin/-/terser-webpack-plugin-5.1.1.tgz",
+      "integrity": "sha1-fv+t7gb37PoJPbvT6asj9fPthnM=",
+      "dev": true,
+      "requires": {
+        "jest-worker": "^26.6.2",
+        "p-limit": "^3.1.0",
+        "schema-utils": "^3.0.0",
+        "serialize-javascript": "^5.0.1",
+        "source-map": "^0.6.1",
+        "terser": "^5.5.1"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha1-Z1AvaqK2ai1AMrQnmilEl4oJE+8=",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "ts-loader": {
+      "version": "9.1.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/ts-loader/-/ts-loader-9.1.2.tgz",
+      "integrity": "sha1-upuauwWlFOj/gleRo/b895MnJyg=",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4"
+      }
+    },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "typescript": {
+      "version": "4.2.4",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha1-hhC1l0feAo/aiYqK7w4QPxVtCWE=",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha1-LeGWGMZtwkfc+2+ZM4A12CRaLO4=",
+      "dev": true
+    },
+    "watchpack": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/watchpack/-/watchpack-2.1.1.tgz",
+      "integrity": "sha1-6ZYwVQ/KB9+fkKBgVph7qkCmicc=",
+      "dev": true,
+      "requires": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "webpack": {
+      "version": "5.37.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/webpack/-/webpack-5.37.0.tgz",
+      "integrity": "sha1-KrAPYT+vSUUE6yvu8njat0k8w50=",
+      "dev": true,
+      "requires": {
+        "@types/eslint-scope": "^3.7.0",
+        "@types/estree": "^0.0.47",
+        "@webassemblyjs/ast": "1.11.0",
+        "@webassemblyjs/wasm-edit": "1.11.0",
+        "@webassemblyjs/wasm-parser": "1.11.0",
+        "acorn": "^8.2.1",
+        "browserslist": "^4.14.5",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.8.0",
+        "es-module-lexer": "^0.4.0",
+        "eslint-scope": "^5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.4",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.0.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.1.1",
+        "watchpack": "^2.0.0",
+        "webpack-sources": "^2.1.1"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha1-Z1AvaqK2ai1AMrQnmilEl4oJE+8=",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
+    "webpack-cli": {
+      "version": "4.7.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/webpack-cli/-/webpack-cli-4.7.0.tgz",
+      "integrity": "sha1-MZWnd/H4Auzacy9sldJMAAS8WjU=",
+      "dev": true,
+      "requires": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^1.0.3",
+        "@webpack-cli/info": "^1.2.4",
+        "@webpack-cli/serve": "^1.4.0",
+        "colorette": "^1.2.1",
+        "commander": "^7.0.0",
+        "execa": "^5.0.0",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^2.2.0",
+        "rechoir": "^0.7.0",
+        "v8-compile-cache": "^2.2.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha1-o2y1fQtQHOEI5NIFWaFQo5HZerc=",
+          "dev": true
+        }
+      }
+    },
+    "webpack-merge": {
+      "version": "5.7.3",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/webpack-merge/-/webpack-merge-5.7.3.tgz",
+      "integrity": "sha1-KgdU4Yd6Jai7qz0kdcpwoFJwghM=",
+      "dev": true,
+      "requires": {
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
+      }
+    },
+    "webpack-sources": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/webpack-sources/-/webpack-sources-2.2.0.tgz",
+      "integrity": "sha1-BYkm8549RDGTtsMVRyKYBv/QK6w=",
+      "dev": true,
+      "requires": {
+        "source-list-map": "^2.0.1",
+        "source-map": "^0.6.1"
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/which/-/which-2.0.2.tgz",
+      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wildcard": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/wildcard/-/wildcard-2.0.0.tgz",
+      "integrity": "sha1-p30g5SAMb6qsl55LOq3Hs91/j+w=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
+      "dev": true
+    }
+  }
+}

--- a/frameworks/keyed/react-focal/package.json
+++ b/frameworks/keyed/react-focal/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "js-framework-benchmark-react-rxjs",
+  "version": "1.1.1",
+  "description": "React demo",
+  "main": "index.tsx",
+  "js-framework-benchmark": {
+    "frameworkVersionFromPackage": "react:@grammarly/focal"
+  },
+  "scripts": {
+    "build-dev": "webpack --watch --mode=development",
+    "build-prod": "webpack --mode=production"
+  },
+  "keywords": [
+    "react",
+    "webpack"
+  ],
+  "author": "Ostap Chervak",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "devDependencies": {
+    "@types/react": "17.0.5",
+    "@types/react-dom": "17.0.4",
+    "prettier": "2.3.0",
+    "ts-loader": "9.1.2",
+    "typescript": "4.2.4",
+    "webpack": "5.37.0",
+    "webpack-cli": "4.7.0"
+  },
+  "dependencies": {
+    "@grammarly/focal": "0.8.5",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "rxjs": "6.6.3"
+  }
+}

--- a/frameworks/keyed/react-focal/src/index.tsx
+++ b/frameworks/keyed/react-focal/src/index.tsx
@@ -1,0 +1,162 @@
+import ReactDOM from 'react-dom'
+import { F, Atom } from '@grammarly/focal'
+
+const A = [
+  'pretty',
+  'large',
+  'big',
+  'small',
+  'tall',
+  'short',
+  'long',
+  'handsome',
+  'plain',
+  'quaint',
+  'clean',
+  'elegant',
+  'easy',
+  'angry',
+  'crazy',
+  'helpful',
+  'mushy',
+  'odd',
+  'unsightly',
+  'adorable',
+  'important',
+  'inexpensive',
+  'cheap',
+  'expensive',
+  'fancy'
+]
+const C = [
+  'red',
+  'yellow',
+  'blue',
+  'green',
+  'pink',
+  'brown',
+  'purple',
+  'brown',
+  'white',
+  'black',
+  'orange'
+]
+const N = [
+  'table',
+  'chair',
+  'house',
+  'bbq',
+  'desk',
+  'car',
+  'pony',
+  'cookie',
+  'sandwich',
+  'burger',
+  'pizza',
+  'mouse',
+  'keyboard'
+]
+
+const random = (max: number) => Math.round(Math.random() * 1000) % max
+
+interface Item {
+  id: number
+  label: string
+}
+
+let nextId = 1
+function buildData(count: number): Item[] {
+  const data = new Array(count)
+  for (let i = 0; i < count; i++) {
+    const id = nextId++
+    data[i] = {
+      id,
+      label: `${A[random(A.length)]} ${C[random(C.length)]} ${N[random(N.length)]}`
+    }
+  }
+  return data
+}
+
+const items = Atom.create<Item[]>([])
+const selectedItem = Atom.create<null | number>(null)
+
+const onReset = (amount: number) => items.set(buildData(amount))
+const onAdd = () => items.modify(data => data.concat(buildData(1000)))
+const onUpdate = () =>
+  items.modify(newData => {
+    const d = newData.slice()
+
+    for (let i = 0; i < d.length; i += 10) {
+      const r = d[i]!
+      d[i] = { id: r.id, label: r.label + ' !!!' }
+    }
+
+    return d
+  })
+const onClear = () => items.set([])
+const onSwap = () =>
+  items.modify(newData => {
+    const d = newData.slice()
+    const tmp = d[1]!
+    d[1] = d[998]!
+    d[998] = tmp
+    return d
+  })
+const onRemove = (id: number) =>
+  items.modify(newData => {
+    const idx = newData.findIndex(d => d.id === id)
+    return [...newData.slice(0, idx), ...newData.slice(idx + 1)]
+  })
+
+const onSelect = (id: number) => selectedItem.set(id)
+
+const GlyphIcon = <span className="glyphicon glyphicon-remove" aria-hidden="true" />
+
+const Row = ({ item }: { item: Item }) => (
+  <F.tr className={selectedItem.view(id => (id === item.id ? 'danger' : ''))}>
+    <td className="col-md-1">{item.id}</td>
+    <td className="col-md-4">
+      <a onClick={() => onSelect(item.id)}>{item.label}</a>
+    </td>
+    <td className="col-md-1">
+      <a onClick={() => onRemove(item.id)}>{GlyphIcon}</a>
+    </td>
+    <td className="col-md-6" />
+  </F.tr>
+)
+
+const Button = ({ id, title, cb }: { id: string; title: string; cb: () => void }) => (
+  <div className="col-sm-6 smallpad">
+    <button type="button" className="btn btn-primary btn-block" id={id} onClick={cb}>
+      {title}
+    </button>
+  </div>
+)
+
+const Main = () => (
+  <div className="container">
+    <div className="jumbotron">
+      <div className="row">
+        <div className="col-md-6">
+          <h1>React + Focal 0.8.5</h1>
+        </div>
+        <div className="col-md-6">
+          <div className="row">
+            <Button id="run" title="Create 1,000 rows" cb={() => onReset(1000)} />
+            <Button id="runlots" title="Create 10,000 rows" cb={() => onReset(10000)} />
+            <Button id="add" title="Append 1,000 rows" cb={onAdd} />
+            <Button id="update" title="Update every 10th row" cb={onUpdate} />
+            <Button id="clear" title="Clear" cb={onClear} />
+            <Button id="swaprows" title="Swap Rows" cb={onSwap} />
+          </div>
+        </div>
+      </div>
+    </div>
+    <table className="table table-hover table-striped test-data">
+      <F.tbody>{items.view(rows => rows.map(item => <Row key={item.id} item={item} />))}</F.tbody>
+    </table>
+    <span className="preloadicon glyphicon glyphicon-remove" aria-hidden="true" />
+  </div>
+)
+
+ReactDOM.render(<Main />, document.getElementById('main'))

--- a/frameworks/keyed/react-focal/tsconfig.json
+++ b/frameworks/keyed/react-focal/tsconfig.json
@@ -1,0 +1,71 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                         /* Enable incremental compilation */
+    "target": "ES2020",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "ES2020",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                                   /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                             /* Allow javascript files to be compiled. */
+    // "checkJs": true,                             /* Report errors in .js files. */
+    "jsx": "react-jsx",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
+    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true,                           /* Generates corresponding '.map' file. */
+    // "outFile": "./",                             /* Concatenate and emit output to single file. */
+    // "outDir": "./",                              /* Redirect output structure to the directory. */
+    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                           /* Enable project compilation */
+    // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
+    // "removeComments": true,                      /* Do not emit comments to output. */
+    // "noEmit": true,                              /* Do not emit outputs. */
+    // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                                 /* Enable all strict type-checking options. */
+    "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strictNullChecks": true,                    /* Enable strict null checks. */
+    "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
+    "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
+    "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
+    "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    "noUnusedLocals": true,                      /* Report errors on unused locals. */
+    "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+    "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+    "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
+    "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                             /* List of folders to include type definitions from. */
+    // "types": [],                                 /* Type declaration files to be included in compilation. */
+    "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                           /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
+  }
+}

--- a/frameworks/keyed/react-focal/webpack.config.js
+++ b/frameworks/keyed/react-focal/webpack.config.js
@@ -1,0 +1,23 @@
+const path = require('path')
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+    alias: {
+      '@grammarly/focal': '@grammarly/focal/dist/_esm2015/src'
+    }
+  },
+  output: {
+    filename: 'main.js',
+    path: path.resolve(__dirname, 'dist')
+  }
+}


### PR DESCRIPTION
Here is a benchmark for [@grammarly/focal library](https://github.com/grammarly/focal).
All local tests are passed 
![image](https://user-images.githubusercontent.com/13982649/118097337-3991d380-b3db-11eb-8ee5-4644098a1b95.png)


```bash
~/Projects/js-framework-benchmark/webdriver-ts % npm run check keyed/react-focal

> webdriver-ts@1.0.0 check /Users/ostap.chervak/Projects/js-framework-benchmark/webdriver-ts
> cross-env LANG="en_US.UTF-8" node dist/isKeyed.js "keyed/react-focal"

args.framework undefined true
http://localhost:8080/frameworks/keyed/react-focal/package-lock.json
Frameworks that will be checked react-focal-v17.0.1 + 0.8.5-keyed
react-focal-v17.0.1 + 0.8.5-keyed is keyed for 'run benchmark' and keyed for 'remove row benchmark' and keyed for 'swap rows benchmark' . It'll appear as keyed in the results
```