### PR TITLE
Upgrade Sinuous v0.28.0

### DIFF
--- a/frameworks/keyed/sinuous/package.json
+++ b/frameworks/keyed/sinuous/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "sinuous": "0.27.12"
+    "sinuous": "0.28.0"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",


### PR DESCRIPTION
This upgrades Sinuous to the latest version.

- Reverts to the old map diff algo which performed a lot better
  https://github.com/luwes/sinuous/pull/192