### PR TITLE
Update uhtml dependencies and logic

### DIFF
--- a/frameworks/keyed/uhtml/package-lock.json
+++ b/frameworks/keyed/uhtml/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "js-framework-benchmark-utils": "^0.2.5",
-        "uhtml": "^2.7.5"
+        "js-framework-benchmark-utils": "^0.3.2",
+        "uhtml": "^2.7.6"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^13.0.0",
-        "@ungap/degap": "^0.2.6",
-        "rollup": "^2.52.1",
+        "@ungap/degap": "^0.2.7",
+        "rollup": "^2.52.6",
         "rollup-plugin-includepaths": "^0.2.4",
         "rollup-plugin-minify-html-literals": "^1.2.6",
         "rollup-plugin-terser": "^7.0.2"
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "15.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
       "dev": true
     },
     "node_modules/@types/relateurl": {
@@ -156,9 +156,9 @@
       "integrity": "sha512-SHzmtS3KHG+gzNhO/E0tFqs12vNC5H3YxpF8a8AeodB/iX3ZYcxzS8vgWXbDGmHy6bgl7m+f9+wDKBdqOVT5FA=="
     },
     "node_modules/@ungap/degap": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@ungap/degap/-/degap-0.2.6.tgz",
-      "integrity": "sha512-aKLHshQtLsAJPK/iD9z+KTBpW2VqKeLhjWzcj4GAD0suYaJB/m8D2jchK6Vmq5oSvt0Kq9Bc+qAcDsv+LuxFVQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@ungap/degap/-/degap-0.2.7.tgz",
+      "integrity": "sha512-GYuRFTOU2RfiSGPMBFlPyAQs0E4dIxbsgwdQRkklrRokJZPu3TpRm4jUsW2p9dFngsP0GFQ2gsWr3fUasZz2rg==",
       "dev": true
     },
     "node_modules/ansi-styles": {
@@ -402,9 +402,9 @@
       }
     },
     "node_modules/js-framework-benchmark-utils": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/js-framework-benchmark-utils/-/js-framework-benchmark-utils-0.2.5.tgz",
-      "integrity": "sha512-ZUgxbyIUFrSjDlfPdXOO7z/tsB20PLOHWHu6X+UqIEj2mh52DRS/KKQ0RMuZBnUZ45kG1y/bI76CGxcVsIH5xA=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-framework-benchmark-utils/-/js-framework-benchmark-utils-0.3.2.tgz",
+      "integrity": "sha512-UvzhokIJ9bwcTNc677X+f2OionK0/GeAA/tCpZleT+mZub5yset/RX1uJX660tv3pEX1MG7Y53iIjhrIZfR1Rg=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -413,9 +413,9 @@
       "dev": true
     },
     "node_modules/jsx2tag": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/jsx2tag/-/jsx2tag-0.2.2.tgz",
-      "integrity": "sha512-f+CIHe9WtguESfMrjXxu0hJTMXrF6ey8GIdJCsaluslXFJNKFMz3Ccg+8nS6lOWEbFhBcthuqDzjSi1VeWcw0g=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/jsx2tag/-/jsx2tag-0.3.0.tgz",
+      "integrity": "sha512-AcELEC4kZIByPXqtK+QdaQ0t7MVZkZ9zjoitLwqGkpLkopDwBOwpG0JHxBcqGaVkv2KF3jPFp6l3l/5cN3J/Yw=="
     },
     "node_modules/lower-case": {
       "version": "1.1.4",
@@ -528,9 +528,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.52.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.1.tgz",
-      "integrity": "sha512-/SPqz8UGnp4P1hq6wc9gdTqA2bXQXGx13TtoL03GBm6qGRI6Hm3p4Io7GeiHNLl0BsQAne1JNYY+q/apcY933w==",
+      "version": "2.52.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.6.tgz",
+      "integrity": "sha512-H+Xudmwf8KO+xji8njQNoIQRp8l+iQge/NdUR20JngTxVYdEEnlpkMvQ71YGLl3+xZcPecmdj4q2lrClKaPdRA==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -658,9 +658,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.0.tgz",
-      "integrity": "sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
+      "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
       "dev": true,
       "dependencies": {
         "commander": "^2.20.0",
@@ -684,9 +684,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
-      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -707,9 +707,9 @@
       "integrity": "sha512-aqjTs5x/wsShZBkVagdafJkP8S3UMGhkHKszsu1cszjjZ7iOp86+Qb3QOFYh01oWjPMy5ZTuxD6hw5uTKxd+VA=="
     },
     "node_modules/uglify-js": {
-      "version": "3.13.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.9.tgz",
-      "integrity": "sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==",
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
+      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
       "dev": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -727,13 +727,13 @@
       }
     },
     "node_modules/uhtml": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/uhtml/-/uhtml-2.7.5.tgz",
-      "integrity": "sha512-IonRsI09IwTvdmSsb/tAui3IPBbyvoX91HlMafu5BVY7Rju5Uuzf7qqnF6fvQCgtZVZETxK3ziH2+yZPU7nsdQ==",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/uhtml/-/uhtml-2.7.6.tgz",
+      "integrity": "sha512-lq5Lb4zKstF0VCLfYlTtkHClMCyC5j8kFB3wWGZlhvMvRy/rd+D7q/bpcKfDibuuB1gRVvAPYHQWetNRyqTW4g==",
       "dependencies": {
         "@ungap/create-content": "^0.3.1",
         "async-tag": "^0.2.0",
-        "jsx2tag": "^0.2.1",
+        "jsx2tag": "^0.3.0",
         "uarray": "^1.0.0",
         "udomdiff": "^1.1.0",
         "uhandlers": "^0.5.0",
@@ -847,9 +847,9 @@
       }
     },
     "@types/node": {
-      "version": "15.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
       "dev": true
     },
     "@types/relateurl": {
@@ -882,9 +882,9 @@
       "integrity": "sha512-SHzmtS3KHG+gzNhO/E0tFqs12vNC5H3YxpF8a8AeodB/iX3ZYcxzS8vgWXbDGmHy6bgl7m+f9+wDKBdqOVT5FA=="
     },
     "@ungap/degap": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@ungap/degap/-/degap-0.2.6.tgz",
-      "integrity": "sha512-aKLHshQtLsAJPK/iD9z+KTBpW2VqKeLhjWzcj4GAD0suYaJB/m8D2jchK6Vmq5oSvt0Kq9Bc+qAcDsv+LuxFVQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@ungap/degap/-/degap-0.2.7.tgz",
+      "integrity": "sha512-GYuRFTOU2RfiSGPMBFlPyAQs0E4dIxbsgwdQRkklrRokJZPu3TpRm4jUsW2p9dFngsP0GFQ2gsWr3fUasZz2rg==",
       "dev": true
     },
     "ansi-styles": {
@@ -1075,9 +1075,9 @@
       }
     },
     "js-framework-benchmark-utils": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/js-framework-benchmark-utils/-/js-framework-benchmark-utils-0.2.5.tgz",
-      "integrity": "sha512-ZUgxbyIUFrSjDlfPdXOO7z/tsB20PLOHWHu6X+UqIEj2mh52DRS/KKQ0RMuZBnUZ45kG1y/bI76CGxcVsIH5xA=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-framework-benchmark-utils/-/js-framework-benchmark-utils-0.3.2.tgz",
+      "integrity": "sha512-UvzhokIJ9bwcTNc677X+f2OionK0/GeAA/tCpZleT+mZub5yset/RX1uJX660tv3pEX1MG7Y53iIjhrIZfR1Rg=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1086,9 +1086,9 @@
       "dev": true
     },
     "jsx2tag": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/jsx2tag/-/jsx2tag-0.2.2.tgz",
-      "integrity": "sha512-f+CIHe9WtguESfMrjXxu0hJTMXrF6ey8GIdJCsaluslXFJNKFMz3Ccg+8nS6lOWEbFhBcthuqDzjSi1VeWcw0g=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/jsx2tag/-/jsx2tag-0.3.0.tgz",
+      "integrity": "sha512-AcELEC4kZIByPXqtK+QdaQ0t7MVZkZ9zjoitLwqGkpLkopDwBOwpG0JHxBcqGaVkv2KF3jPFp6l3l/5cN3J/Yw=="
     },
     "lower-case": {
       "version": "1.1.4",
@@ -1189,9 +1189,9 @@
       }
     },
     "rollup": {
-      "version": "2.52.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.1.tgz",
-      "integrity": "sha512-/SPqz8UGnp4P1hq6wc9gdTqA2bXQXGx13TtoL03GBm6qGRI6Hm3p4Io7GeiHNLl0BsQAne1JNYY+q/apcY933w==",
+      "version": "2.52.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.6.tgz",
+      "integrity": "sha512-H+Xudmwf8KO+xji8njQNoIQRp8l+iQge/NdUR20JngTxVYdEEnlpkMvQ71YGLl3+xZcPecmdj4q2lrClKaPdRA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -1289,9 +1289,9 @@
       }
     },
     "terser": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.0.tgz",
-      "integrity": "sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
+      "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -1308,9 +1308,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
-      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "uarray": {
@@ -1324,9 +1324,9 @@
       "integrity": "sha512-aqjTs5x/wsShZBkVagdafJkP8S3UMGhkHKszsu1cszjjZ7iOp86+Qb3QOFYh01oWjPMy5ZTuxD6hw5uTKxd+VA=="
     },
     "uglify-js": {
-      "version": "3.13.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.9.tgz",
-      "integrity": "sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==",
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
+      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
       "dev": true
     },
     "uhandlers": {
@@ -1338,13 +1338,13 @@
       }
     },
     "uhtml": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/uhtml/-/uhtml-2.7.5.tgz",
-      "integrity": "sha512-IonRsI09IwTvdmSsb/tAui3IPBbyvoX91HlMafu5BVY7Rju5Uuzf7qqnF6fvQCgtZVZETxK3ziH2+yZPU7nsdQ==",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/uhtml/-/uhtml-2.7.6.tgz",
+      "integrity": "sha512-lq5Lb4zKstF0VCLfYlTtkHClMCyC5j8kFB3wWGZlhvMvRy/rd+D7q/bpcKfDibuuB1gRVvAPYHQWetNRyqTW4g==",
       "requires": {
         "@ungap/create-content": "^0.3.1",
         "async-tag": "^0.2.0",
-        "jsx2tag": "^0.2.1",
+        "jsx2tag": "^0.3.0",
         "uarray": "^1.0.0",
         "udomdiff": "^1.1.0",
         "uhandlers": "^0.5.0",

--- a/frameworks/keyed/uhtml/package.json
+++ b/frameworks/keyed/uhtml/package.json
@@ -4,10 +4,7 @@
   "description": "uhtml demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "uhtml",
-    "issues": [
-      801
-    ]
+    "frameworkVersionFromPackage": "uhtml"
   },
   "scripts": {
     "build-dev": "rollup -c -w",
@@ -27,13 +24,13 @@
   },
   "homepage": "https://github.com/krausest/js-framework-benchmark#readme",
   "dependencies": {
-    "js-framework-benchmark-utils": "^0.2.5",
-    "uhtml": "^2.7.5"
+    "js-framework-benchmark-utils": "^0.3.2",
+    "uhtml": "^2.7.6"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",
-    "@ungap/degap": "^0.2.6",
-    "rollup": "^2.52.1",
+    "@ungap/degap": "^0.2.7",
+    "rollup": "^2.52.6",
     "rollup-plugin-includepaths": "^0.2.4",
     "rollup-plugin-minify-html-literals": "^1.2.6",
     "rollup-plugin-terser": "^7.0.2"

--- a/frameworks/keyed/uhtml/src/index.js
+++ b/frameworks/keyed/uhtml/src/index.js
@@ -2,9 +2,9 @@ import {State} from 'js-framework-benchmark-utils';
 import {html, render} from 'uhtml';
 
 import Jumbotron from './jumbotron.js';
-import Table from './table-delegate.js';
+import Table from './table.js';
 
-const state = State(Table);
+const state = State(Table, false, html.for);
 
 render(document.getElementById('container'), html`
   <div class="container">

--- a/frameworks/keyed/uhtml/src/table.js
+++ b/frameworks/keyed/uhtml/src/table.js
@@ -1,0 +1,24 @@
+import {html} from 'uhtml';
+
+export default (state) => {
+  const {data, selected, selectRow, removeRow} = state;
+  return html.for(state)`
+    <table class="table table-hover table-striped test-data" .state=${state}>
+      <tbody>${
+      data.map(({id, label, html}) => html`
+        <tr id=${id} class=${id === selected ? 'danger' : ''}>
+          <td class="col-md-1">${id}</td>
+          <td class="col-md-4">
+            <a @click=${selectRow}>${label}</a>
+          </td>
+          <td class="col-md-1">
+            <a @click=${removeRow}>
+              <span class="glyphicon glyphicon-remove" aria-hidden="true" />
+            </a>
+          </td>
+          <td class="col-md-6" />
+        </tr>`
+      )}</tbody>
+    </table>
+  `;
+};


### PR DESCRIPTION
This MR applies the following changes:

  * previous techniques are preserved
  * the 801 "*issue*" has been removed
  * new helpers landed as dependency update
  * some logic has been moved (as implementation detail) to the helper
  * events are attached directly to the element, like others without 801 do
  * no trickery beyond the events ... these are *not* a top level delegate, even if that would give more perf boost

Thanks for considering this MR 👋