### PR TITLE
Updated Voby to v0.25

### DIFF
--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "voby"
@@ -16,7 +16,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "voby": "0.27.2"
+    "voby": "0.27.3"
   },
   "devDependencies": {
     "esbuild": "0.14.39"

--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.27.4",
+  "version": "0.27.5",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "voby"
@@ -16,7 +16,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "voby": "0.27.4"
+    "voby": "0.27.5"
   },
   "devDependencies": {
     "esbuild": "0.14.39"

--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.23.2",
+  "version": "0.25.0",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "voby"
@@ -16,7 +16,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "voby": "0.23.2"
+    "voby": "0.25.0"
   },
   "devDependencies": {
     "esbuild": "0.14.39"

--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.25.0",
+  "version": "0.26.1",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "voby"
@@ -16,7 +16,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "voby": "0.25.0"
+    "voby": "0.26.1"
   },
   "devDependencies": {
     "esbuild": "0.14.39"

--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.26.1",
+  "version": "0.27.2",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "voby"
@@ -16,7 +16,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "voby": "0.26.1"
+    "voby": "0.27.2"
   },
   "devDependencies": {
     "esbuild": "0.14.39"

--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.27.3",
+  "version": "0.27.4",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "voby"
@@ -16,7 +16,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "voby": "0.27.3"
+    "voby": "0.27.4"
   },
   "devDependencies": {
     "esbuild": "0.14.39"

--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-voby",
-  "version": "0.27.5",
+  "version": "0.27.7",
   "main": "dist/main.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "voby"
@@ -16,7 +16,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "voby": "0.27.5"
+    "voby": "0.27.7"
   },
   "devDependencies": {
     "esbuild": "0.14.39"

--- a/frameworks/keyed/voby/src/main.tsx
+++ b/frameworks/keyed/voby/src/main.tsx
@@ -110,8 +110,8 @@ const Button = ({ id, text, onClick }: { id: string | number, text: string, onCl
   </div>
 );
 
-const Row = template (({ id, label, className, onSelect, onRemove }: { id: FunctionMaybe<string | number>, label: FunctionMaybe<string>, className: FunctionMaybe<string>, onSelect: ObservableMaybe<(( event: MouseEvent ) => any)>, onRemove: ObservableMaybe<(( event: MouseEvent ) => any)> }): JSX.Element => (
-  <tr className={className}>
+const Row = template (({ id, label, className, onSelect, onRemove }: { id: FunctionMaybe<string | number>, label: FunctionMaybe<string>, className: FunctionMaybe<Record<string, FunctionMaybe<boolean>>>, onSelect: ObservableMaybe<(( event: MouseEvent ) => any)>, onRemove: ObservableMaybe<(( event: MouseEvent ) => any)> }): JSX.Element => (
+  <tr class={className}>
     <td class="col-md-1">{id}</td>
     <td class="col-md-4">
       <a onClick={onSelect}>{label}</a>
@@ -153,7 +153,8 @@ const App = (): JSX.Element => {
           <For values={$data}>
             {( datum: IDatum ) => {
               const {id, label} = datum;
-              const className = () => isSelected ( id ) ? 'danger' : '';
+              const selected = isSelected ( id, { observable: true } );
+              const className = { danger: selected };
               const onSelect = select.bind ( undefined, id );
               const onRemove = remove.bind ( undefined, id );
               const props = {id, label, className, onSelect, onRemove};

--- a/frameworks/keyed/voby/src/main.tsx
+++ b/frameworks/keyed/voby/src/main.tsx
@@ -153,7 +153,7 @@ const App = (): JSX.Element => {
           <For values={$data}>
             {( datum: IDatum ) => {
               const {id, label} = datum;
-              const selected = isSelected ( id, { observable: true } );
+              const selected = isSelected ( id );
               const className = { danger: selected };
               const onSelect = select.bind ( undefined, id );
               const onRemove = remove.bind ( undefined, id );


### PR DESCRIPTION
Some internal fixes and new APIs, the main thing relevant to the benchmark I guess is that now the framework tree-shakes a little better. Nothing drastic though.

I hope this will be the last PR for a while, the future main ones should be about supporting stores, which may have a positive impact on clearing actually (and maybe a negative one on everything else), and about supporting automatic application of the "template" function via a bundler plugin, which could be kind of a big improvement, but irrelevant for the benchmark I think.