### PR TITLE
Update Sling.js to version 18.1.0

### DIFF
--- a/frameworks/non-keyed/slingjs/index.html
+++ b/frameworks/non-keyed/slingjs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Sling.js v18.0.0</title>
+  <title>Sling.js v18.1.0</title>
   <link href="/css/currentStyle.css" rel="stylesheet"/>
 </head>
 <body>

--- a/frameworks/non-keyed/slingjs/package-lock.json
+++ b/frameworks/non-keyed/slingjs/package-lock.json
@@ -1,14 +1,14 @@
 {
-  "name": "js-framework-benchmark-slingjs-18.0.0",
-  "version": "18.0.0",
+  "name": "js-framework-benchmark-slingjs-18.1.0",
+  "version": "18.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "js-framework-benchmark-slingjs-18.0.0",
-      "version": "18.0.0",
+      "name": "js-framework-benchmark-slingjs-18.1.0",
+      "version": "18.1.0",
       "dependencies": {
-        "slingjs": "18.0.0"
+        "slingjs": "18.1.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.21.0",
@@ -1749,9 +1749,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.38.0.tgz",
-      "integrity": "sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==",
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.39.0.tgz",
+      "integrity": "sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -1936,9 +1936,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "version": "18.16.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
+      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ==",
       "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
@@ -2114,9 +2114,9 @@
       }
     },
     "node_modules/@webpack-cli/serve": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.1.tgz",
-      "integrity": "sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.2.tgz",
+      "integrity": "sha512-S9h3GmOmzUseyeFW3tYNnWS7gNUuwxZ3mmMq0JyW78Vx1SGKPSkt5bT4pB0rUnVfHjP0EL9gW2bOzmtiTfQt0A==",
       "dev": true,
       "engines": {
         "node": ">=14.15.0"
@@ -2414,9 +2414,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001478",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001478.tgz",
-      "integrity": "sha512-gMhDyXGItTHipJj2ApIvR+iVB5hd0KP3svMWWXDvZOmjzJJassGLMfxRkQCSYgGd2gtdL/ReeiyvMSFD1Ss6Mw==",
+      "version": "1.0.30001481",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
+      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
       "dev": true,
       "funding": [
         {
@@ -2622,9 +2622,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.365",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.365.tgz",
-      "integrity": "sha512-FRHZO+1tUNO4TOPXmlxetkoaIY8uwHzd1kKopK/Gx2SKn1L47wJXWD44wxP5CGRyyP98z/c8e1eBzJrgPeiBOg==",
+      "version": "1.4.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.371.tgz",
+      "integrity": "sha512-jlBzY4tFcJaiUjzhRTCWAqRvTO/fWzjA3Bls0mykzGZ7zvcMP7h05W6UcgzfT9Ca1SW2xyKDOFRyI0pQeRNZGw==",
       "dev": true
     },
     "node_modules/emojis-list": {
@@ -2637,9 +2637,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
-      "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.13.0.tgz",
+      "integrity": "sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -2686,16 +2686,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.38.0.tgz",
-      "integrity": "sha512-pIdsD2jwlUGf/U38Jv97t8lq6HpaU/G9NKbYmpWpZGw3LdTNhZLbJePqxOXGB5+JEKfOPU/XLxYxFh03nr1KTg==",
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.39.0.tgz",
+      "integrity": "sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
         "@eslint/eslintrc": "^2.0.2",
-        "@eslint/js": "8.38.0",
+        "@eslint/js": "8.39.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -2705,7 +2705,7 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
+        "eslint-scope": "^7.2.0",
         "eslint-visitor-keys": "^3.4.0",
         "espree": "^9.5.1",
         "esquery": "^1.4.2",
@@ -4160,12 +4160,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
-      "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.12.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -4357,9 +4357,9 @@
       }
     },
     "node_modules/slingjs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/slingjs/-/slingjs-18.0.0.tgz",
-      "integrity": "sha512-uXivT5bFszomfeZcnPnNQWe8/c88g1tpniMhaObfjo2MHXZhgO4QP7bWONO5TGJWimvjTQzkwQ26V+SBXKv44A=="
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/slingjs/-/slingjs-18.1.0.tgz",
+      "integrity": "sha512-lIJ/R+jy8t+5HCrhSzs11mKKkUbwfcaF8oKMGzZLLpkn2S1+IYiyWlDe/IUvXstEZCRVpXKOvAigKa8oCYA3aA=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -4440,9 +4440,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.16.9",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.9.tgz",
-      "integrity": "sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
+      "integrity": "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -4805,9 +4805,9 @@
       }
     },
     "node_modules/wildcard": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true
     },
     "node_modules/word-wrap": {

--- a/frameworks/non-keyed/slingjs/package.json
+++ b/frameworks/non-keyed/slingjs/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "js-framework-benchmark-slingjs-18.0.0",
-  "version": "18.0.0",
-  "description": "Benchmark for Sling.js 18.0.0 framework",
+  "name": "js-framework-benchmark-slingjs-18.1.0",
+  "version": "18.1.0",
+  "description": "Benchmark for Sling.js 18.1.0 framework",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "slingjs",
     "frameworkHomeURL": "https://github.com/puckowski/Sling.js"
@@ -21,6 +21,6 @@
     "webpack-cli": "5.0.1"
   },
   "dependencies": {
-    "slingjs": "18.0.0"
+    "slingjs": "18.1.0"
   }
 }

--- a/frameworks/non-keyed/slingjs/src/controller.js
+++ b/frameworks/non-keyed/slingjs/src/controller.js
@@ -139,7 +139,7 @@ export class ControllerComponent {
                                     children: [
                                         markup('h1', {
                                             children: [
-                                                textNode('Sling.js 18.0.0')
+                                                textNode('Sling.js 18.1.0')
                                             ]
                                         })
                                     ]


### PR DESCRIPTION
* Update Sling.js to version 18.1.0.

Tested on:
```
Node v18.15.0
npm 9.5.0
```

```
npm run isKeyed non-keyed/slingjs

> webdriver-ts@1.0.0 isKeyed
> cross-env LANG="en_US.UTF-8" node dist/isKeyed.js non-keyed/slingjs

args.framework undefined true
Frameworks that will be checked slingjs-v18.1.0-non-keyed
*** headless undefined
slingjs-v18.1.0-non-keyed is non-keyed for 'run benchmark' and non-keyed for 'remove row benchmark' and non-keyed for 'swap rows benchmark' . It'll appear as non-keyed in the results
```