### PR TITLE
Updated Voby to v0.14.0

### DIFF
--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -6,7 +6,7 @@
     "frameworkVersionFromPackage": "voby"
   },
   "scripts": {
-    "build-prod": "rm -rf dist && mkdir dist && esbuild --bundle --minify --target=es2015 ./src/main.tsx > ./dist/main.js"
+    "build-prod": "rm -rf dist && mkdir dist && esbuild --bundle --minify --target=es2018 ./src/main.tsx > ./dist/main.js"
   },
   "author": "Fabio Spampinato",
   "license": "MIT",

--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "voby"
@@ -16,7 +16,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "voby": "0.13.0"
+    "voby": "0.14.0"
   },
   "devDependencies": {
     "esbuild": "0.14.28"

--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "voby"
@@ -16,7 +16,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "voby": "0.12.1"
+    "voby": "0.13.0"
   },
   "devDependencies": {
     "esbuild": "0.14.23"

--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -19,6 +19,6 @@
     "voby": "0.13.0"
   },
   "devDependencies": {
-    "esbuild": "0.14.23"
+    "esbuild": "0.14.28"
   }
 }

--- a/frameworks/keyed/voby/src/main.tsx
+++ b/frameworks/keyed/voby/src/main.tsx
@@ -86,7 +86,16 @@ const Model = (() => {
     $data.emit ();
   };
 
+  const dispose = (): void => {
+    const data = $data ();
+    for ( let i = 0, l = data.length; i < l; i++ ) {
+      data[i].label.dispose ();
+    }
+    isSelected.dispose ();
+  };
+
   const clear = (): void => {
+    dispose ();
     $data ( [] );
   };
 
@@ -94,6 +103,8 @@ const Model = (() => {
     const data = $data ();
     const index = data.findIndex ( datum => datum.id === id );
     if ( index === -1 ) return;
+    const datum = data[index];
+    datum.label.dispose ();
     data.splice ( index, 1 );
     $data.emit ();
   };
@@ -102,7 +113,9 @@ const Model = (() => {
     $selected ( id );
   };
 
-  return { $data, $selected, run, runLots, runWith, add, update, swapRows, clear, remove, select };
+  const isSelected = useSelector ( $selected );
+
+  return { $data, $selected, run, runLots, runWith, add, update, swapRows, dispose, clear, remove, select, isSelected };
 
 })();
 
@@ -114,7 +127,7 @@ const Button = ({ id, text, onClick }: { id: string | number, text: string, onCl
   </div>
 );
 
-const RowDynamic = ({ id, label, className, onSelect, onRemove }: { id: FunctionMaybe<string | number>, label: FunctionMaybe<string>, className: FunctionMaybe<string>, onSelect: ObservableMaybe<(( event: MouseEvent ) => any)>, onRemove: ObservableMaybe<(( event: MouseEvent ) => any)> }): JSX.Element => (
+const Row = template (({ id, label, className, onSelect, onRemove }: { id: FunctionMaybe<string | number>, label: FunctionMaybe<string>, className: FunctionMaybe<string>, onSelect: ObservableMaybe<(( event: MouseEvent ) => any)>, onRemove: ObservableMaybe<(( event: MouseEvent ) => any)> }): JSX.Element => (
   <tr className={className}>
     <td class="col-md-1">{id}</td>
     <td class="col-md-4">
@@ -127,14 +140,11 @@ const RowDynamic = ({ id, label, className, onSelect, onRemove }: { id: Function
     </td>
     <td class="col-md-6"></td>
   </tr>
-);
-
-const RowTemplate = template ( RowDynamic, { recycle: false } );
+));
 
 const App = (): JSX.Element => {
 
-  const {$data, $selected, run, runLots, add, update, clear, swapRows, select, remove} = Model;
-  const isSelected = useSelector ( $selected );
+  const {$data, run, runLots, add, update, swapRows, clear, remove, select, isSelected} = Model;
 
   return (
     <div class="container">
@@ -164,8 +174,7 @@ const App = (): JSX.Element => {
               const onSelect = select.bind ( undefined, id );
               const onRemove = remove.bind ( undefined, id );
               const props = {id, label, className, onSelect, onRemove};
-              return RowTemplate ( props );
-              // return RowDynamic ( props );
+              return Row ( props );
             }}
           </For>
         </tbody>


### PR DESCRIPTION
- v0.12 had faster clearing but it left some work to do in the future potentially, now clearing may be a bit slower but there's no leftover work or risks of memory leaks, though I had to resort to some manual disposition to gain some of that performance back.
- A fairly important bug got fixed, it just made things less efficient though, the framework still worked correctly as far as I can tell.
- The cache behind the crucial For component is more optimized.
- The framework is now tree shakeable, and its core is mangled. 

Basically the framework should do better on memory usage and startup tests, but it may be a bit slower.

Apparently today/tomorrow Chrome 100 will be released, I hope I submitted this in time for that.