### PR TITLE
Remove unused vars in webdriver-ts and remove .prettierrc

### DIFF
--- a/webdriver-ts/src/.prettierrc
+++ b/webdriver-ts/src/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "tabWidth": 2,
-  "useTabs": false,
-  "printWidth": 140
-}

--- a/webdriver-ts/src/benchmarkRunner.ts
+++ b/webdriver-ts/src/benchmarkRunner.ts
@@ -345,7 +345,7 @@ console.log("benchmarkOptions", benchmarkOptions);
 }
 
 main()
-  .then((_) => {
+  .then(() => {
     console.log("successful run");
     process.exit(0);
   })

--- a/webdriver-ts/src/benchmarksCommon.ts
+++ b/webdriver-ts/src/benchmarksCommon.ts
@@ -1,4 +1,4 @@
-import { BenchmarkOptions, FrameworkData, config } from "./common.js";
+import { FrameworkData, config } from "./common.js";
 
 export enum BenchmarkType {
   CPU,

--- a/webdriver-ts/src/benchmarksCommon.ts
+++ b/webdriver-ts/src/benchmarksCommon.ts
@@ -189,19 +189,19 @@ export const memBenchmarkInfosArray: Array<MemBenchmarkInfo> = [
 {
   id: BENCHMARK_21,
   label: "ready memory",
-  description: (throttleCPU: number|undefined) => "Memory usage after page load.",
+  description: () => "Memory usage after page load.",
   type: BenchmarkType.MEM,
 },
 {
   id: BENCHMARK_22,
   label: "run memory",
-  description: (throttleCPU: number|undefined) => "Memory usage after adding 1,000 rows.",
+  description: () => "Memory usage after adding 1,000 rows.",
   type: BenchmarkType.MEM,
 },
 {
   id: BENCHMARK_23,
   label: "update every 10th row for 1k rows (5 cycles)",
-  description: (throttleCPU: number|undefined) => "Memory usage after clicking update every 10th row 5 times",
+  description: () => "Memory usage after clicking update every 10th row 5 times",
   type: BenchmarkType.MEM,
 },
 // {
@@ -213,13 +213,13 @@ export const memBenchmarkInfosArray: Array<MemBenchmarkInfo> = [
 {
   id: BENCHMARK_25,
   label: "creating/clearing 1k rows (5 cycles)",
-  description: (throttleCPU: number|undefined) => "Memory usage after creating and clearing 1000 rows 5 times",
+  description: () => "Memory usage after creating and clearing 1000 rows 5 times",
   type: BenchmarkType.MEM,
 },
 {
   id: BENCHMARK_26,
   label: "run memory 10k",
-  description: (throttleCPU: number|undefined) => "Memory usage after adding 10,000 rows.",
+  description: () => "Memory usage after adding 10,000 rows.",
   type: BenchmarkType.MEM,
 }];
 
@@ -228,7 +228,7 @@ export const startupBenchmarkInfosArray: Array<StartupMainBenchmarkInfo> = [
   id: BENCHMARK_30,
   type: BenchmarkType.STARTUP_MAIN,
   label: '',
-  description: (throttleCPU: number|undefined) => '',
+  description: () => '',
 },
 ];
 

--- a/webdriver-ts/src/benchmarksLighthouse.ts
+++ b/webdriver-ts/src/benchmarksLighthouse.ts
@@ -12,7 +12,7 @@ let toKb = (x:number) => x/1024;
 export const benchStartupConsistentlyInteractive: StartupBenchmarkInfo = {
   id: "31_startup-ci",
   label: "consistently interactive",
-  description: (throttleCPU: number|undefined) => "a pessimistic TTI - when the CPU and network are both definitely very idle. (no more CPU tasks over 50ms)",
+  description: () => "a pessimistic TTI - when the CPU and network are both definitely very idle. (no more CPU tasks over 50ms)",
   property: "interactive",
   fn: id,
   type: BenchmarkType.STARTUP,
@@ -21,7 +21,7 @@ export const benchStartupConsistentlyInteractive: StartupBenchmarkInfo = {
 export const benchStartupBootup: StartupBenchmarkInfo = {
   id: "32_startup-bt",
   label: "script bootup time",
-  description: (throttleCPU: number|undefined) => "the total ms required to parse/compile/evaluate all the page's scripts",
+  description: () => "the total ms required to parse/compile/evaluate all the page's scripts",
   property: "bootup-time",
   fn: id,
   type: BenchmarkType.STARTUP,
@@ -30,7 +30,7 @@ export const benchStartupBootup: StartupBenchmarkInfo = {
 export const benchStartupMainThreadWorkCost: StartupBenchmarkInfo = {
   id: "33_startup-mainthreadcost",
   label: "main thread work cost",
-  description: (throttleCPU: number|undefined) => "total amount of time spent doing work on the main thread. includes style/layout/etc.",
+  description: () => "total amount of time spent doing work on the main thread. includes style/layout/etc.",
   property: "mainthread-work-breakdown",
   fn: id,
   type: BenchmarkType.STARTUP,
@@ -39,7 +39,7 @@ export const benchStartupMainThreadWorkCost: StartupBenchmarkInfo = {
 export const benchStartupTotalBytes: StartupBenchmarkInfo = {
   id: "34_startup-totalbytes",
   label: "total kilobyte weight",
-  description: (throttleCPU: number|undefined) => "network transfer cost (post-compression) of all the resources loaded into the page.",
+  description: () => "network transfer cost (post-compression) of all the resources loaded into the page.",
   property: "total-byte-weight",
   fn: toKb,
   type: BenchmarkType.STARTUP,

--- a/webdriver-ts/src/benchmarksPlaywright.ts
+++ b/webdriver-ts/src/benchmarksPlaywright.ts
@@ -212,7 +212,7 @@ export const benchReadyMemory = new (class extends MemBenchmarkPlaywright {
   async init(browser: Browser, page: Page) {
     await checkElementExists(page, "#run");
   }
-  async run(browser: Browser, page: Page) {return await Promise.resolve(null);}
+  async run() {return await Promise.resolve(null);}
 })();
 
 export const benchRunMemory = new (class extends MemBenchmarkPlaywright {

--- a/webdriver-ts/src/benchmarksPuppeteer.ts
+++ b/webdriver-ts/src/benchmarksPuppeteer.ts
@@ -211,7 +211,7 @@ export const benchReadyMemory = new (class extends MemBenchmarkPuppeteer {
   async init(page: Page) {
     await checkElementExists(page, "pierce/#run");
   }
-  async run(page: Page) {return await Promise.resolve(null);}
+  async run() {return await Promise.resolve(null);}
 })();
 
 export const benchRunMemory = new (class extends MemBenchmarkPuppeteer {

--- a/webdriver-ts/src/benchmarksWebdriverAfterframe.ts
+++ b/webdriver-ts/src/benchmarksWebdriverAfterframe.ts
@@ -1,4 +1,4 @@
-import { By, WebDriver, WebElement } from "selenium-webdriver";
+import { WebDriver, WebElement } from "selenium-webdriver";
 import * as benchmarksCommon from "./benchmarksCommon.js";
 import { BenchmarkType } from "./benchmarksCommon.js";
 import { config, FrameworkData } from "./common.js";
@@ -7,7 +7,7 @@ import {
   clickElementByXPath,
   findById,
   findByXPath,
-  getTextByXPath, mainRoot, retry, testClassContains, testElementLocatedById, testElementLocatedByXpath,
+  getTextByXPath, testClassContains, testElementLocatedById, testElementLocatedByXpath,
   testElementNotLocatedByXPath, testTextContains
 } from "./webdriverAccess.js";
 

--- a/webdriver-ts/src/common.ts
+++ b/webdriver-ts/src/common.ts
@@ -94,16 +94,7 @@ export interface FrameworkData {
   frameworkHomeURL: string;
 }
 
-interface Options {
-  uri: string;
-  useShadowRoot?: boolean;
-}
-
 type KeyedType = "keyed" | "non-keyed";
-
-function computeHash(keyedType: KeyedType, directory: string) {
-  return keyedType + "/" + directory;
-}
 
 export interface FrameworkInformation {
   type: KeyedType;
@@ -123,7 +114,7 @@ export interface IMatchPredicate {
   (frameworkDirectory: string): boolean;
 }
 
-const matchAll: IMatchPredicate = (frameworkDirectory: string) => true;
+const matchAll: IMatchPredicate = () => true;
 
 export async function initializeFrameworks(benchmarkOptions: BenchmarkOptions, matchPredicate: IMatchPredicate = matchAll): Promise<FrameworkData[]> {
   let lsResult ;

--- a/webdriver-ts/src/createIndex.ts
+++ b/webdriver-ts/src/createIndex.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import { BenchmarkOptions, JSONResult, config, initializeFrameworks } from "./common.js";
+import { BenchmarkOptions, config, initializeFrameworks } from "./common.js";
 import * as dot from "dot";
 
 let benchmarkOptions: BenchmarkOptions = {

--- a/webdriver-ts/src/createResultJS.ts
+++ b/webdriver-ts/src/createResultJS.ts
@@ -37,14 +37,12 @@ let resultsDirectory = args.browser ? "./results_client_"+args.browser : "./resu
 async function main() {
   let frameworks = await initializeFrameworks(benchmarkOptions);
 
-  let results: Map<string, Map<string, JSONResult>> = new Map();
-
   let resultJS = "import {RawResult} from './Common';\n\nexport const results: RawResult[]=[";
 
   let allBenchmarks: Array<BenchmarkInfo> = [];
   let jsonResult: { framework: string; benchmark: string; values: {[key:string]: number[]} }[] = [];
   
-  benchmarkInfos.forEach((benchmarkInfo, bIdx) => {
+  benchmarkInfos.forEach((benchmarkInfo) => {
     if (args.browser) {
       if (benchmarkInfo.type == BenchmarkType.CPU) {
         allBenchmarks.push(benchmarkInfo);
@@ -58,7 +56,7 @@ async function main() {
     }
   });
   
-  frameworks.forEach((framework, fIdx) => {
+  frameworks.forEach((framework) => {
     allBenchmarks.forEach((benchmarkInfo) => {
       if (!args.browser || framework.keyed) {
         let name = `${fileName(framework, benchmarkInfo)}`;

--- a/webdriver-ts/src/createResultJS.ts
+++ b/webdriver-ts/src/createResultJS.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import yargs from "yargs";
 import { BenchmarkInfo, benchmarkInfos, BenchmarkType, fileName, slowDownFactor } from "./benchmarksCommon.js";
 import { subbenchmarks } from "./benchmarksLighthouse.js";
-import { BenchmarkOptions, config, initializeFrameworks, JSONResult, JSONResultData } from "./common.js";
+import { BenchmarkOptions, config, initializeFrameworks, JSONResult } from "./common.js";
 
 let args: any = yargs(process.argv)
   .usage(

--- a/webdriver-ts/src/forkedBenchmarkRunnerPlaywright.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunnerPlaywright.ts
@@ -46,6 +46,7 @@ function convertError(error: any): string {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function forceGC(page: Page, client: CDPSession) {
   for (let i=0;i<7;i++) {
       // await client.send('HeapProfiler.collectGarbage');

--- a/webdriver-ts/src/forkedBenchmarkRunnerPuppeteer.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunnerPuppeteer.ts
@@ -43,6 +43,7 @@ function convertError(error: any): string {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function forceGC(page: Page, client: CDPSession) {
   for (let i=0;i<7;i++) {
       // await client.send('HeapProfiler.collectGarbage');

--- a/webdriver-ts/src/forkedBenchmarkRunnerWebdriverAfterframe.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunnerWebdriverAfterframe.ts
@@ -1,6 +1,6 @@
-import { WebDriver, logging, Builder } from "selenium-webdriver";
+import { WebDriver, Builder } from "selenium-webdriver";
 import { CPUBenchmarkWebdriver, benchmarks } from "./benchmarksWebdriverAfterframe.js";
-import { setUseShadowRoot, buildDriver, setUseRowShadowRoot, setShadowRootName, setButtonsInShadowRoot } from "./webdriverAccess.js";
+import { setUseShadowRoot, setUseRowShadowRoot, setShadowRootName, setButtonsInShadowRoot } from "./webdriverAccess.js";
 
 import { TConfig, config as defaultConfig, FrameworkData, ErrorAndWarning, BenchmarkOptions } from "./common.js";
 import { BenchmarkType, CPUBenchmarkResult } from "./benchmarksCommon.js";

--- a/webdriver-ts/src/forkedBenchmarkRunnerWebdriverCDP.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunnerWebdriverCDP.ts
@@ -109,7 +109,7 @@ async function runCPUBenchmark(
         },
       })
 
-      let p = new Promise((resolve,reject) => {
+      let p = new Promise((resolve) => {
         cdpConnection._wsConnection.on('message', async (msg: any) => {
           let message: any = JSON.parse(msg);
           // console.log("####", typeof message, message.method, Object.keys(message), message);

--- a/webdriver-ts/src/interval.test.ts
+++ b/webdriver-ts/src/interval.test.ts
@@ -1,4 +1,4 @@
-import { Interval, isContained, newContainedInterval } from "./interval.js";
+import { isContained, newContainedInterval } from "./interval.js";
 import {describe, expect, test} from '@jest/globals';
 
 describe('isContained', () => {

--- a/webdriver-ts/src/isCSPCompliant.ts
+++ b/webdriver-ts/src/isCSPCompliant.ts
@@ -45,8 +45,6 @@ async function runBench(frameworkNames: string[]) {
   runFrameworks = await initializeFrameworks(benchmarkOptions, matchesDirectoryArg);
   console.log("Frameworks that will be checked", runFrameworks.map((f) => f.fullNameWithKeyedAndVersion).join(" "));
 
-  let frameworkMap = new Map<string, FrameworkData>();
-
   let allCorrect = true;
 
   let browser = await startBrowser(benchmarkOptions);
@@ -61,7 +59,6 @@ async function runBench(frameworkNames: string[]) {
   console.log("*** headless", benchmarkOptions.headless)
 
   for (let i = 0; i < runFrameworks.length; i++) {
-    let cspError = false;
     let browser = await startBrowser(benchmarkOptions);
     let page = await browser.newPage();
     try {

--- a/webdriver-ts/src/isKeyed.ts
+++ b/webdriver-ts/src/isKeyed.ts
@@ -247,8 +247,6 @@ async function runBench(frameworkNames: string[]) {
   runFrameworks = await initializeFrameworks(benchmarkOptions, matchesDirectoryArg);
   console.log("Frameworks that will be checked", runFrameworks.map((f) => f.fullNameWithKeyedAndVersion).join(" "));
 
-  let frameworkMap = new Map<string, FrameworkData>();
-
   let allCorrect = true;
 
   console.log("*** headless", benchmarkOptions.headless)

--- a/webdriver-ts/src/parseTrace.ts
+++ b/webdriver-ts/src/parseTrace.ts
@@ -40,9 +40,9 @@ async function single() {
 
 }
 
-async function readAll() {
-    let jsonResult: { framework: string; benchmark: string; values: number[] }[] = [];
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function readAll() {
     let cpuCPUBenchmarks = Object.values(cpuBenchmarkInfos);
     
     let frameworks = await initializeFrameworks(benchmarkOptions);

--- a/webdriver-ts/src/parseTrace.ts
+++ b/webdriver-ts/src/parseTrace.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
-import { BenchmarkInfo, BenchmarkType, cpuBenchmarkInfos, CPUBenchmarkResult, DurationMeasurementMode } from './benchmarksCommon.js';
-import { CPUBenchmarkPuppeteer, fileNameTrace } from './benchmarksPuppeteer.js';
+import { BenchmarkType, cpuBenchmarkInfos, CPUBenchmarkResult, DurationMeasurementMode } from './benchmarksCommon.js';
+import { fileNameTrace } from './benchmarksPuppeteer.js';
 import { BenchmarkOptions, config, initializeFrameworks } from './common.js';
 import { computeResultsCPU, computeResultsJS } from './timeline.js';
 import { writeResults } from "./writeResults.js";

--- a/webdriver-ts/src/puppeteerAccess.ts
+++ b/webdriver-ts/src/puppeteerAccess.ts
@@ -1,6 +1,6 @@
 import * as puppeteer from "puppeteer-core";
 import { Page } from "puppeteer-core";
-import { BenchmarkOptions, config } from "./common.js";
+import { BenchmarkOptions } from "./common.js";
 
 
 

--- a/webdriver-ts/src/timeline.ts
+++ b/webdriver-ts/src/timeline.ts
@@ -77,8 +77,6 @@ interface Timingresult {
 
   export function extractRelevantJSEvents(config: TConfig, entries: any[]) {
     let filteredEvents: any[] = [];
-    let click_start = 0;
-    let click_end = 0;
   
     entries.forEach(x => {
         let e = x;
@@ -86,8 +84,6 @@ interface Timingresult {
         if (e.name==='EventDispatch') {
           if (e.args.data.type==="click") {
             if (config.LOG_DETAILS) console.log("CLICK ",+e.ts);
-              click_start = +e.ts;
-              click_end = +e.ts+e.dur;
               filteredEvents.push({type:'click', ts: +e.ts, dur: +e.dur, end: +e.ts+e.dur});
           }
         }
@@ -286,7 +282,7 @@ interface Timingresult {
       timingResult: Timingresult
     }
     function isContained(testIv: Interval, otherIv: Interval) {
-      return intervals.some(iv => testIv.start>=otherIv.start && testIv.end<=otherIv.end);
+      return intervals.some(() => testIv.start>=otherIv.start && testIv.end<=otherIv.end);
     }
     function newContainedInterval(outer: Timingresult, intervals: Array<Interval>) {
       let outerIv = {start: outer.ts, end: outer.end, timingResult: outer};

--- a/webdriver-ts/src/webdriverAccess.ts
+++ b/webdriver-ts/src/webdriverAccess.ts
@@ -2,11 +2,6 @@ import { Capabilities, Condition, WebDriver, WebElement } from "selenium-webdriv
 import * as chrome from "selenium-webdriver/chrome.js";
 import { BenchmarkOptions, config } from "./common.js";
 
-interface PathPart {
-  tagName: string;
-  index: number;
-}
-
 let useShadowRoot = false;
 let useRowShadowRoot = false;
 let shadowRootName = "";

--- a/webdriver-ts/src/webdriverAccess.ts
+++ b/webdriver-ts/src/webdriverAccess.ts
@@ -1,4 +1,4 @@
-import { By, Capabilities, Condition, WebDriver, WebElement } from "selenium-webdriver";
+import { Capabilities, Condition, WebDriver, WebElement } from "selenium-webdriver";
 import * as chrome from "selenium-webdriver/chrome.js";
 import { BenchmarkOptions, config } from "./common.js";
 

--- a/webdriver-ts/src/webdriverCDPAccess.ts
+++ b/webdriver-ts/src/webdriverCDPAccess.ts
@@ -89,11 +89,6 @@ export async function findByXPath(driver: WebDriver, path: string, isInButtonAre
   return n;
 }
 
-function elemNull(v: any) {
-  console.log("*** ELEMENT WAS NULL");
-  return false;
-}
-
 function waitForCondition(driver: WebDriver) {
   return async function (text: string, fn: (driver: WebDriver) => Promise<boolean>, timeout: number): Promise<boolean> {
     return await driver.wait(new Condition<Promise<boolean>>(text, fn), timeout);
@@ -189,7 +184,7 @@ export function testElementLocatedById(driver: WebDriver, id: string, timeout = 
     async function (driver) {
       try {
         let elem = await mainRoot(driver, isInButtonArea);
-        elem = await elem.findElement(By.id(id));
+        await elem.findElement(By.id(id));
         return true;
       } catch (err) {
         // console.log("ignoring error in testElementLocatedById for id = "+id,err.toString().split("\n")[0]);

--- a/webdriver-ts/src/writeResults.ts
+++ b/webdriver-ts/src/writeResults.ts
@@ -1,10 +1,7 @@
 import * as fs from "fs";
-import { result } from "lodash";
 import { BenchmarkInfo, BenchmarkType, CPUBenchmarkResult, fileName } from "./benchmarksCommon.js";
-import { BenchmarkLighthouse, StartupBenchmarkResult, subbenchmarks } from "./benchmarksLighthouse.js";
-import { TBenchmarkPuppeteer } from "./benchmarksPuppeteer.js";
-import { CPUBenchmarkWebdriver } from "./benchmarksWebdriver.js";
-import { config as defaultConfig, FrameworkData, JSONResult, JSONResultData } from "./common.js";
+import { StartupBenchmarkResult, subbenchmarks } from "./benchmarksLighthouse.js";
+import { FrameworkData, JSONResult, JSONResultData } from "./common.js";
 import pkg from 'jstat';
 const { jStat } = pkg;
 

--- a/webdriver-ts/src/writeResults.ts
+++ b/webdriver-ts/src/writeResults.ts
@@ -19,8 +19,6 @@ export type ResultCPU = {
   type: BenchmarkType.CPU; 
 }
 
-const DEFAULT = "default";
-
 export type ResultMem = {
   framework: FrameworkData;
   benchmark: BenchmarkInfo;


### PR DESCRIPTION
- Remove most unused imports, variables and functions.
- Remove .prettierrc.