### PR TITLE
fix(webdriver-ts): eslint configuration

### DIFF
--- a/webdriver-ts/.eslintrc.json
+++ b/webdriver-ts/.eslintrc.json
@@ -10,9 +10,7 @@
     "plugin:@typescript-eslint/recommended"
   ],
   "parserOptions": {
-    "project": [
-      "./tsconfig.json"
-    ]
+    "project": true
   },
   "rules": {
     "prefer-const": "off",

--- a/webdriver-ts/package.json
+++ b/webdriver-ts/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "lint": "eslint . --ext .ts",
+    "lint": "eslint src/ --ext .ts",
     "tsbench": "cross-env LANG=\"en_US.UTF-8\" ts-node --files src/benchmarkRunner.ts",
     "bench": "cross-env LANG=\"en_US.UTF-8\" node dist/benchmarkRunner.js",
     "checkCSP": "cross-env LANG=\"en_US.UTF-8\" node dist/isCSPCompliant.js",

--- a/webdriver-ts/src/benchmarkRunner.ts
+++ b/webdriver-ts/src/benchmarkRunner.ts
@@ -311,7 +311,7 @@ console.log("benchmarkOptions", benchmarkOptions);
   let runBenchmarksArgs: string[] =  (args.benchmark && args.benchmark.length > 0) ? args.benchmark : [""];
   let runBenchmarks: Array<BenchmarkInfo> = benchmarkInfos.filter((b) =>
     // afterframe currently only targets CPU benchmarks
-    (config.BENCHMARK_RUNNER !== BENCHMARK_RUNNER.WEBDRIVER_AFTERFRAME || b.type == BenchmarkType.CPU) && 
+    (config.BENCHMARK_RUNNER !== BENCHMARK_RUNNER.WEBDRIVER_AFTERFRAME || b.type == BenchmarkType.CPU) && 
     runBenchmarksArgs.some((name) => b.id.toLowerCase().indexOf(name) > -1)
   );
   


### PR DESCRIPTION
Fixed 2 bugs:
1. Eslint in VSCode could not find `typescript.json` in `.eslintrc.json` `parserOptions.parser`, so could not lint typescirpt files.
2. When calling `npm run lint` script, eslint tried to check all files in the root directory (i.e. `webdriver-ts`), but could not check `jest.config.js` because the configuration file jest was not specified in the `include` property in `tsconfig.json`. Now running 'npm run lint' will only check files in the src directory.