### PR TITLE
Add glob support for rimraf for Windows

### DIFF
--- a/webdriver-ts-results/package.json
+++ b/webdriver-ts-results/package.json
@@ -23,7 +23,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint './src/**/*.{ts,tsx}'",
-    "build-prod": "rimraf dist && cross-env NODE_ENV=\"production\" webpack --env prod -c webpack.config.js && rimraf table.html && rimraf \"BoxPlotTable*.js\" && cpx dist/table.html . && cpx \"dist/BoxPlotTable*.js\" . && cpx \"dist/plotly*.js\" ."
+    "build-prod": "rimraf --glob dist && cross-env NODE_ENV=\"production\" webpack --env prod -c webpack.config.js && rimraf --glob table.html && rimraf --glob \"BoxPlotTable*.js\" && cpx dist/table.html . && cpx \"dist/BoxPlotTable*.js\" . && cpx \"dist/plotly*.js\" ."
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
* Add glob support for rimraf for Windows hosts.

Tested on:
- Ubuntu 20.04.5 LTS
- Windows 11 Version 22H2

```rimraf``` version 4.2+ puts glob support for systems that don't natively support globs behind the ```--glob``` option.

With this change users on Windows can build the results table. 

Don't believe there are adverse impacts to non-Windows users, but I haven't tested on a macOS machine.