### PR TITLE
refactor: rebuild-check-single.js

### DIFF
--- a/rebuild-check-single.js
+++ b/rebuild-check-single.js
@@ -1,15 +1,15 @@
-var _ = require('lodash');
-var exec = require('child_process').execSync;
-var fs = require('fs');
-var path = require('path');
-var yargs = require('yargs');
-const rimraf = require('rimraf');
+const { execSync } = require("child_process");
 
-let args = process.argv.length <= 2 ? [] : process.argv.slice(2, process.argv.length);
+const args = process.argv.slice(2);
+const frameworks = args.filter((a) => !a.startsWith("--"));
+const frameworkNames = frameworks.join(" ");
 
-let frameworks = args.filter(a => !a.startsWith("--"));
-
-console.log("rebuild-check-single.js started: args", args, "frameworks", frameworks);
+console.log(
+  "rebuild-check-single.js started: args",
+  args,
+  "frameworks",
+  frameworks
+);
 
 /*
 rebuild-single.js [--ci] [--docker] [keyed/framework1 ... non-keyed/frameworkN]
@@ -25,25 +25,26 @@ Pass list of frameworks
 */
 
 try {
-    let frameworkNames = frameworks.join(" ");
-    let bench_cmd = 'npm run bench -- --headless true --smoketest true ' + frameworkNames; 
-    console.log(bench_cmd);
-    exec(bench_cmd, {
-        cwd: 'webdriver-ts',
-        stdio: 'inherit'
-    });
+  const benchCmd = `npm run bench -- --headless true --smoketest true ${frameworkNames}`;
+  console.log(benchCmd);
+  execSync(benchCmd, {
+    cwd: "webdriver-ts",
+    stdio: "inherit",
+  });
 
-    let keyed_cmd = 'npm run isKeyed -- --headless true ' + frameworkNames; 
-    console.log(keyed_cmd);
-    exec(keyed_cmd, {
-        cwd: 'webdriver-ts',
-        stdio: 'inherit'
-    });
+  const keyedCmd = `npm run isKeyed -- --headless true ${frameworkNames}`;
+  console.log(keyedCmd);
+  execSync(keyedCmd, {
+    cwd: "webdriver-ts",
+    stdio: "inherit",
+  });
 
-    console.log("rebuild-check-single.js finished");
-    console.log("All checks are fine!");
-    console.log("======> Please rerun the benchmark: npm run bench ", frameworkNames);
+  console.log("rebuild-check-single.js finished");
+  console.log("All checks are fine!");
+  console.log(
+    `======> Please rerun the benchmark: npm run bench ${frameworkNames}`
+  );
 } catch (e) {
-    console.log(`rebuild-check-single failed for ${frameworks.join(" ")}`);
-    process.exit(-1);
+  console.log(`rebuild-check-single failed for ${frameworks.join(" ")}`);
+  process.exit(-1);
 }


### PR DESCRIPTION
- Replace var and let with const where possible.
- Remove the argv <= 2 length check, since slice still removes 2 elements.
- Remove unnecessary imports.
- Replace string concatenation with string template.