### PR TITLE
udomsay v0.3.4

### DIFF
--- a/frameworks/keyed/udomsay/package-lock.json
+++ b/frameworks/keyed/udomsay/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "udomsay": "0.1.7"
+                "udomsay": "0.3.4"
             },
             "devDependencies": {
                 "@babel/cli": "^7.19.3",
@@ -76,30 +76,30 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.4.tgz",
-            "integrity": "sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.1.tgz",
+            "integrity": "sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
-            "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.2.tgz",
+            "integrity": "sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.6",
-                "@babel/helper-compilation-targets": "^7.19.3",
-                "@babel/helper-module-transforms": "^7.19.6",
-                "@babel/helpers": "^7.19.4",
-                "@babel/parser": "^7.19.6",
+                "@babel/generator": "^7.20.2",
+                "@babel/helper-compilation-targets": "^7.20.0",
+                "@babel/helper-module-transforms": "^7.20.2",
+                "@babel/helpers": "^7.20.1",
+                "@babel/parser": "^7.20.2",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.6",
-                "@babel/types": "^7.19.4",
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.2",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -115,12 +115,12 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.6.tgz",
-            "integrity": "sha512-oHGRUQeoX1QrKeJIKVe0hwjGqNnVYsM5Nep5zo0uE0m42sLH+Fsd2pStJ5sRM1bNyTUUoz0pe2lTeMJrb/taTA==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.2.tgz",
+            "integrity": "sha512-SD75PMIK6i9H8G/tfGvB4KKl4Nw6Ssos9nGgYwxbgyTP0iX/Z55DveoH86rmUB/YHTQQ+ZC0F7xxaY8l2OF44Q==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.19.4",
+                "@babel/types": "^7.20.2",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "jsesc": "^2.5.1"
             },
@@ -155,12 +155,12 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz",
-            "integrity": "sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==",
+            "version": "7.20.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
+            "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.19.3",
+                "@babel/compat-data": "^7.20.0",
                 "@babel/helper-validator-option": "^7.18.6",
                 "browserslist": "^4.21.3",
                 "semver": "^6.3.0"
@@ -219,40 +219,40 @@
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.6.tgz",
-            "integrity": "sha512-fCmcfQo/KYr/VXXDIyd3CBGZ6AFhPFy1TfSEJ+PilGVlQT6jcbqtHAM4C1EciRqMza7/TpOUZliuSH+U6HAhJw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
+            "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-module-imports": "^7.18.6",
-                "@babel/helper-simple-access": "^7.19.4",
+                "@babel/helper-simple-access": "^7.20.2",
                 "@babel/helper-split-export-declaration": "^7.18.6",
                 "@babel/helper-validator-identifier": "^7.19.1",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.6",
-                "@babel/types": "^7.19.4"
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.2"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-            "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+            "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
-            "integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+            "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.19.4"
+                "@babel/types": "^7.20.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -298,14 +298,14 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.4.tgz",
-            "integrity": "sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
+            "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.4",
-                "@babel/types": "^7.19.4"
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -326,9 +326,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.6.tgz",
-            "integrity": "sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.2.tgz",
+            "integrity": "sha512-afk318kh2uKbo7BEj2QtEi8HVCGrwHUffrYDy7dgVcSa2j9lY3LDjPzcyGdpX7xgm35aWqvciZJ4WKmdF/SxYg==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -386,19 +386,19 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.6.tgz",
-            "integrity": "sha512-6l5HrUCzFM04mfbG09AagtYyR2P0B71B1wN7PfSPiksDPz2k5H9CBC1tcZpz2M8OxbKTPccByoOJ22rUKbpmQQ==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
+            "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.6",
+                "@babel/generator": "^7.20.1",
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-function-name": "^7.19.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.19.6",
-                "@babel/types": "^7.19.4",
+                "@babel/parser": "^7.20.1",
+                "@babel/types": "^7.20.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -407,9 +407,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.4.tgz",
-            "integrity": "sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+            "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.19.4",
@@ -677,9 +677,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001426",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
-            "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
+            "version": "1.0.30001430",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001430.tgz",
+            "integrity": "sha512-IB1BXTZKPDVPM7cnV4iaKaHxckvdr/3xtctB3f7Hmenx3qYBhGtTZ//7EllK66aKXW98Lx0+7Yr0kxBtIt3tzg==",
             "dev": true,
             "funding": [
                 {
@@ -797,9 +797,9 @@
             }
         },
         "node_modules/domconstants": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/domconstants/-/domconstants-0.1.2.tgz",
-            "integrity": "sha512-sPOoOckTxtwy5t8PFf6zl11gOEhOpl1k0ZCc/NfCNmHoMw8n9HnCQCzxWKX9gdBp+qM+2DTFkst++Yw6C41izQ=="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/domconstants/-/domconstants-1.0.0.tgz",
+            "integrity": "sha512-uCPEW7lrZMUdkGkCUHebBF2EItFEA0F6cw8MpvZI+t4/RryE/nbUEtTx7F2P+MsAnOvyyHd0xePMlC5fbgOmsA=="
         },
         "node_modules/electron-to-chromium": {
             "version": "1.4.284",
@@ -947,11 +947,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/html-escaper": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-            "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
         },
         "node_modules/inflight": {
             "version": "1.0.6",
@@ -1216,9 +1211,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.3.tgz",
-            "integrity": "sha512-qfadtkY5kl0F5e4dXVdj2D+GtOdifasXHFMiL1SMf9ADQDv5Eti6xReef9FKj+iQPR2pvtqWna57s/PjARY4fg==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.5.tgz",
+            "integrity": "sha512-/Ha7HhVVofduy+RKWOQJrxe4Qb3xyZo+chcpYiD8SoQa4AG7llhupUtyfKSSrdBM2mWJjhM8wZwmbY23NmlIYw==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -1296,13 +1291,12 @@
             }
         },
         "node_modules/udomsay": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/udomsay/-/udomsay-0.1.7.tgz",
-            "integrity": "sha512-jvwr153OB3O8rwHDxfW6VKfimJvjZJnDJK1PQlwEi5ptFiKo8/1cQVCXhjKBgowgE3TQR369ORBYf5bJuOI9RA==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/udomsay/-/udomsay-0.3.4.tgz",
+            "integrity": "sha512-BU8RbOQ8U9kFy+Cv3QA1DWOgZxaLtXgbLgBxR0Iag0+8rbyWLGGQ0bZd1kav8UJtkvX9bxKEiYDmzCuternSxA==",
             "dependencies": {
-                "domconstants": "^0.1.2",
-                "html-escaper": "^3.0.3",
-                "usignal": "^0.8.1"
+                "domconstants": "^1.0.0",
+                "usignal": "^0.8.9"
             }
         },
         "node_modules/uglify-js": {
@@ -1344,9 +1338,9 @@
             }
         },
         "node_modules/usignal": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/usignal/-/usignal-0.8.1.tgz",
-            "integrity": "sha512-aM2rX6CRofxhRj/0QmvIT5Kx6LJgVbzoBMUPHlWH6cTFxSSMN2DotLEXt63f6dT7baFPPyBNpaiOXSwxySdWkA=="
+            "version": "0.8.9",
+            "resolved": "https://registry.npmjs.org/usignal/-/usignal-0.8.9.tgz",
+            "integrity": "sha512-jI8+NVOb5AZIx5JzKcCfQzdwbL/E5oOmRciFAKlU9ZV3jeBbaBh9FpwG2Jr1AYsHOxBLNA5GwaQATdjzGydA2Q=="
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
@@ -1393,27 +1387,27 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.4.tgz",
-            "integrity": "sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.1.tgz",
+            "integrity": "sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==",
             "dev": true
         },
         "@babel/core": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
-            "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.2.tgz",
+            "integrity": "sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==",
             "dev": true,
             "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.6",
-                "@babel/helper-compilation-targets": "^7.19.3",
-                "@babel/helper-module-transforms": "^7.19.6",
-                "@babel/helpers": "^7.19.4",
-                "@babel/parser": "^7.19.6",
+                "@babel/generator": "^7.20.2",
+                "@babel/helper-compilation-targets": "^7.20.0",
+                "@babel/helper-module-transforms": "^7.20.2",
+                "@babel/helpers": "^7.20.1",
+                "@babel/parser": "^7.20.2",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.6",
-                "@babel/types": "^7.19.4",
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.2",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -1422,12 +1416,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.6.tgz",
-            "integrity": "sha512-oHGRUQeoX1QrKeJIKVe0hwjGqNnVYsM5Nep5zo0uE0m42sLH+Fsd2pStJ5sRM1bNyTUUoz0pe2lTeMJrb/taTA==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.2.tgz",
+            "integrity": "sha512-SD75PMIK6i9H8G/tfGvB4KKl4Nw6Ssos9nGgYwxbgyTP0iX/Z55DveoH86rmUB/YHTQQ+ZC0F7xxaY8l2OF44Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.19.4",
+                "@babel/types": "^7.20.2",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "jsesc": "^2.5.1"
             },
@@ -1455,12 +1449,12 @@
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz",
-            "integrity": "sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==",
+            "version": "7.20.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
+            "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.19.3",
+                "@babel/compat-data": "^7.20.0",
                 "@babel/helper-validator-option": "^7.18.6",
                 "browserslist": "^4.21.3",
                 "semver": "^6.3.0"
@@ -1501,34 +1495,34 @@
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.6.tgz",
-            "integrity": "sha512-fCmcfQo/KYr/VXXDIyd3CBGZ6AFhPFy1TfSEJ+PilGVlQT6jcbqtHAM4C1EciRqMza7/TpOUZliuSH+U6HAhJw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
+            "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
             "dev": true,
             "requires": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-module-imports": "^7.18.6",
-                "@babel/helper-simple-access": "^7.19.4",
+                "@babel/helper-simple-access": "^7.20.2",
                 "@babel/helper-split-export-declaration": "^7.18.6",
                 "@babel/helper-validator-identifier": "^7.19.1",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.6",
-                "@babel/types": "^7.19.4"
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.2"
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-            "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+            "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
             "dev": true
         },
         "@babel/helper-simple-access": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
-            "integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+            "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.19.4"
+                "@babel/types": "^7.20.2"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -1559,14 +1553,14 @@
             "dev": true
         },
         "@babel/helpers": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.4.tgz",
-            "integrity": "sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
+            "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.4",
-                "@babel/types": "^7.19.4"
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.0"
             }
         },
         "@babel/highlight": {
@@ -1581,9 +1575,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.6.tgz",
-            "integrity": "sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.2.tgz",
+            "integrity": "sha512-afk318kh2uKbo7BEj2QtEi8HVCGrwHUffrYDy7dgVcSa2j9lY3LDjPzcyGdpX7xgm35aWqvciZJ4WKmdF/SxYg==",
             "dev": true
         },
         "@babel/plugin-syntax-jsx": {
@@ -1620,27 +1614,27 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.6.tgz",
-            "integrity": "sha512-6l5HrUCzFM04mfbG09AagtYyR2P0B71B1wN7PfSPiksDPz2k5H9CBC1tcZpz2M8OxbKTPccByoOJ22rUKbpmQQ==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
+            "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.6",
+                "@babel/generator": "^7.20.1",
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-function-name": "^7.19.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.19.6",
-                "@babel/types": "^7.19.4",
+                "@babel/parser": "^7.20.1",
+                "@babel/types": "^7.20.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.4.tgz",
-            "integrity": "sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+            "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
             "dev": true,
             "requires": {
                 "@babel/helper-string-parser": "^7.19.4",
@@ -1821,9 +1815,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001426",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
-            "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
+            "version": "1.0.30001430",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001430.tgz",
+            "integrity": "sha512-IB1BXTZKPDVPM7cnV4iaKaHxckvdr/3xtctB3f7Hmenx3qYBhGtTZ//7EllK66aKXW98Lx0+7Yr0kxBtIt3tzg==",
             "dev": true
         },
         "chalk": {
@@ -1903,9 +1897,9 @@
             "dev": true
         },
         "domconstants": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/domconstants/-/domconstants-0.1.2.tgz",
-            "integrity": "sha512-sPOoOckTxtwy5t8PFf6zl11gOEhOpl1k0ZCc/NfCNmHoMw8n9HnCQCzxWKX9gdBp+qM+2DTFkst++Yw6C41izQ=="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/domconstants/-/domconstants-1.0.0.tgz",
+            "integrity": "sha512-uCPEW7lrZMUdkGkCUHebBF2EItFEA0F6cw8MpvZI+t4/RryE/nbUEtTx7F2P+MsAnOvyyHd0xePMlC5fbgOmsA=="
         },
         "electron-to-chromium": {
             "version": "1.4.284",
@@ -2016,11 +2010,6 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
             "dev": true
-        },
-        "html-escaper": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-            "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
         },
         "inflight": {
             "version": "1.0.6",
@@ -2221,9 +2210,9 @@
             }
         },
         "rollup": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.3.tgz",
-            "integrity": "sha512-qfadtkY5kl0F5e4dXVdj2D+GtOdifasXHFMiL1SMf9ADQDv5Eti6xReef9FKj+iQPR2pvtqWna57s/PjARY4fg==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.5.tgz",
+            "integrity": "sha512-/Ha7HhVVofduy+RKWOQJrxe4Qb3xyZo+chcpYiD8SoQa4AG7llhupUtyfKSSrdBM2mWJjhM8wZwmbY23NmlIYw==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
@@ -2273,13 +2262,12 @@
             }
         },
         "udomsay": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/udomsay/-/udomsay-0.1.7.tgz",
-            "integrity": "sha512-jvwr153OB3O8rwHDxfW6VKfimJvjZJnDJK1PQlwEi5ptFiKo8/1cQVCXhjKBgowgE3TQR369ORBYf5bJuOI9RA==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/udomsay/-/udomsay-0.3.4.tgz",
+            "integrity": "sha512-BU8RbOQ8U9kFy+Cv3QA1DWOgZxaLtXgbLgBxR0Iag0+8rbyWLGGQ0bZd1kav8UJtkvX9bxKEiYDmzCuternSxA==",
             "requires": {
-                "domconstants": "^0.1.2",
-                "html-escaper": "^3.0.3",
-                "usignal": "^0.8.1"
+                "domconstants": "^1.0.0",
+                "usignal": "^0.8.9"
             }
         },
         "uglify-js": {
@@ -2299,9 +2287,9 @@
             }
         },
         "usignal": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/usignal/-/usignal-0.8.1.tgz",
-            "integrity": "sha512-aM2rX6CRofxhRj/0QmvIT5Kx6LJgVbzoBMUPHlWH6cTFxSSMN2DotLEXt63f6dT7baFPPyBNpaiOXSwxySdWkA=="
+            "version": "0.8.9",
+            "resolved": "https://registry.npmjs.org/usignal/-/usignal-0.8.9.tgz",
+            "integrity": "sha512-jI8+NVOb5AZIx5JzKcCfQzdwbL/E5oOmRciFAKlU9ZV3jeBbaBh9FpwG2Jr1AYsHOxBLNA5GwaQATdjzGydA2Q=="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/frameworks/keyed/udomsay/package.json
+++ b/frameworks/keyed/udomsay/package.json
@@ -21,7 +21,7 @@
         "url": "https://github.com/krausest/js-framework-benchmark.git"
     },
     "dependencies": {
-        "udomsay": "0.1.7"
+        "udomsay": "0.3.4"
     },
     "devDependencies": {
         "@babel/cli": "^7.19.3",

--- a/frameworks/keyed/udomsay/src/main.jsx
+++ b/frameworks/keyed/udomsay/src/main.jsx
@@ -97,7 +97,7 @@ const App = () => (
       {data.value.map(({id: rowId, label}, idx) => (
         <tr key={rowId}>
           <td class='col-md-1' textContent={rowId} />
-          <td class='col-md-4'><a onClick={({currentTarget: t}) => { selected.value = t.closest('tr') }} textContent={ label.value } /></td>
+          <td class='col-md-4'><a onClick={({currentTarget: t}) => { selected.value = t.closest('tr') }}>{ label }</a></td>
           <td class='col-md-1'><a onClick={() => { remove(idx) }}><span class='glyphicon glyphicon-remove' aria-hidden='true' /></a></td>
           <td class='col-md-6'/>
         </tr>

--- a/frameworks/non-keyed/udomsay/package-lock.json
+++ b/frameworks/non-keyed/udomsay/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "udomsay": "0.1.7"
+                "udomsay": "0.3.4"
             },
             "devDependencies": {
                 "@babel/cli": "^7.19.3",
@@ -76,30 +76,30 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.4.tgz",
-            "integrity": "sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.1.tgz",
+            "integrity": "sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
-            "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.2.tgz",
+            "integrity": "sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.6",
-                "@babel/helper-compilation-targets": "^7.19.3",
-                "@babel/helper-module-transforms": "^7.19.6",
-                "@babel/helpers": "^7.19.4",
-                "@babel/parser": "^7.19.6",
+                "@babel/generator": "^7.20.2",
+                "@babel/helper-compilation-targets": "^7.20.0",
+                "@babel/helper-module-transforms": "^7.20.2",
+                "@babel/helpers": "^7.20.1",
+                "@babel/parser": "^7.20.2",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.6",
-                "@babel/types": "^7.19.4",
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.2",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -115,12 +115,12 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.6.tgz",
-            "integrity": "sha512-oHGRUQeoX1QrKeJIKVe0hwjGqNnVYsM5Nep5zo0uE0m42sLH+Fsd2pStJ5sRM1bNyTUUoz0pe2lTeMJrb/taTA==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.2.tgz",
+            "integrity": "sha512-SD75PMIK6i9H8G/tfGvB4KKl4Nw6Ssos9nGgYwxbgyTP0iX/Z55DveoH86rmUB/YHTQQ+ZC0F7xxaY8l2OF44Q==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.19.4",
+                "@babel/types": "^7.20.2",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "jsesc": "^2.5.1"
             },
@@ -155,12 +155,12 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz",
-            "integrity": "sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==",
+            "version": "7.20.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
+            "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.19.3",
+                "@babel/compat-data": "^7.20.0",
                 "@babel/helper-validator-option": "^7.18.6",
                 "browserslist": "^4.21.3",
                 "semver": "^6.3.0"
@@ -219,40 +219,40 @@
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.6.tgz",
-            "integrity": "sha512-fCmcfQo/KYr/VXXDIyd3CBGZ6AFhPFy1TfSEJ+PilGVlQT6jcbqtHAM4C1EciRqMza7/TpOUZliuSH+U6HAhJw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
+            "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-module-imports": "^7.18.6",
-                "@babel/helper-simple-access": "^7.19.4",
+                "@babel/helper-simple-access": "^7.20.2",
                 "@babel/helper-split-export-declaration": "^7.18.6",
                 "@babel/helper-validator-identifier": "^7.19.1",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.6",
-                "@babel/types": "^7.19.4"
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.2"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-            "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+            "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
-            "integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+            "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.19.4"
+                "@babel/types": "^7.20.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -298,14 +298,14 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.4.tgz",
-            "integrity": "sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
+            "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.4",
-                "@babel/types": "^7.19.4"
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -326,9 +326,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.6.tgz",
-            "integrity": "sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.2.tgz",
+            "integrity": "sha512-afk318kh2uKbo7BEj2QtEi8HVCGrwHUffrYDy7dgVcSa2j9lY3LDjPzcyGdpX7xgm35aWqvciZJ4WKmdF/SxYg==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -386,19 +386,19 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.6.tgz",
-            "integrity": "sha512-6l5HrUCzFM04mfbG09AagtYyR2P0B71B1wN7PfSPiksDPz2k5H9CBC1tcZpz2M8OxbKTPccByoOJ22rUKbpmQQ==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
+            "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.6",
+                "@babel/generator": "^7.20.1",
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-function-name": "^7.19.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.19.6",
-                "@babel/types": "^7.19.4",
+                "@babel/parser": "^7.20.1",
+                "@babel/types": "^7.20.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -407,9 +407,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.4.tgz",
-            "integrity": "sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+            "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.19.4",
@@ -677,9 +677,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001426",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
-            "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
+            "version": "1.0.30001430",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001430.tgz",
+            "integrity": "sha512-IB1BXTZKPDVPM7cnV4iaKaHxckvdr/3xtctB3f7Hmenx3qYBhGtTZ//7EllK66aKXW98Lx0+7Yr0kxBtIt3tzg==",
             "dev": true,
             "funding": [
                 {
@@ -797,9 +797,9 @@
             }
         },
         "node_modules/domconstants": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/domconstants/-/domconstants-0.1.2.tgz",
-            "integrity": "sha512-sPOoOckTxtwy5t8PFf6zl11gOEhOpl1k0ZCc/NfCNmHoMw8n9HnCQCzxWKX9gdBp+qM+2DTFkst++Yw6C41izQ=="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/domconstants/-/domconstants-1.0.0.tgz",
+            "integrity": "sha512-uCPEW7lrZMUdkGkCUHebBF2EItFEA0F6cw8MpvZI+t4/RryE/nbUEtTx7F2P+MsAnOvyyHd0xePMlC5fbgOmsA=="
         },
         "node_modules/electron-to-chromium": {
             "version": "1.4.284",
@@ -947,11 +947,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/html-escaper": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-            "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
         },
         "node_modules/inflight": {
             "version": "1.0.6",
@@ -1216,9 +1211,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.3.tgz",
-            "integrity": "sha512-qfadtkY5kl0F5e4dXVdj2D+GtOdifasXHFMiL1SMf9ADQDv5Eti6xReef9FKj+iQPR2pvtqWna57s/PjARY4fg==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.5.tgz",
+            "integrity": "sha512-/Ha7HhVVofduy+RKWOQJrxe4Qb3xyZo+chcpYiD8SoQa4AG7llhupUtyfKSSrdBM2mWJjhM8wZwmbY23NmlIYw==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -1296,13 +1291,12 @@
             }
         },
         "node_modules/udomsay": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/udomsay/-/udomsay-0.1.7.tgz",
-            "integrity": "sha512-jvwr153OB3O8rwHDxfW6VKfimJvjZJnDJK1PQlwEi5ptFiKo8/1cQVCXhjKBgowgE3TQR369ORBYf5bJuOI9RA==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/udomsay/-/udomsay-0.3.4.tgz",
+            "integrity": "sha512-BU8RbOQ8U9kFy+Cv3QA1DWOgZxaLtXgbLgBxR0Iag0+8rbyWLGGQ0bZd1kav8UJtkvX9bxKEiYDmzCuternSxA==",
             "dependencies": {
-                "domconstants": "^0.1.2",
-                "html-escaper": "^3.0.3",
-                "usignal": "^0.8.1"
+                "domconstants": "^1.0.0",
+                "usignal": "^0.8.9"
             }
         },
         "node_modules/uglify-js": {
@@ -1344,9 +1338,9 @@
             }
         },
         "node_modules/usignal": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/usignal/-/usignal-0.8.1.tgz",
-            "integrity": "sha512-aM2rX6CRofxhRj/0QmvIT5Kx6LJgVbzoBMUPHlWH6cTFxSSMN2DotLEXt63f6dT7baFPPyBNpaiOXSwxySdWkA=="
+            "version": "0.8.9",
+            "resolved": "https://registry.npmjs.org/usignal/-/usignal-0.8.9.tgz",
+            "integrity": "sha512-jI8+NVOb5AZIx5JzKcCfQzdwbL/E5oOmRciFAKlU9ZV3jeBbaBh9FpwG2Jr1AYsHOxBLNA5GwaQATdjzGydA2Q=="
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
@@ -1393,27 +1387,27 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.4.tgz",
-            "integrity": "sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.1.tgz",
+            "integrity": "sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==",
             "dev": true
         },
         "@babel/core": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
-            "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.2.tgz",
+            "integrity": "sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==",
             "dev": true,
             "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.6",
-                "@babel/helper-compilation-targets": "^7.19.3",
-                "@babel/helper-module-transforms": "^7.19.6",
-                "@babel/helpers": "^7.19.4",
-                "@babel/parser": "^7.19.6",
+                "@babel/generator": "^7.20.2",
+                "@babel/helper-compilation-targets": "^7.20.0",
+                "@babel/helper-module-transforms": "^7.20.2",
+                "@babel/helpers": "^7.20.1",
+                "@babel/parser": "^7.20.2",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.6",
-                "@babel/types": "^7.19.4",
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.2",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -1422,12 +1416,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.6.tgz",
-            "integrity": "sha512-oHGRUQeoX1QrKeJIKVe0hwjGqNnVYsM5Nep5zo0uE0m42sLH+Fsd2pStJ5sRM1bNyTUUoz0pe2lTeMJrb/taTA==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.2.tgz",
+            "integrity": "sha512-SD75PMIK6i9H8G/tfGvB4KKl4Nw6Ssos9nGgYwxbgyTP0iX/Z55DveoH86rmUB/YHTQQ+ZC0F7xxaY8l2OF44Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.19.4",
+                "@babel/types": "^7.20.2",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "jsesc": "^2.5.1"
             },
@@ -1455,12 +1449,12 @@
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz",
-            "integrity": "sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==",
+            "version": "7.20.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
+            "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.19.3",
+                "@babel/compat-data": "^7.20.0",
                 "@babel/helper-validator-option": "^7.18.6",
                 "browserslist": "^4.21.3",
                 "semver": "^6.3.0"
@@ -1501,34 +1495,34 @@
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.6.tgz",
-            "integrity": "sha512-fCmcfQo/KYr/VXXDIyd3CBGZ6AFhPFy1TfSEJ+PilGVlQT6jcbqtHAM4C1EciRqMza7/TpOUZliuSH+U6HAhJw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
+            "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
             "dev": true,
             "requires": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-module-imports": "^7.18.6",
-                "@babel/helper-simple-access": "^7.19.4",
+                "@babel/helper-simple-access": "^7.20.2",
                 "@babel/helper-split-export-declaration": "^7.18.6",
                 "@babel/helper-validator-identifier": "^7.19.1",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.6",
-                "@babel/types": "^7.19.4"
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.2"
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-            "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+            "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
             "dev": true
         },
         "@babel/helper-simple-access": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
-            "integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+            "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.19.4"
+                "@babel/types": "^7.20.2"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -1559,14 +1553,14 @@
             "dev": true
         },
         "@babel/helpers": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.4.tgz",
-            "integrity": "sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
+            "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.4",
-                "@babel/types": "^7.19.4"
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.0"
             }
         },
         "@babel/highlight": {
@@ -1581,9 +1575,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.6.tgz",
-            "integrity": "sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.2.tgz",
+            "integrity": "sha512-afk318kh2uKbo7BEj2QtEi8HVCGrwHUffrYDy7dgVcSa2j9lY3LDjPzcyGdpX7xgm35aWqvciZJ4WKmdF/SxYg==",
             "dev": true
         },
         "@babel/plugin-syntax-jsx": {
@@ -1620,27 +1614,27 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.6.tgz",
-            "integrity": "sha512-6l5HrUCzFM04mfbG09AagtYyR2P0B71B1wN7PfSPiksDPz2k5H9CBC1tcZpz2M8OxbKTPccByoOJ22rUKbpmQQ==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
+            "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.6",
+                "@babel/generator": "^7.20.1",
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-function-name": "^7.19.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.19.6",
-                "@babel/types": "^7.19.4",
+                "@babel/parser": "^7.20.1",
+                "@babel/types": "^7.20.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.4.tgz",
-            "integrity": "sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+            "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
             "dev": true,
             "requires": {
                 "@babel/helper-string-parser": "^7.19.4",
@@ -1821,9 +1815,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001426",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
-            "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
+            "version": "1.0.30001430",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001430.tgz",
+            "integrity": "sha512-IB1BXTZKPDVPM7cnV4iaKaHxckvdr/3xtctB3f7Hmenx3qYBhGtTZ//7EllK66aKXW98Lx0+7Yr0kxBtIt3tzg==",
             "dev": true
         },
         "chalk": {
@@ -1903,9 +1897,9 @@
             "dev": true
         },
         "domconstants": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/domconstants/-/domconstants-0.1.2.tgz",
-            "integrity": "sha512-sPOoOckTxtwy5t8PFf6zl11gOEhOpl1k0ZCc/NfCNmHoMw8n9HnCQCzxWKX9gdBp+qM+2DTFkst++Yw6C41izQ=="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/domconstants/-/domconstants-1.0.0.tgz",
+            "integrity": "sha512-uCPEW7lrZMUdkGkCUHebBF2EItFEA0F6cw8MpvZI+t4/RryE/nbUEtTx7F2P+MsAnOvyyHd0xePMlC5fbgOmsA=="
         },
         "electron-to-chromium": {
             "version": "1.4.284",
@@ -2016,11 +2010,6 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
             "dev": true
-        },
-        "html-escaper": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-            "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
         },
         "inflight": {
             "version": "1.0.6",
@@ -2221,9 +2210,9 @@
             }
         },
         "rollup": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.3.tgz",
-            "integrity": "sha512-qfadtkY5kl0F5e4dXVdj2D+GtOdifasXHFMiL1SMf9ADQDv5Eti6xReef9FKj+iQPR2pvtqWna57s/PjARY4fg==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.5.tgz",
+            "integrity": "sha512-/Ha7HhVVofduy+RKWOQJrxe4Qb3xyZo+chcpYiD8SoQa4AG7llhupUtyfKSSrdBM2mWJjhM8wZwmbY23NmlIYw==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
@@ -2273,13 +2262,12 @@
             }
         },
         "udomsay": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/udomsay/-/udomsay-0.1.7.tgz",
-            "integrity": "sha512-jvwr153OB3O8rwHDxfW6VKfimJvjZJnDJK1PQlwEi5ptFiKo8/1cQVCXhjKBgowgE3TQR369ORBYf5bJuOI9RA==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/udomsay/-/udomsay-0.3.4.tgz",
+            "integrity": "sha512-BU8RbOQ8U9kFy+Cv3QA1DWOgZxaLtXgbLgBxR0Iag0+8rbyWLGGQ0bZd1kav8UJtkvX9bxKEiYDmzCuternSxA==",
             "requires": {
-                "domconstants": "^0.1.2",
-                "html-escaper": "^3.0.3",
-                "usignal": "^0.8.1"
+                "domconstants": "^1.0.0",
+                "usignal": "^0.8.9"
             }
         },
         "uglify-js": {
@@ -2299,9 +2287,9 @@
             }
         },
         "usignal": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/usignal/-/usignal-0.8.1.tgz",
-            "integrity": "sha512-aM2rX6CRofxhRj/0QmvIT5Kx6LJgVbzoBMUPHlWH6cTFxSSMN2DotLEXt63f6dT7baFPPyBNpaiOXSwxySdWkA=="
+            "version": "0.8.9",
+            "resolved": "https://registry.npmjs.org/usignal/-/usignal-0.8.9.tgz",
+            "integrity": "sha512-jI8+NVOb5AZIx5JzKcCfQzdwbL/E5oOmRciFAKlU9ZV3jeBbaBh9FpwG2Jr1AYsHOxBLNA5GwaQATdjzGydA2Q=="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/frameworks/non-keyed/udomsay/package.json
+++ b/frameworks/non-keyed/udomsay/package.json
@@ -21,7 +21,7 @@
         "url": "https://github.com/krausest/js-framework-benchmark.git"
     },
     "dependencies": {
-        "udomsay": "0.1.7"
+        "udomsay": "0.3.4"
     },
     "devDependencies": {
         "@babel/cli": "^7.19.3",

--- a/frameworks/non-keyed/udomsay/src/main.jsx
+++ b/frameworks/non-keyed/udomsay/src/main.jsx
@@ -97,7 +97,7 @@ const App = () => (
       {data.value.map(({id: rowId, label}, idx) => (
         <tr>
           <td class='col-md-1' textContent={rowId} />
-          <td class='col-md-4'><a onClick={({currentTarget: t}) => { selected.value = t.closest('tr') }} textContent={ label.value } /></td>
+          <td class='col-md-4'><a onClick={({currentTarget: t}) => { selected.value = t.closest('tr') }}>{ label }</a></td>
           <td class='col-md-1'><a onClick={() => { remove(idx) }}><span class='glyphicon glyphicon-remove' aria-hidden='true' /></a></td>
           <td class='col-md-6'/>
         </tr>


### PR DESCRIPTION
Well, this is my better take at this benchmark, after quite some work on internal logic for udomsay, where:

  * the current benchmark works but it's basically broken as the library wasn't effecting as expected with the partial rows update test, moving each time the whole App reload for no reason, and scoring accordingly (poorly)
  * instead of using hacks around `textContent` props, the JSX now uses the signal as is in the place it belongs to: the text part f the `<a />` element. The library now automatically creates "*atomic effects*" for signals used live on the DOM, granting updates in loco, resulting in more natural JSX representation without abusing props names to use as direct accessors
  * because usignal was broken before, the heap usage was also misleading ... now it's more aligned with real-world scenarios (it's higher, unfortunately, but it is what it is)

Thanks for considering this update so that the table will better reflect *udomsay* potentials out there.