### PR TITLE
Update `compostate-jsx` to `beta.10`

### DIFF
--- a/frameworks/keyed/compostate-jsx/package-lock.json
+++ b/frameworks/keyed/compostate-jsx/package-lock.json
@@ -13,12 +13,12 @@
         "compostate-jsx": "^0.2.1-beta.10"
       },
       "devDependencies": {
-        "@babel/core": "7.15.0",
+        "@babel/core": "7.15.5",
         "@rollup/plugin-babel": "5.3.0",
-        "@rollup/plugin-node-resolve": "13.0.4",
+        "@rollup/plugin-node-resolve": "13.0.5",
         "@rollup/plugin-replace": "^3.0.0",
-        "babel-plugin-jsx-dom-expressions": "^0.29.14",
-        "rollup": "2.56.3",
+        "babel-plugin-jsx-dom-expressions": "^0.29.17",
+        "rollup": "2.58.0",
         "rollup-plugin-terser": "7.0.2"
       }
     },
@@ -44,20 +44,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.0",
-        "@babel/helper-module-transforms": "^7.15.0",
-        "@babel/helpers": "^7.14.8",
-        "@babel/parser": "^7.15.0",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.5",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -67,6 +67,10 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
       }
     },
     "node_modules/@babel/generator": {
@@ -370,9 +374,9 @@
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "13.0.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz",
-      "integrity": "sha512-eYq4TFy40O8hjeDs+sIxEH/jc9lyuI2k9DM557WN6rO5OpnC2qXMBNj4IKH1oHrnAazL49C5p0tgP0/VpqJ+/w==",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.5.tgz",
+      "integrity": "sha512-mVaw6uxtvuGx/XCI4qBQXsDZJUfyx5vp39iE0J/7Hd6wDhEbjHr6aES7Nr9yWbuE0BY+oKp6N7Bq6jX5NCGNmQ==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
@@ -384,6 +388,9 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.42.0"
       }
     },
     "node_modules/@rollup/plugin-replace": {
@@ -444,9 +451,9 @@
       }
     },
     "node_modules/babel-plugin-jsx-dom-expressions": {
-      "version": "0.29.15",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.29.15.tgz",
-      "integrity": "sha512-chCcxW66Y0HirwRQT9CvZ7iwqJNxwerz4WAAHwsKSGwCjJ8z1lLOe/5AynkTglZYLkJam091bUOcygKh05gWig==",
+      "version": "0.29.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.29.17.tgz",
+      "integrity": "sha512-RGd2bUEu6Ym+t/eqS+CwhTMRBnoIgVUEPDD+rUx5GhwLLuGBbJI2tTC0Q92ScX1I5hQpJgveAvaaoDjjyGkgPA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.10.4",
@@ -832,9 +839,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.56.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
-      "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.58.0.tgz",
+      "integrity": "sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -981,20 +988,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.0",
-        "@babel/helper-module-transforms": "^7.15.0",
-        "@babel/helpers": "^7.14.8",
-        "@babel/parser": "^7.15.0",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.5",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -1232,9 +1239,9 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "13.0.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz",
-      "integrity": "sha512-eYq4TFy40O8hjeDs+sIxEH/jc9lyuI2k9DM557WN6rO5OpnC2qXMBNj4IKH1oHrnAazL49C5p0tgP0/VpqJ+/w==",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.5.tgz",
+      "integrity": "sha512-mVaw6uxtvuGx/XCI4qBQXsDZJUfyx5vp39iE0J/7Hd6wDhEbjHr6aES7Nr9yWbuE0BY+oKp6N7Bq6jX5NCGNmQ==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -1297,9 +1304,9 @@
       }
     },
     "babel-plugin-jsx-dom-expressions": {
-      "version": "0.29.15",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.29.15.tgz",
-      "integrity": "sha512-chCcxW66Y0HirwRQT9CvZ7iwqJNxwerz4WAAHwsKSGwCjJ8z1lLOe/5AynkTglZYLkJam091bUOcygKh05gWig==",
+      "version": "0.29.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.29.17.tgz",
+      "integrity": "sha512-RGd2bUEu6Ym+t/eqS+CwhTMRBnoIgVUEPDD+rUx5GhwLLuGBbJI2tTC0Q92ScX1I5hQpJgveAvaaoDjjyGkgPA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
@@ -1611,9 +1618,9 @@
       }
     },
     "rollup": {
-      "version": "2.56.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
-      "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.58.0.tgz",
+      "integrity": "sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/frameworks/keyed/compostate-jsx/package.json
+++ b/frameworks/keyed/compostate-jsx/package.json
@@ -21,12 +21,12 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "@babel/core": "7.15.0",
+    "@babel/core": "7.15.5",
     "@rollup/plugin-babel": "5.3.0",
-    "@rollup/plugin-node-resolve": "13.0.4",
+    "@rollup/plugin-node-resolve": "13.0.5",
     "@rollup/plugin-replace": "^3.0.0",
-    "babel-plugin-jsx-dom-expressions": "^0.29.14",
-    "rollup": "2.56.3",
+    "babel-plugin-jsx-dom-expressions": "^0.29.17",
+    "rollup": "2.58.0",
     "rollup-plugin-terser": "7.0.2"
   },
   "dependencies": {


### PR DESCRIPTION
Bump into new patch version. There's some internal rework so I'm not entirely sure if it will affect the benchmark drastically, however I'm being optimistic that it will.