### PR TITLE
Fix #1139 - Flagged all packages with Function, eval, or with statement in dist

### DIFF
--- a/frameworks/keyed/alpine/package.json
+++ b/frameworks/keyed/alpine/package.json
@@ -3,7 +3,10 @@
   "version": "3.4.2",
   "main": "dist/main.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "alpinejs"
+    "frameworkVersionFromPackage": "alpinejs",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "rollup -c -w",

--- a/frameworks/keyed/angularjs/package.json
+++ b/frameworks/keyed/angularjs/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "description": "Boilerplate for Angular.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "angular"
+    "frameworkVersionFromPackage": "angular",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack -w",

--- a/frameworks/keyed/blazor-wasm-aot/package.json
+++ b/frameworks/keyed/blazor-wasm-aot/package.json
@@ -4,7 +4,10 @@
   "description": "Blazor WebAssembly demo",
   "js-framework-benchmark": {
     "frameworkVersion": "6.0.1",
-    "customURL": "/bundeled-dist/wwwroot/"
+    "customURL": "/bundeled-dist/wwwroot/",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "install": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to clone reflex-dom\\'s benchmark and build system use: && echo npm run install-force",

--- a/frameworks/keyed/blazor-wasm/package.json
+++ b/frameworks/keyed/blazor-wasm/package.json
@@ -4,7 +4,10 @@
   "description": "Blazor WebAssembly demo",
   "js-framework-benchmark": {
     "frameworkVersion": "6.0.1",
-    "customURL": "/bundeled-dist/wwwroot/"
+    "customURL": "/bundeled-dist/wwwroot/",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "install": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to clone reflex-dom\\'s benchmark and build system use: && echo npm run install-force",

--- a/frameworks/keyed/dioxus/package.json
+++ b/frameworks/keyed/dioxus/package.json
@@ -4,7 +4,10 @@
   "description": "Benchmark for Dioxus",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.2.4"
+    "frameworkVersion": "0.2.4",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",

--- a/frameworks/keyed/dojo/package.json
+++ b/frameworks/keyed/dojo/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "@dojo/framework",
-    "customURL": "/output/dist"
+    "customURL": "/output/dist",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "./node_modules/.bin/dojo build"

--- a/frameworks/keyed/dominator/package.json
+++ b/frameworks/keyed/dominator/package.json
@@ -4,7 +4,10 @@
   "description": "Benchmark for dominator",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.5.0"
+    "frameworkVersion": "0.5.0",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",

--- a/frameworks/keyed/doohtml/package.json
+++ b/frameworks/keyed/doohtml/package.json
@@ -8,7 +8,7 @@
       "useShadowRoot": true,
       "shadowRootName": "doo-main",
       "buttonsInShadowRoot": false,
-      "issues": [772]      
+      "issues": [772, 1139]
     },
     "scripts": {
       "build-dev": "exit 0",

--- a/frameworks/keyed/doz/package.json
+++ b/frameworks/keyed/doz/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "js-framework-benchmark": {
     "frameworkVersion": "5-preview",
-    "issues": [800]
+    "issues": [800, 1139]
   },
   "scripts": {
     "build-dev": "webpack --watch --mode=development",

--- a/frameworks/keyed/ember/package.json
+++ b/frameworks/keyed/ember/package.json
@@ -13,7 +13,9 @@
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "ember-source",
     "customURL": "/dist",
-    "issues": []
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "ember": "node_modules/.bin/ember",

--- a/frameworks/keyed/glimmer-2/package.json
+++ b/frameworks/keyed/glimmer-2/package.json
@@ -27,7 +27,9 @@
   },
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "@glimmer/core",
-    "issues": []
+    "issues": [
+      1139
+    ]
   },
   "dependencies": {
     "@glimmer/babel-preset": "^2.0.0-beta.13",

--- a/frameworks/keyed/glimmer/package.json
+++ b/frameworks/keyed/glimmer/package.json
@@ -10,7 +10,8 @@
     "frameworkVersionFromPackage": "@glimmer/application",
     "customURL": "/dist",
     "issues": [
-      800
+      800,
+      1139
     ]
   },
   "scripts": {

--- a/frameworks/keyed/gyron/package.json
+++ b/frameworks/keyed/gyron/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "description": "Benchmark for gyron.js framework",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "gyron"
+    "frameworkVersionFromPackage": "gyron",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --mode development --watch",

--- a/frameworks/keyed/imba/package.json
+++ b/frameworks/keyed/imba/package.json
@@ -4,7 +4,10 @@
   "description": "Imba demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "imba"
+    "frameworkVersionFromPackage": "imba",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/knockout/package.json
+++ b/frameworks/keyed/knockout/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "description": "Knockout v3.5 demo",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "knockout"
+    "frameworkVersionFromPackage": "knockout",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "rollup -c",

--- a/frameworks/keyed/ko-jsx/package.json
+++ b/frameworks/keyed/ko-jsx/package.json
@@ -3,7 +3,10 @@
   "version": "0.16.1",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "ko-jsx"
+    "frameworkVersionFromPackage": "ko-jsx",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "rollup -c",

--- a/frameworks/keyed/leptos/package.json
+++ b/frameworks/keyed/leptos/package.json
@@ -4,7 +4,10 @@
   "description": "Benchmark for Leptos",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.0.17"
+    "frameworkVersion": "0.0.17",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",

--- a/frameworks/keyed/lui/package.json
+++ b/frameworks/keyed/lui/package.json
@@ -3,7 +3,10 @@
   "version": "1.1.0",
   "description": "Benchmark for lui",
   "js-framework-benchmark": {
-    "frameworkVersion": "1.2.3"
+    "frameworkVersion": "1.2.3",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "echo 0",

--- a/frameworks/keyed/marionette-backbone/package.json
+++ b/frameworks/keyed/marionette-backbone/package.json
@@ -7,7 +7,8 @@
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "marionette",
     "issues": [
-      772
+      772,
+      1139
     ]
   },
   "scripts": {

--- a/frameworks/keyed/marionette/package.json
+++ b/frameworks/keyed/marionette/package.json
@@ -6,7 +6,9 @@
   "main": "index.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "marionette",
-    "issues": []
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "rollup -c -w",

--- a/frameworks/keyed/mikado/package.json
+++ b/frameworks/keyed/mikado/package.json
@@ -6,7 +6,9 @@
   "license": "Apache-2.0",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "mikado",
-    "issues": []
+    "issues": [
+      1139
+    ]
   },
   "preferGlobal": false,
   "repository": {

--- a/frameworks/keyed/mimbl/package.json
+++ b/frameworks/keyed/mimbl/package.json
@@ -3,7 +3,10 @@
   "version": "0.8.1",
   "description": "Benchmark for Mimbl framework (keyed)",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "mimbl"
+    "frameworkVersionFromPackage": "mimbl",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "webpack"

--- a/frameworks/keyed/miso/package.json
+++ b/frameworks/keyed/miso/package.json
@@ -9,7 +9,10 @@
   ],
   "js-framework-benchmark": {
     "frameworkVersion": "1.4.0",
-    "customURL": "/dist-bundle"
+    "customURL": "/dist-bundle",
+    "issues": [
+      1139
+    ]
   },
   "homepage": "https://github.com/krausest/js-framework-benchmark",
   "repository": {

--- a/frameworks/keyed/mithril/package.json
+++ b/frameworks/keyed/mithril/package.json
@@ -3,7 +3,10 @@
   "version": "2.0.4",
   "description": "Benchmark for Mithrill 2.0.4 framework",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "mithril"
+    "frameworkVersionFromPackage": "mithril",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack -w -d",

--- a/frameworks/keyed/ractive/package.json
+++ b/frameworks/keyed/ractive/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "description": "Boilerplate for Ractive.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "ractive"
+    "frameworkVersionFromPackage": "ractive",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack -w -d",

--- a/frameworks/keyed/react-easy-state/package.json
+++ b/frameworks/keyed/react-easy-state/package.json
@@ -4,7 +4,10 @@
   "description": "React Easy State demo",
   "main": "src/index.jsx",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react:@risingstack/react-easy-state"
+    "frameworkVersionFromPackage": "react:@risingstack/react-easy-state",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack -w -d",

--- a/frameworks/keyed/react-hooks-use-transition/package.json
+++ b/frameworks/keyed/react-hooks-use-transition/package.json
@@ -4,7 +4,10 @@
   "description": "React Hooks demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react"
+    "frameworkVersionFromPackage": "react",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/react-hooks/package.json
+++ b/frameworks/keyed/react-hooks/package.json
@@ -4,7 +4,10 @@
   "description": "React Hooks demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react"
+    "frameworkVersionFromPackage": "react",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/react-lab/package.json
+++ b/frameworks/keyed/react-lab/package.json
@@ -4,7 +4,10 @@
   "description": "React lab",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersion": "17.0.3"
+    "frameworkVersion": "17.0.3",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/react-mlyn/package.json
+++ b/frameworks/keyed/react-mlyn/package.json
@@ -4,7 +4,10 @@
   "description": "React mlyn demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react-mlyn"
+    "frameworkVersionFromPackage": "react-mlyn",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/react-mobX/package.json
+++ b/frameworks/keyed/react-mobX/package.json
@@ -4,7 +4,10 @@
   "description": "React demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react:mobx"
+    "frameworkVersionFromPackage": "react:mobx",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack -w -d",

--- a/frameworks/keyed/react-recoil/package.json
+++ b/frameworks/keyed/react-recoil/package.json
@@ -4,7 +4,10 @@
   "description": "React Recoil demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react"
+    "frameworkVersionFromPackage": "react",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/react-redux-hooks-immutable/package.json
+++ b/frameworks/keyed/react-redux-hooks-immutable/package.json
@@ -4,7 +4,10 @@
   "description": "React demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react:react-redux"
+    "frameworkVersionFromPackage": "react:react-redux",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/react-redux-hooks/package.json
+++ b/frameworks/keyed/react-redux-hooks/package.json
@@ -4,7 +4,10 @@
   "description": "React demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react:react-redux"
+    "frameworkVersionFromPackage": "react:react-redux",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/react-redux-rematch/package.json
+++ b/frameworks/keyed/react-redux-rematch/package.json
@@ -4,7 +4,10 @@
   "description": "React with Rematch and Redux demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react:react-redux:@rematch/core"
+    "frameworkVersionFromPackage": "react:react-redux:@rematch/core",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/react-redux/package.json
+++ b/frameworks/keyed/react-redux/package.json
@@ -4,7 +4,10 @@
   "description": "React demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react:react-redux"
+    "frameworkVersionFromPackage": "react:react-redux",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/react-rxjs/package.json
+++ b/frameworks/keyed/react-rxjs/package.json
@@ -4,7 +4,10 @@
   "description": "React demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react:@react-rxjs/core"
+    "frameworkVersionFromPackage": "react:@react-rxjs/core",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/react-starbeam/package.json
+++ b/frameworks/keyed/react-starbeam/package.json
@@ -4,7 +4,10 @@
   "description": "Starbeam demo using React",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react:@starbeam/core"
+    "frameworkVersionFromPackage": "react:@starbeam/core",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "start": "npx live-server",

--- a/frameworks/keyed/react-tagged-state/package.json
+++ b/frameworks/keyed/react-tagged-state/package.json
@@ -4,7 +4,10 @@
   "description": "React demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react:react-tagged-state"
+    "frameworkVersionFromPackage": "react:react-tagged-state",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/react-tracked/package.json
+++ b/frameworks/keyed/react-tracked/package.json
@@ -4,7 +4,10 @@
   "description": "React Tracked demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react:react-tracked"
+    "frameworkVersionFromPackage": "react:react-tracked",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/react-zustand/package.json
+++ b/frameworks/keyed/react-zustand/package.json
@@ -4,7 +4,10 @@
   "description": "React Zustand demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "react:zustand"
+    "frameworkVersionFromPackage": "react:zustand",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/keyed/reagent/package.json
+++ b/frameworks/keyed/reagent/package.json
@@ -2,7 +2,10 @@
   "name": "reagent",
   "private": true,
   "js-framework-benchmark": {
-    "frameworkVersion": "0.10"
+    "frameworkVersion": "0.10",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "LEIN_VERSION=2.9.3 lein cljsbuild auto",

--- a/frameworks/keyed/resonatejs/package.json
+++ b/frameworks/keyed/resonatejs/package.json
@@ -4,7 +4,10 @@
   "description": "ResonateJS Demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersion": ""
+    "frameworkVersion": "",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack -w -d",

--- a/frameworks/keyed/san-composition/package.json
+++ b/frameworks/keyed/san-composition/package.json
@@ -5,7 +5,8 @@
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "san:san-composition",
     "issues": [
-      800
+      800,
+      1139
     ]
   },
   "scripts": {

--- a/frameworks/keyed/san-store/package.json
+++ b/frameworks/keyed/san-store/package.json
@@ -5,7 +5,8 @@
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "san:san-store",
     "issues": [
-      800
+      800,
+      1139
     ]
   },
   "scripts": {

--- a/frameworks/keyed/san/package.json
+++ b/frameworks/keyed/san/package.json
@@ -4,7 +4,7 @@
   "description": "Benchmark for san framework",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "san",
-    "issues": [800]
+    "issues": [800, 1139]
   },
   "scripts": {
     "build-dev": "webpack -w -d",

--- a/frameworks/keyed/scarlets-frame/package.json
+++ b/frameworks/keyed/scarlets-frame/package.json
@@ -4,7 +4,10 @@
   "description": "ScarletsFrame demo",
   "main": "src/index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "scarletsframe"
+    "frameworkVersionFromPackage": "scarletsframe",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "rollup -c -w",

--- a/frameworks/keyed/sifrr/package.json
+++ b/frameworks/keyed/sifrr/package.json
@@ -11,7 +11,7 @@
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "@sifrr/dom",
     "useShadowRoot": true,
-    "issues": [800, 801]
+    "issues": [800, 801, 1139]
   },
   "repository": {
     "type": "git",

--- a/frameworks/keyed/sledgehammer/package.json
+++ b/frameworks/keyed/sledgehammer/package.json
@@ -6,7 +6,8 @@
   "js-framework-benchmark": {
     "frameworkVersion": "1.0.0",
     "issues": [
-      772
+      772,
+      1139
     ]
   },
   "scripts": {

--- a/frameworks/keyed/spair-qr/package.json
+++ b/frameworks/keyed/spair-qr/package.json
@@ -4,7 +4,10 @@
   "description": "Benchmark for Spair-qr",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.0.8"
+    "frameworkVersion": "0.0.8",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",

--- a/frameworks/keyed/spair/package.json
+++ b/frameworks/keyed/spair/package.json
@@ -4,7 +4,10 @@
   "description": "Benchmark for Spair",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.0.8"
+    "frameworkVersion": "0.0.8",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",

--- a/frameworks/keyed/stencil/package.json
+++ b/frameworks/keyed/stencil/package.json
@@ -2,7 +2,10 @@
   "name": "stencil",
   "version": "0.0.1",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "@stencil/core"
+    "frameworkVersionFromPackage": "@stencil/core",
+    "issues": [
+      1139
+    ]
   },
   "description": "Stencil Demo",
   "homepage": "https://github.com/krausest/js-framework-benchmark",

--- a/frameworks/keyed/sycamore/package.json
+++ b/frameworks/keyed/sycamore/package.json
@@ -4,7 +4,10 @@
   "description": "Benchmark for Sycamore",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.8.0"
+    "frameworkVersion": "0.8.0",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",

--- a/frameworks/keyed/voby/package.json
+++ b/frameworks/keyed/voby/package.json
@@ -3,7 +3,10 @@
   "version": "0.43.8",
   "main": "dist/main.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "voby"
+    "frameworkVersionFromPackage": "voby",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "rm -rf dist && mkdir dist && esbuild --bundle --minify --target=es2018 --jsx-factory=createElement --jsx-fragment=Fragment --banner:js='\"use strict\";' ./src/main.tsx > ./dist/main.js"

--- a/frameworks/keyed/vue/package.json
+++ b/frameworks/keyed/vue/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "description": "Benchmark for vue.js framework",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "vue"
+    "frameworkVersionFromPackage": "vue",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --mode development --watch",

--- a/frameworks/keyed/wasm-bindgen/package.json
+++ b/frameworks/keyed/wasm-bindgen/package.json
@@ -5,7 +5,7 @@
   "license": "ISC",
   "js-framework-benchmark": {
     "frameworkVersion": "0.2.47",
-    "issues": [772]
+    "issues": [772, 1139]
   },
   "scripts": {
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",

--- a/frameworks/keyed/whatsup/package.json
+++ b/frameworks/keyed/whatsup/package.json
@@ -5,7 +5,10 @@
     "author": "Denis Churbanov",
     "license": "MIT",
     "js-framework-benchmark": {
-        "frameworkVersionFromPackage": "whatsup"
+        "frameworkVersionFromPackage": "whatsup",
+        "issues": [
+          1139
+        ]
     },
     "repository": {
         "type": "git",

--- a/frameworks/keyed/yew-hooks/package.json
+++ b/frameworks/keyed/yew-hooks/package.json
@@ -4,7 +4,10 @@
   "description": "Benchmark for Yew Hooks",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.19.3"
+    "frameworkVersion": "0.19.3",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",

--- a/frameworks/keyed/yew/package.json
+++ b/frameworks/keyed/yew/package.json
@@ -4,7 +4,10 @@
   "description": "Benchmark for Yew",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.19.3"
+    "frameworkVersion": "0.19.3",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",

--- a/frameworks/non-keyed/delorean/package.json
+++ b/frameworks/non-keyed/delorean/package.json
@@ -4,7 +4,10 @@
   "description": "Benchmark for DeLorean",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.1.0"
+    "frameworkVersion": "0.1.0",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",

--- a/frameworks/non-keyed/dojo/package.json
+++ b/frameworks/non-keyed/dojo/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "@dojo/framework",
-    "customURL": "/output/dist"
+    "customURL": "/output/dist",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "./node_modules/.bin/dojo build"

--- a/frameworks/non-keyed/doohtml/package.json
+++ b/frameworks/non-keyed/doohtml/package.json
@@ -8,7 +8,7 @@
       "useShadowRoot": true,
       "shadowRootName": "doo-main",
       "buttonsInShadowRoot": false,
-      "issues": [772]      
+      "issues": [772, 1139]
     },
     "scripts": {
       "build-dev": "exit 0",

--- a/frameworks/non-keyed/doz/package.json
+++ b/frameworks/non-keyed/doz/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "doz",
-    "issues": [800]
+    "issues": [800, 1139]
   },
   "scripts": {
     "build-dev": "webpack --watch --mode=development",

--- a/frameworks/non-keyed/imba/package.json
+++ b/frameworks/non-keyed/imba/package.json
@@ -4,7 +4,10 @@
   "description": "Imba demo",
   "main": "index.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "imba"
+    "frameworkVersionFromPackage": "imba",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --watch",

--- a/frameworks/non-keyed/mikado/package.json
+++ b/frameworks/non-keyed/mikado/package.json
@@ -6,7 +6,9 @@
   "license": "Apache-2.0",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "mikado",
-    "issues": []
+    "issues": [
+      1139
+    ]
   },
   "preferGlobal": false,
   "repository": {

--- a/frameworks/non-keyed/miso/package.json
+++ b/frameworks/non-keyed/miso/package.json
@@ -9,7 +9,10 @@
   ],
   "js-framework-benchmark": {
     "frameworkVersion": "1.4.0",
-    "customURL": "/dist-bundle"
+    "customURL": "/dist-bundle",
+    "issues": [
+      1139
+    ]
   },
   "homepage": "https://github.com/krausest/js-framework-benchmark",
   "repository": {

--- a/frameworks/non-keyed/ractive/package.json
+++ b/frameworks/non-keyed/ractive/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "description": "Boilerplate for Ractive.js",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "ractive"
+    "frameworkVersionFromPackage": "ractive",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack -w -d",

--- a/frameworks/non-keyed/reflex-dom/package.json
+++ b/frameworks/non-keyed/reflex-dom/package.json
@@ -6,7 +6,9 @@
   "js-framework-benchmark": {
     "frameworkVersion": "0.4",
     "customURL": "/bundled-dist",
-    "issues": []
+    "issues": [
+      1139
+    ]
   },
   "contributors": [
     "Ryan Trinkle <ryan.trinkle@gmail.com>"

--- a/frameworks/non-keyed/san/package.json
+++ b/frameworks/non-keyed/san/package.json
@@ -4,7 +4,7 @@
   "description": "Benchmark for san framework",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "san",
-    "issues": [800]
+    "issues": [800, 1139]
   },
   "scripts": {
     "build-dev": "webpack -w -d",

--- a/frameworks/non-keyed/sauron/package.json
+++ b/frameworks/non-keyed/sauron/package.json
@@ -4,7 +4,10 @@
   "description": "Benchmark for Sauron",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.50.3"
+    "frameworkVersion": "0.50.3",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",

--- a/frameworks/non-keyed/scarlets-frame/package.json
+++ b/frameworks/non-keyed/scarlets-frame/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "scarletsframe",
-    "issues": [800]
+    "issues": [800, 1139]
   },
   "scripts": {
     "build-dev": "rollup -c -w",

--- a/frameworks/non-keyed/seed/package.json
+++ b/frameworks/non-keyed/seed/package.json
@@ -4,7 +4,10 @@
   "description": "Benchmark for Seed",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.8.0"
+    "frameworkVersion": "0.8.0",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "rimraf bundled-dist && wasm-pack build --dev --target web --out-name js-framework-benchmark-non-keyed-seed --out-dir bundled-dist && cpr index.html bundled-dist/index.html && rimraf bundled-dist/.gitignore",

--- a/frameworks/non-keyed/sifrr/package.json
+++ b/frameworks/non-keyed/sifrr/package.json
@@ -11,7 +11,7 @@
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "@sifrr/dom",
     "useShadowRoot": true,
-    "issues": [800]
+    "issues": [800, 1139]
   },
   "repository": {
     "type": "git",

--- a/frameworks/non-keyed/simi/package.json
+++ b/frameworks/non-keyed/simi/package.json
@@ -4,7 +4,10 @@
   "description": "Benchmark for Simi",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.2.0-dev1"
+    "frameworkVersion": "0.2.0-dev1",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated files are already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",

--- a/frameworks/non-keyed/slingjs/package.json
+++ b/frameworks/non-keyed/slingjs/package.json
@@ -3,7 +3,10 @@
   "version": "14.3.0",
   "description": "Benchmark for Sling.js 14.3.0 framework",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "slingjs"
+    "frameworkVersionFromPackage": "slingjs",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack -w -d",

--- a/frameworks/non-keyed/vue/package.json
+++ b/frameworks/non-keyed/vue/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "description": "Benchmark for vue.js framework",
   "js-framework-benchmark": {
-    "frameworkVersionFromPackage": "vue"
+    "frameworkVersionFromPackage": "vue",
+    "issues": [
+      1139
+    ]
   },
   "scripts": {
     "build-dev": "webpack --mode development --watch",


### PR DESCRIPTION
While checking all dist files and folders in search for code evaluation as AsyncFunction constructor (alpine), Function (many others), explicit eval or indirection to reach a with statement in code, I've noticed the following cases:

  * the architecture requires usage of evaluation by author's choice.
  * the architecture requires code evaluation due WASM.
  * it's actually the bundler that puts in code evaluation.
  * it's possible that some library/framework allows evaluation through `<script>` tags, so I might have missed some but it's hard to understand if that's the case

I believe the purpose of the flag is to inform libraries and frameworks consumers that they need special CSP rules or the code might break in the wild. At the same time, I believe developers should be aware about poor choices previously made by bundlers, as example `new Function('return this')` to reach the global context. In the WASM case, I also believe developers should be aware special care of the CSP rules must be taken.

As result, all dist used to demo the benchmark in here that contains Functions either intentionally or as side effect due outdated or poor bundlers *should* be flagged equally as potentially problematic if deployed with those tools or those requirements (WASM) in the wild.