### PR TITLE
keyed/svelte: optimize hot loop by eliminating extra whitespace nodes

### DIFF
--- a/frameworks/keyed/svelte/src/Main.svelte
+++ b/frameworks/keyed/svelte/src/Main.svelte
@@ -31,15 +31,16 @@
 </div>
 <table class="table table-hover table-striped test-data">
   <tbody>
-    {#each data as row, num (row.id)}
-      <tr class={selected === row.id ? 'danger' : ''}>
-        <td class="col-md-1">{row.id}</td>
-        <td class="col-md-4">
-          <a on:click={() => select(row.id)}>{row.label}</a>
-        </td>
-        <td class="col-md-1"><a on:click={() => remove(row.id)}><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td>
-        <td class="col-md-6"></td>
-      </tr>
+    {#each data as row (row.id)}
+      <tr class={selected === row.id ? 'danger' : ''}
+        ><td class="col-md-1">{row.id}</td><td class="col-md-4"
+          ><a on:click={() => select(row.id)}>{row.label}</a></td
+        ><td class="col-md-1"
+          ><a on:click={() => remove(row.id)}
+            ><span class="glyphicon glyphicon-remove" aria-hidden="true" /></a
+          ></td
+        ><td class="col-md-6" /></tr
+      >
     {/each}
   </tbody>
 </table>


### PR DESCRIPTION
Svelte does not currently [1] remove purely whitespace text nodes like
most other frameworks do, which causes noticeable performance impact
when benchmarking creating thousands of rows.

This commit manually fixes that so that the generated HTML is closer to
the competing implementations, using a workaround mentioned in [1].

On my system, all the benchmarks involving creation of rows run ~5%
faster with this change and the overall geometric mean improves from
around 1.28 to 1.25.

[1]: https://github.com/sveltejs/svelte/issues/6540