### PR TITLE
Updated Voby to v0.23.2

### DIFF
--- a/frameworks/keyed/voby/package-lock.json
+++ b/frameworks/keyed/voby/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.21.1",
+  "version": "0.23.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-voby",
-      "version": "0.21.1",
+      "version": "0.23.2",
       "license": "MIT",
       "dependencies": {
-        "voby": "0.21.1"
+        "voby": "0.23.2"
       },
       "devDependencies": {
-        "esbuild": "0.14.28"
+        "esbuild": "0.14.39"
       }
     },
     "node_modules/esbuild": {
-      "version": "0.14.28",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.28.tgz",
-      "integrity": "sha512-YLNprkCcMVKQ5sekmCKEQ3Obu/L7s6+iij38xNKyBeSmSsTWur4Ky/9zB3XIGT8SCJITG/bZwAR2l7YOAXch4Q==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz",
+      "integrity": "sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -28,32 +28,32 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.28",
-        "esbuild-android-arm64": "0.14.28",
-        "esbuild-darwin-64": "0.14.28",
-        "esbuild-darwin-arm64": "0.14.28",
-        "esbuild-freebsd-64": "0.14.28",
-        "esbuild-freebsd-arm64": "0.14.28",
-        "esbuild-linux-32": "0.14.28",
-        "esbuild-linux-64": "0.14.28",
-        "esbuild-linux-arm": "0.14.28",
-        "esbuild-linux-arm64": "0.14.28",
-        "esbuild-linux-mips64le": "0.14.28",
-        "esbuild-linux-ppc64le": "0.14.28",
-        "esbuild-linux-riscv64": "0.14.28",
-        "esbuild-linux-s390x": "0.14.28",
-        "esbuild-netbsd-64": "0.14.28",
-        "esbuild-openbsd-64": "0.14.28",
-        "esbuild-sunos-64": "0.14.28",
-        "esbuild-windows-32": "0.14.28",
-        "esbuild-windows-64": "0.14.28",
-        "esbuild-windows-arm64": "0.14.28"
+        "esbuild-android-64": "0.14.39",
+        "esbuild-android-arm64": "0.14.39",
+        "esbuild-darwin-64": "0.14.39",
+        "esbuild-darwin-arm64": "0.14.39",
+        "esbuild-freebsd-64": "0.14.39",
+        "esbuild-freebsd-arm64": "0.14.39",
+        "esbuild-linux-32": "0.14.39",
+        "esbuild-linux-64": "0.14.39",
+        "esbuild-linux-arm": "0.14.39",
+        "esbuild-linux-arm64": "0.14.39",
+        "esbuild-linux-mips64le": "0.14.39",
+        "esbuild-linux-ppc64le": "0.14.39",
+        "esbuild-linux-riscv64": "0.14.39",
+        "esbuild-linux-s390x": "0.14.39",
+        "esbuild-netbsd-64": "0.14.39",
+        "esbuild-openbsd-64": "0.14.39",
+        "esbuild-sunos-64": "0.14.39",
+        "esbuild-windows-32": "0.14.39",
+        "esbuild-windows-64": "0.14.39",
+        "esbuild-windows-arm64": "0.14.39"
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.28",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.28.tgz",
-      "integrity": "sha512-XEq/bLR/glsUl+uGrBimQzOVs/CmwI833fXUhP9xrLI3IJ+rKyrZ5IA8u+1crOEf1LoTn8tV+hInmX6rGjbScw==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
+      "integrity": "sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==",
       "cpu": [
         "arm64"
       ],
@@ -72,53 +72,53 @@
       "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "node_modules/oby": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/oby/-/oby-7.0.9.tgz",
-      "integrity": "sha512-cqaU9Iqv0+nIlJH5cvSRPliTwRyWYXVtJQvvxnT60FOVy/5GLR53mqh7ZKj3yfFt9sxyK0Hv2x5glCxr0EHZPg=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/oby/-/oby-8.0.1.tgz",
+      "integrity": "sha512-OQXZmkxuUDpyzCSZhA5JcO2xViindtYrt6X4T4T4Wq+PTBpJxkEl2faZIcxIKdh5r7DtAcaX//HPS//nN5FaCg=="
     },
     "node_modules/voby": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/voby/-/voby-0.21.1.tgz",
-      "integrity": "sha512-O88ssRz41zA8/2A8yIYJpcLpDExwyFD79eZkCZsM4bG6Lg6XQDPXOy9UPmAvsrMva2e3MdV3tHnNZgCsZM4jqw==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/voby/-/voby-0.23.2.tgz",
+      "integrity": "sha512-/++zb/v60yCMJ/2SPNWSzrZcuLSk9lt7+dLY4Oc2yz4ZhMZPXrQ+gOjDczYsOEB+4wZKGZqk/pXSaaEwlc80gQ==",
       "dependencies": {
         "htm": "^3.1.1",
-        "oby": "^7.0.9"
+        "oby": "^8.0.1"
       }
     }
   },
   "dependencies": {
     "esbuild": {
-      "version": "0.14.28",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.28.tgz",
-      "integrity": "sha512-YLNprkCcMVKQ5sekmCKEQ3Obu/L7s6+iij38xNKyBeSmSsTWur4Ky/9zB3XIGT8SCJITG/bZwAR2l7YOAXch4Q==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz",
+      "integrity": "sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==",
       "dev": true,
       "requires": {
-        "esbuild-android-64": "0.14.28",
-        "esbuild-android-arm64": "0.14.28",
-        "esbuild-darwin-64": "0.14.28",
-        "esbuild-darwin-arm64": "0.14.28",
-        "esbuild-freebsd-64": "0.14.28",
-        "esbuild-freebsd-arm64": "0.14.28",
-        "esbuild-linux-32": "0.14.28",
-        "esbuild-linux-64": "0.14.28",
-        "esbuild-linux-arm": "0.14.28",
-        "esbuild-linux-arm64": "0.14.28",
-        "esbuild-linux-mips64le": "0.14.28",
-        "esbuild-linux-ppc64le": "0.14.28",
-        "esbuild-linux-riscv64": "0.14.28",
-        "esbuild-linux-s390x": "0.14.28",
-        "esbuild-netbsd-64": "0.14.28",
-        "esbuild-openbsd-64": "0.14.28",
-        "esbuild-sunos-64": "0.14.28",
-        "esbuild-windows-32": "0.14.28",
-        "esbuild-windows-64": "0.14.28",
-        "esbuild-windows-arm64": "0.14.28"
+        "esbuild-android-64": "0.14.39",
+        "esbuild-android-arm64": "0.14.39",
+        "esbuild-darwin-64": "0.14.39",
+        "esbuild-darwin-arm64": "0.14.39",
+        "esbuild-freebsd-64": "0.14.39",
+        "esbuild-freebsd-arm64": "0.14.39",
+        "esbuild-linux-32": "0.14.39",
+        "esbuild-linux-64": "0.14.39",
+        "esbuild-linux-arm": "0.14.39",
+        "esbuild-linux-arm64": "0.14.39",
+        "esbuild-linux-mips64le": "0.14.39",
+        "esbuild-linux-ppc64le": "0.14.39",
+        "esbuild-linux-riscv64": "0.14.39",
+        "esbuild-linux-s390x": "0.14.39",
+        "esbuild-netbsd-64": "0.14.39",
+        "esbuild-openbsd-64": "0.14.39",
+        "esbuild-sunos-64": "0.14.39",
+        "esbuild-windows-32": "0.14.39",
+        "esbuild-windows-64": "0.14.39",
+        "esbuild-windows-arm64": "0.14.39"
       }
     },
     "esbuild-darwin-arm64": {
-      "version": "0.14.28",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.28.tgz",
-      "integrity": "sha512-XEq/bLR/glsUl+uGrBimQzOVs/CmwI833fXUhP9xrLI3IJ+rKyrZ5IA8u+1crOEf1LoTn8tV+hInmX6rGjbScw==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
+      "integrity": "sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==",
       "dev": true,
       "optional": true
     },
@@ -128,17 +128,17 @@
       "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "oby": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/oby/-/oby-7.0.9.tgz",
-      "integrity": "sha512-cqaU9Iqv0+nIlJH5cvSRPliTwRyWYXVtJQvvxnT60FOVy/5GLR53mqh7ZKj3yfFt9sxyK0Hv2x5glCxr0EHZPg=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/oby/-/oby-8.0.1.tgz",
+      "integrity": "sha512-OQXZmkxuUDpyzCSZhA5JcO2xViindtYrt6X4T4T4Wq+PTBpJxkEl2faZIcxIKdh5r7DtAcaX//HPS//nN5FaCg=="
     },
     "voby": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/voby/-/voby-0.21.1.tgz",
-      "integrity": "sha512-O88ssRz41zA8/2A8yIYJpcLpDExwyFD79eZkCZsM4bG6Lg6XQDPXOy9UPmAvsrMva2e3MdV3tHnNZgCsZM4jqw==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/voby/-/voby-0.23.2.tgz",
+      "integrity": "sha512-/++zb/v60yCMJ/2SPNWSzrZcuLSk9lt7+dLY4Oc2yz4ZhMZPXrQ+gOjDczYsOEB+4wZKGZqk/pXSaaEwlc80gQ==",
       "requires": {
         "htm": "^3.1.1",
-        "oby": "^7.0.9"
+        "oby": "^8.0.1"
       }
     }
   }

--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -1,12 +1,12 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.21.1",
+  "version": "0.23.2",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "voby"
   },
   "scripts": {
-    "build-prod": "rm -rf dist && mkdir dist && esbuild --bundle --minify --target=es2018 ./src/main.tsx > ./dist/main.js"
+    "build-prod": "rm -rf dist && mkdir dist && esbuild --bundle --minify --target=es2018 --jsx-factory=createElement --jsx-fragment=Fragment --banner:js='\"use strict\";' ./src/main.tsx > ./dist/main.js"
   },
   "author": "Fabio Spampinato",
   "license": "MIT",
@@ -16,9 +16,9 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "voby": "0.21.1"
+    "voby": "0.23.2"
   },
   "devDependencies": {
-    "esbuild": "0.14.28"
+    "esbuild": "0.14.39"
   }
 }

--- a/frameworks/keyed/voby/src/main.tsx
+++ b/frameworks/keyed/voby/src/main.tsx
@@ -1,11 +1,9 @@
 
 /* IMPORT */
 
-import {FunctionMaybe, Observable, ObservableMaybe} from 'voby';
-import {$, render, template, useSelector, For} from 'voby';
 import {createElement, Fragment} from 'voby';
-
-const React = {createElement, Fragment};
+import {$, render, template, useSelector, For} from 'voby';
+import type {FunctionMaybe, Observable, ObservableMaybe} from 'voby';
 
 /* TYPES */
 


### PR DESCRIPTION
- Some internal changes, nothing that should make much of an impact here I think, the framework is more granularly tree-shakeable, but esbuild can't take advantage of that it seems.
- Apparently esbuild was outputting sloppy-mode code, now I forced it to output the `"use strict";` directive, maybe that could have an impact, but probably not I guess.