### PR TITLE
refactor: configureStyles.js

### DIFF
--- a/configureStyles.js
+++ b/configureStyles.js
@@ -1,111 +1,55 @@
-var _ = require('lodash');
-var exec = require('child_process').execSync;
-var fs = require('fs-extra');
-var path = require('path');
-var yargs = require ('yargs');
+const fs = require("fs-extra");
+const yargs = require("yargs");
+const path = require("path");
 
-let args = yargs(process.argv)
-.usage("$0 [--bootstrap --minimal]")
-.help('help')
-.boolean('bootstrap')
-.boolean('minimal')
-.argv;
+const args = yargs(process.argv)
+  .usage("$0 [--bootstrap --minimal]")
+  .help("help")
+  .boolean("bootstrap")
+  .default("bootstrap", false)
+  .boolean("minimal")
+  .default("minimal", false).argv;
 
-if (args.bootstrap ^ args.minimal == false) {
-	console.log("ERROR: You must either choose bootstrap or minimal");
-} else {
-	if (args.bootstrap) {
-		fs.copySync("css/useOriginalBootstrap.css","css/currentStyle.css");
-		let bootstrap = fs.readFileSync("css/bootstrap/dist/css/bootstrap.min.css")
-		let mainCss = fs.readFileSync("css/main.css")
-		let str = `<dom-module id="shared-styles"><template><style>${bootstrap}\n${mainCss}</style></template></dom-module>`;
-		fs.writeFileSync("polymer-v2.0.0-non-keyed/src/shared-styles.html", str);
-	} else {
-		fs.copySync("css/useMinimalCss.css","css/currentStyle.css");
-		let minCss = fs.readFileSync("css/useMinimalCss.css")
-		let str = `<dom-module id="shared-styles"><template><style>${minCss}</style></template></dom-module>`;
-		fs.writeFileSync("polymer-v2.0.0-non-keyed/src/shared-styles.html", str);
-	}
+// Function to copy CSS and generate shared-styles.html
+async function copyAndGenerateSharedStyles(sourceCss, mainCss) {
+  await fs.copy(sourceCss, path.join("css", "currentStyle.css"));
+
+  // Read the main CSS file
+  const mainCssContent = await fs.readFile(mainCss, "utf8");
+
+  // Generate shared-styles.html content
+  const sharedStylesContent = `<dom-module id="shared-styles"><template><style>${mainCssContent}</style></template></dom-module>`;
+
+  // Write shared-styles.html
+  await fs.writeFile(
+    path.join("polymer-v2.0.0-non-keyed", "src", "shared-styles.html"),
+    sharedStylesContent
+  );
 }
 
-
-/*
-if (fs.existsSync("dist")) fs.removeSync("dist");
-fs.mkdirSync("dist");
-fs.mkdirSync("dist"+path.sep+"webdriver-ts");
-fs.copySync("webdriver-ts"+path.sep+"table.html", "dist"+path.sep+"webdriver-ts"+path.sep+"table.html");
-
-fs.copySync("index.html", "dist"+path.sep+"index.html");
-fs.copySync("css", "dist"+path.sep+"css");
-
-var excludes = ["node_modules","elm-stuff","project",".DS_Store"]
-var excludedDirectories = ['css', 'dist','node_modules','webdriver-ts'];
-
-// http://stackoverflow.com/questions/13786160/copy-folder-recursively-in-node-js
-function copyFileSync( source, target ) {
-
-    var targetFile = target;
-
-    //if target is a directory a new file with the same name will be created
-    if ( fs.existsSync( target ) ) {
-        if ( fs.lstatSync( target ).isDirectory() ) {
-            targetFile = path.join( target, path.basename( source ) );
-        }
+// Main function
+async function configureStyles() {
+  try {
+    if (args.bootstrap ^ args.minimal) {
+      console.log("ERROR: You must either choose bootstrap or minimal");
+      return;
     }
 
-    fs.writeFileSync(targetFile, fs.readFileSync(source));
-}
-
-function include(name) {
-		if (name.indexOf("binding.scala")>-1) {
-				if (name.indexOf("/target")>-1) {
-					return name.indexOf("/target/web")>-1;
-				}
-		}
-		if (excludes.every(ex => name.indexOf(ex)==-1)) {
-			// console.log("<- filter", name);
-			return true;
-		} else {
-			return false;
-		}
-}
-
-function copyFolderRecursiveSync( source, target ) {
-    var files = [];
-
-    //check if folder needs to be created or integrated
-    var targetFolder = path.join( target, path.basename( source ) );
-    if ( !fs.existsSync( targetFolder ) ) {
-        fs.mkdirSync( targetFolder );
+    // Read and copy the appropriate CSS file
+    if (args.bootstrap) {
+      await copyAndGenerateSharedStyles(
+        path.join("css", "useOriginalBootstrap.css"),
+        path.join("css", "bootstrap", "dist", "css", "bootstrap.min.css")
+      );
+    } else {
+      await copyAndGenerateSharedStyles(
+        path.join("css", "useMinimalCss.css"),
+        path.join("css", "useMinimalCss.css")
+      );
     }
-
-    //copy
-    if ( fs.lstatSync( source ).isDirectory() ) {
-        files = fs.readdirSync( source );
-        files.forEach( function ( file ) {
-			if (include(file)) {
-				var curSource = path.join( source, file );
-				if ( fs.lstatSync( curSource ).isDirectory() ) {
-					// console.log("copy dir "+curSource);
-					copyFolderRecursiveSync( curSource, targetFolder );
-				} else if ( fs.lstatSync( curSource ).isSymbolicLink() ) {
-					console.log("**** LINK");
-				} else {
-					// console.log("copy file "+curSource);
-					copyFileSync( curSource, targetFolder );
-				}
-			}
-        } );
-    }
+  } catch (error) {
+    console.error("An error occurred:", error.message);
+  }
 }
 
-_.each(fs.readdirSync('.'), function(name) {
-	if(fs.statSync(name).isDirectory() && name[0] !== '.' && excludedDirectories.indexOf(name)==-1) {
-		console.log("dist"+path.sep+name);
-		fs.mkdirSync("dist"+path.sep+name);
-		copyFolderRecursiveSync(name, "dist");
-
-	}
-});
-
-*/
+configureStyles();


### PR DESCRIPTION
- Add default values for `bootstrap` and `minimal`.
- Replace `var` and `let` with `const`.
- Replace synchronous calls to the file system with asynchronous ones.
- Split the code.
- Remove unused imports.
- Remove the commented code because its functionality was duplicated from the `copy.js` files.