### PR TITLE
chore: update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "js-framework-benchmark",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.5.9",


### PR DESCRIPTION
npm adds an extra line to the lockfile for me. I guess the lockfile must have been generated with an older version of npm? It'd be nice to update the lockfile in the repo because the file is always being updated on my local copy