### PR TITLE
refactor: rebuild-single.js

### DIFF
--- a/rebuild-single.js
+++ b/rebuild-single.js
@@ -1,18 +1,15 @@
-var _ = require('lodash');
-var exec = require('child_process').execSync;
-var fs = require('fs');
-var path = require('path');
-var yargs = require('yargs');
-const rimraf = require('rimraf');
+const { execSync } = require("child_process");
 
-let args = process.argv.length <= 2 ? [] : process.argv.slice(2, process.argv.length);
+const args = process.argv.slice(2);
+const argsString = args.join(" ");
 
 // Use npm ci or npm install ?
-let ci = args.includes("--ci");
-// Copy package-lock back for docker build or build locally?
-let docker = args.includes("--docker");
+const ci = args.includes("--ci");
 
-let frameworks = args.filter(a => !a.startsWith("--"));
+// Copy package-lock back for docker build or build locally?
+const docker = args.includes("--docker");
+
+const frameworks = args.filter((a) => !a.startsWith("--"));
 
 console.log("args", args, "ci", ci, "docker", docker, "frameworks", frameworks);
 
@@ -30,33 +27,26 @@ Pass list of frameworks
 */
 
 try {
-    if (frameworks.length == 0) {
-        console.log("ERROR: Missing arguments. Command: docker-rebuild keyed/framework1 non-keyed/framework2 ...");
-        process.exit(1);
-    }
+  if (frameworks.length == 0) {
+    console.log(
+      "ERROR: Missing arguments. Command: docker-rebuild keyed/framework1 non-keyed/framework2 ..."
+    );
+    process.exit(1);
+  }
 
-    if (docker) {
-        let build_cmd = `docker exec -it js-framework-benchmark cp /src/rebuild-build-single.js /build/ && docker exec -it js-framework-benchmark node rebuild-build-single.js ${args.join(" ")}`;
-        console.log(build_cmd);
-        exec(build_cmd,
-            {
-                stdio: 'inherit'
-            });        
-    } else {
-        let build_cmd = `node rebuild-build-single.js ${args.join(" ")}`;
-        console.log(build_cmd);
-        exec(build_cmd,
-            {
-                stdio: 'inherit'
-            });    
-    }
+  const buildCmd = docker
+    ? `docker exec -it js-framework-benchmark cp /src/rebuild-build-single.js /build/ && docker exec -it js-framework-benchmark node rebuild-build-single.js ${argsString}`
+    : `node rebuild-build-single.js ${argsString}`;
+  console.log(buildCmd);
+  execSync(buildCmd, {
+    stdio: "inherit",
+  });
 
-    let check_cmd = `node rebuild-check-single.js ${args.join(" ")}`;
-    console.log(check_cmd);
-    exec(check_cmd,
-    {
-        stdio: 'inherit'
-    });        
+  const checkCmd = `node rebuild-check-single.js ${argsString}`;
+  console.log(checkCmd);
+  execSync(checkCmd, {
+    stdio: "inherit",
+  });
 } catch (e) {
-    console.log(`ERROR: Rebuilding  ${args.join(" ")} was not successful`);
+  console.log(`ERROR: Rebuilding  ${argsString} was not successful`);
 }


### PR DESCRIPTION
- Add a dockerCmd assignment using a ternary operator.
- Remove unused imports.
- Simplify the assignment of args.
- Replace var and let with const where possible.
- Format with prettier.