### PR TITLE
Update file path for Chrome on Windows

### DIFF
--- a/webdriver-ts/src/playwrightAccess.ts
+++ b/webdriver-ts/src/playwrightAccess.ts
@@ -87,7 +87,7 @@ function browserPath(benchmarkOptions: BenchmarkDriverOptions) {
   } else if (process.platform == "linux") {
     return "/usr/bin/google-chrome";
   } else if(/^win/i.test(process.platform)) {
-    return 'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe';    
+    return 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe';    
   } else {
     throw new Error("Path to Google Chrome executable must be specified");
   }

--- a/webdriver-ts/src/puppeteerAccess.ts
+++ b/webdriver-ts/src/puppeteerAccess.ts
@@ -86,7 +86,7 @@ function browserPath(benchmarkOptions: BenchmarkDriverOptions) {
   } else if (process.platform == "linux") {
     return "google-chrome";
   } else if(/^win/i.test(process.platform)) {
-    return 'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe';    
+    return 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe';    
   } else {
     throw new Error("Path to Google Chrome executable must be specified");
   }


### PR DESCRIPTION
* Update file path for Chrome on Windows to use 64-bit version.

On my Windows 11 Version 22H2 machine I needed to update the paths for Chrome to use the 64-bit version, which I believe should be the new standard. 