### PR TITLE
[WIP] Fix framework detection for a new package-lock.json format

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -47,7 +47,11 @@ async function loadFrameworkInfo(keyedDir, directoryName) {
             let packageLockJSON = JSON.parse(await fsp.readFile(packageLockJSONPath, "utf8"));
             result.versions = {};
             for (let packageName of packageNames) {
-              if (packageLockJSON.dependencies[packageName]) {
+              if (packageLockJSON?.packages?.['']?.dependencies?.[packageName]) {
+                result.versions[packageName] = packageLockJSON.packages?.['']?.dependencies?.[packageName];
+              } else if (packageLockJSON?.packages?.['']?.devDependencies?.[packageName]) {
+                result.versions[packageName] = packageLockJSON.packages?.['']?.devDependencies?.[packageName];
+              } else if (packageLockJSON?.dependencies?.[packageName]) {
                 result.versions[packageName] = packageLockJSON.dependencies[packageName].version;
               } else {
                 result.versions[packageName] = "ERROR: Not found in package-lock";


### PR DESCRIPTION
NPM has new `package-lock.json` formats (v2 and v3), which means if you recreate the file for any framework, version detection  in `server/index.js` is going to break.

Instead of `packageLockJSON.dependencies[packageName]` the new format looks like `packageLockJSON.packages.[''].dependencies.[packageName]`. See e.g. [https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json).

Also, some frameworks (e.g. Ember), put their core dependency, from which version should be derived, into `devDependencies` instead of `dependencies`.

This PR tries to remedy these situations, but I understand you might prefer a different solution :D, as this one is fairly ugly/might use JS features outside your preferred `node` support matrix. Anyway, thought it might be useful for someone, so I'll just leave it here.