### PR TITLE
Update Halogen

### DIFF
--- a/frameworks/non-keyed/halogen/index.html
+++ b/frameworks/non-keyed/halogen/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Halogen v5.0.0</title>
+    <title>Halogen v6.1.3</title>
     <link href="/css/currentStyle.css" rel="stylesheet" />
   </head>
   <body>

--- a/frameworks/non-keyed/halogen/package.json
+++ b/frameworks/non-keyed/halogen/package.json
@@ -4,7 +4,7 @@
   "description": "Purescript Halogen JS Benchmark",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersion": "5.0.0"
+    "frameworkVersion": "6.1.3"
   },
   "scripts": {
     "postinstall": "spago install",
@@ -24,7 +24,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "devDependencies": {
-    "purescript": "0.13.6",
-    "spago": "0.14.0"
+    "purescript": "0.14.5",
+    "spago": "0.20.3"
   }
 }

--- a/frameworks/non-keyed/halogen/packages.dhall
+++ b/frameworks/non-keyed/halogen/packages.dhall
@@ -1,10 +1,7 @@
 let upstream =
-  https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200331/packages.dhall sha256:350af1fdc68c91251138198f03ceedc4f8ed6651ee2af8a2177f87bcd64570d4
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.5-20211116/packages.dhall sha256:7ba810597a275e43c83411d2ab0d4b3c54d0b551436f4b1632e9ff3eb62e327a
 
-let overrides = 
-  { halogen =
-      upstream.halogen // { version = "v5.0.0-rc.8" }
-  }
+let overrides = {=}
 
 let additions = {=}
 

--- a/frameworks/non-keyed/halogen/spago.dhall
+++ b/frameworks/non-keyed/halogen/spago.dhall
@@ -1,5 +1,5 @@
 { name = "js-framework-benchmark-halogen"
-, dependencies = [ "halogen" ]
+, dependencies = [ "aff", "arrays", "effect", "halogen", "maybe", "prelude" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs" ]
 }

--- a/frameworks/non-keyed/halogen/src/Main.purs
+++ b/frameworks/non-keyed/halogen/src/Main.purs
@@ -1,5 +1,6 @@
 module Main where
 
+import Prim hiding (Row)
 import Prelude
 
 import Data.Array as Array
@@ -39,7 +40,7 @@ type Row =
   , label :: String
   }
 
-app :: forall q i o. H.Component HH.HTML q i o Aff
+app :: forall q i o. H.Component q i o Aff
 app = H.mkComponent
   { initialState
   , render
@@ -121,9 +122,9 @@ renderActionButton { id, label, action } =
     [ HH.button 
         [ HP.type_ HP.ButtonButton
         , class_ "btn btn-primary btn-block"
-        , HP.id_ id
+        , HP.id id
         , HP.attr (HH.AttrName "ref") "text"
-        , HE.onClick \_ -> Just action
+        , HE.onClick \_ -> action
         ]
         [ HH.text label ]
     ]
@@ -139,8 +140,8 @@ renderRow selectedId row =
       [ ]
     )
     [ HH.td colMd1 [ HH.text (show row.id) ]
-    , HH.td colMd4 [ HH.a [ HE.onClick \_ -> Just (Select row.id) ] [ HH.text row.label ] ]
-    , HH.td colMd1 [ HH.a [ HE.onClick \_ -> Just (Remove row.id) ] removeIcon ]
+    , HH.td colMd4 [ HH.a [ HE.onClick \_ -> Select row.id ] [ HH.text row.label ] ]
+    , HH.td colMd1 [ HH.a [ HE.onClick \_ -> Remove row.id ] removeIcon ]
     , spacer
     ]
 
@@ -181,7 +182,7 @@ jumbotron =
         [ class_ "row" ]
         [ HH.div
             [ class_ "col-md-6" ]
-            [ HH.h1_ [ HH.text "Halogen 5.0.0 (non-keyed)" ] ]
+            [ HH.h1_ [ HH.text "Halogen 6.1.3 (non-keyed)" ] ]
             , HH.div [ class_ "col-md-6" ] do
                 map (HH.lazy renderActionButton) buttons
             ]


### PR DESCRIPTION
This PR updates Halogen and the PureScript ecosystem to the latest version.
- PureScript 14.5
- Spago 20.3
- Halogen 6.1.3

It also includes minimal code changes to conform to Halogen 6. 