### PR TITLE
refactor: rebuild-add.js

### DIFF
--- a/rebuild-all.js
+++ b/rebuild-all.js
@@ -1,10 +1,7 @@
-var _ = require('lodash');
-var exec = require('child_process').execSync;
-var fs = require('fs');
-var path = require('path');
-const rimraf = require('rimraf');
-
-let args = process.argv.length <= 2 ? [] : process.argv.slice(2, process.argv.length);
+const takeWhile = require("lodash/takeWhile");
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
 
 /*
 This script rebuilds all frameworks from scratch,
@@ -15,66 +12,124 @@ If building a framework fails you can resume building like
 npm run rebuild-frameworks --restartWith keyed/react
 */
 
+const [, , ...cliArgs] = process.argv;
+
 // Use npm ci or npm install ?
-let ci = args.includes("--ci");
+const useCi = cliArgs.includes("--ci");
+
 // Copy package-lock back for docker build or build locally?
-let docker = args.includes("--docker");
-let restartBuildingWith = args.find(a => !a.startsWith("--"));
+const useDocker = cliArgs.includes("--docker");
 
+const restartBuildingWith = cliArgs.find((arg) => !arg.startsWith("--"));
+const restartWithFramework = restartBuildingWith || "";
 
-var restartWithFramework = restartBuildingWith || '';
-console.log("ARGS", "ci", ci, "docker", docker, "restartWith", restartWithFramework);
+console.log(
+  "ARGS",
+  "ci",
+  useCi,
+  "docker",
+  useDocker,
+  "restartWith",
+  restartWithFramework
+);
 
-var frameworks = [].concat(
-  fs.readdirSync('./frameworks/keyed').map(f => ['keyed', f]),
-  fs.readdirSync('./frameworks/non-keyed').map(f => ['non-keyed', f]));
+/**
+ * Returns an array with arrays of types and names of frameworks
+ * @example getFramewokrs()
+ * @returns [["keyed", "vue"],["keyed", "qwik"],["non-keyed", "svelte"]]
+ */
+function getFrameworks() {
+  const keyedFrameworks = fs
+    .readdirSync("./frameworks/keyed")
+    .map((framework) => ["keyed", framework]);
+  const nonKeyedFrameworks = fs
+    .readdirSync("./frameworks/non-keyed")
+    .map((framework) => ["non-keyed", framework]);
+  return [...keyedFrameworks, ...nonKeyedFrameworks];
+}
 
-var notRestarter = ([dir, name]) => {
+/**
+ * @param {[string,string]} tuple
+ * @returns {boolean}
+ */
+function shouldSkipFramework([dir, name]) {
   if (!restartWithFramework) return false;
-  if (restartWithFramework.indexOf("/")>-1) {
-    return !(dir+"/"+name).startsWith(restartWithFramework);
+  if (restartWithFramework.indexOf("/") > -1) {
+    return !`${dir}/${name}`.startsWith(restartWithFramework);
   } else {
     return !name.startsWith(restartWithFramework);
   }
-};
-
-let skippable = _.takeWhile(frameworks, notRestarter);
-let buildable = _.slice(frameworks, skippable.length);
-
-console.log("Building ", buildable);
-
-
-for (f of buildable) {
-    console.log("BUILDING ", f);
-    let [keyed,name] = f;
-    let path = `frameworks/${keyed}/${name}`;
-    if (!fs.existsSync(path+"/package.json")) {
-      console.log("WARN: skipping ", f, " since there's no package.json");    
-    } else {
-      // if (fs.existsSync(path)) {
-      //     console.log("deleting folder ",path);
-      //     exec(`rm -r ${path}`);
-      // }
-      // rsync(keyed,name);
-      let rm_cmd = `rm -rf ${ci ? '' : 'package-lock.json'} yarn.lock dist elm-stuff bower_components node_modules output`
-      console.log(rm_cmd);
-      exec(rm_cmd, {
-        cwd: path,
-        stdio: 'inherit'
-      });
-
-      let install_cmd = `npm ${ci ? 'ci' : 'install'} && npm run build-prod`;
-      console.log(install_cmd);
-      exec(install_cmd, {
-        cwd: path,
-        stdio: 'inherit'
-      });
-
-      if (docker) {
-        let packageLockPath = path+"/package-lock.json";
-        fs.copyFileSync(packageLockPath, "/src/"+packageLockPath);
-      }
-    }
 }
 
-console.log("All frameworks were built!");
+/**
+ * @param {string} frameworkPath
+ */
+function removeFiles(frameworkPath) {
+  const rmCmd = `rm -rf ${
+    useCi ? "" : "package-lock.json"
+  } yarn.lock dist elm-stuff bower_components node_modules output`;
+  console.log(rmCmd);
+  execSync(rmCmd, {
+    cwd: frameworkPath,
+    stdio: "inherit",
+  });
+}
+
+/**
+ * @param {string} frameworkPath
+ */
+function installAndBuild(frameworkPath) {
+  const installCmd = `npm ${useCi ? "ci" : "install"} && npm run build-prod`;
+  console.log(installCmd);
+  execSync(installCmd, {
+    cwd: frameworkPath,
+    stdio: "inherit",
+  });
+}
+
+/**
+ * @param {string} frameworkPath
+ */
+function copyPackageLock(frameworkPath) {
+  if (useDocker) {
+    const packageLockPath = path.join(frameworkPath, "package-lock.json");
+    fs.copyFileSync(packageLockPath, path.join("/src", packageLockPath));
+  }
+}
+
+function buildFrameworks() {
+  const frameworks = getFrameworks();
+  const skippableFrameworks = takeWhile(frameworks, shouldSkipFramework);
+  const buildableFrameworks = frameworks.slice(skippableFrameworks.length);
+
+  console.log("Building frameworks:", buildableFrameworks);
+
+  for (const framework of buildableFrameworks) {
+    console.log("Building framework:", framework);
+
+    const [keyed, name] = framework;
+    const frameworkPath = path.join("frameworks", keyed, name);
+
+    if (!fs.existsSync(`${frameworkPath}/package.json`)) {
+      console.log(
+        "WARN: skipping ",
+        framework,
+        " since there's no package.json"
+      );
+      continue;
+    }
+    // if (fs.existsSync(path)) {
+    //     console.log("deleting folder ",path);
+    //     execSync(`rm -r ${path}`);
+    // }
+    // rsync(keyed,name);
+
+    removeFiles(frameworkPath);
+    installAndBuild(frameworkPath);
+    copyPackageLock(frameworkPath);
+  }
+
+  console.log("All frameworks were built!");
+}
+
+buildFrameworks();


### PR DESCRIPTION
- Add JSDoc comments and types.
- Split the code into functions.
- Use more meaningful names for variables and functions.
- Simplify getting args.
- Replace var and let with const where possible.
- Replace string concatenation with string templates.
- Remove unused imports.