### PR TITLE
update fntags to 0.1.7

### DIFF
--- a/frameworks/keyed/fntags/package-lock.json
+++ b/frameworks/keyed/fntags/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@srfnstack/fntags": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@srfnstack/fntags/-/fntags-0.1.1.tgz",
-      "integrity": "sha512-3n2sjesYFGjjqwu1uJ8+Ho9iGWjU+hP5QmleZrDe0mJj3dXi274m0stenDrfJE36y9S6+Y1B5tJynCVD+tS2XQ=="
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@srfnstack/fntags/-/fntags-0.1.7.tgz",
+      "integrity": "sha512-ZJ5FkuQQ2VS9zZNwi1BFLvSAQ73v6Gw2VV+LtDbn4IQfFz1R4B8szCwRduBv/GdtxPHZnUlK//GpTuqLIr97QQ=="
     },
     "buffer-from": {
       "version": "1.1.1",

--- a/frameworks/keyed/fntags/package.json
+++ b/frameworks/keyed/fntags/package.json
@@ -12,7 +12,7 @@
   },
   "author": "Robert Kempton",
   "dependencies": {
-    "@srfnstack/fntags": "0.1.1"
+    "@srfnstack/fntags": "0.1.7"
   },
   "devDependencies": {
     "fs-extra": "8.1.0",


### PR DESCRIPTION
I was using setTimeout to schedule an async task instead of creating a Promise because I'm a noob. I'm expecting this version to be a bit quicker than the last one.