### PR TITLE
Updated Voby to v0.18.1

### DIFF
--- a/frameworks/keyed/voby/package-lock.json
+++ b/frameworks/keyed/voby/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-voby",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
-        "voby": "0.18.0"
+        "voby": "0.18.1"
       },
       "devDependencies": {
         "esbuild": "0.14.28"
@@ -67,16 +67,16 @@
       }
     },
     "node_modules/oby": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/oby/-/oby-7.0.1.tgz",
-      "integrity": "sha512-lL84ZAdaP2yMyg+xSGcCR8VD2MpW3BRpZTSv5N1ZLtH79S3ihfRpj6mAKYRnDEiBqR4s1xn5Mi5Dkxh8qoM80Q=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/oby/-/oby-7.0.4.tgz",
+      "integrity": "sha512-r3c79sdXi1mdNFhpjNRiDx/zvRXUO58EhHDzasTZ/R4grDDif6HXrAkEDVszNjuTJhAubEgkQF/RtA+fq/QHFQ=="
     },
     "node_modules/voby": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/voby/-/voby-0.18.0.tgz",
-      "integrity": "sha512-ca2gGN/8XNvHXoyOfyTy8kjm7mbW9zyCZQkoyopIh0Yb3Pu0/P/43XxpDEo0/++2DNwISWNRBcGOKLIx9tm/uQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/voby/-/voby-0.18.1.tgz",
+      "integrity": "sha512-y5+3XYfMCACr8NTfwJ8d5ZPkd4HZHMnR19YEmh1rTIiSVauACFIyfPpbkMnLV37nM7ojD2CZnKlWgV2ApGOOQg==",
       "dependencies": {
-        "oby": "^7.0.1"
+        "oby": "^7.0.4"
       }
     }
   },
@@ -117,16 +117,16 @@
       "optional": true
     },
     "oby": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/oby/-/oby-7.0.1.tgz",
-      "integrity": "sha512-lL84ZAdaP2yMyg+xSGcCR8VD2MpW3BRpZTSv5N1ZLtH79S3ihfRpj6mAKYRnDEiBqR4s1xn5Mi5Dkxh8qoM80Q=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/oby/-/oby-7.0.4.tgz",
+      "integrity": "sha512-r3c79sdXi1mdNFhpjNRiDx/zvRXUO58EhHDzasTZ/R4grDDif6HXrAkEDVszNjuTJhAubEgkQF/RtA+fq/QHFQ=="
     },
     "voby": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/voby/-/voby-0.18.0.tgz",
-      "integrity": "sha512-ca2gGN/8XNvHXoyOfyTy8kjm7mbW9zyCZQkoyopIh0Yb3Pu0/P/43XxpDEo0/++2DNwISWNRBcGOKLIx9tm/uQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/voby/-/voby-0.18.1.tgz",
+      "integrity": "sha512-y5+3XYfMCACr8NTfwJ8d5ZPkd4HZHMnR19YEmh1rTIiSVauACFIyfPpbkMnLV37nM7ojD2CZnKlWgV2ApGOOQg==",
       "requires": {
-        "oby": "^7.0.1"
+        "oby": "^7.0.4"
       }
     }
   }

--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "voby"
@@ -16,7 +16,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "voby": "0.18.0"
+    "voby": "0.18.1"
   },
   "devDependencies": {
     "esbuild": "0.14.28"


### PR DESCRIPTION
With this update the framework should gain back some of the performance that was lost with v0.18.

Locally I'm seeing 1.11 -> 1.09 for the templated version (this version), and 1.25 -> 1.17 for the version that doesn't use `template` which seems pretty good to me.