### PR TITLE
Update webdriver-ts build command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ npm ci
 and build the benchmark driver
 
 ```
-npm run build-prod
+npm run compile
 ```
 
 now run the benchmark driver for the vanillajs-keyed framework:


### PR DESCRIPTION
The command for building the webdriver is mentioned as `npm run build-prod` in the readme, which is not correct.

Correct command is mentioned [here](https://github.com/krausest/js-framework-benchmark/tree/master/webdriver-ts#readme) which is `npm run compile`