### PR TITLE
Update s2 to use published version from npm

### DIFF
--- a/frameworks/keyed/s2/package-lock.json
+++ b/frameworks/keyed/s2/package-lock.json
@@ -7,7 +7,15 @@
     "": {
       "name": "js-framework-benchmark-keyed-s2",
       "version": "1.0.0",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "dependencies": {
+        "s2-engine": "^1.0.17"
+      }
+    },
+    "node_modules/s2-engine": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/s2-engine/-/s2-engine-1.0.17.tgz",
+      "integrity": "sha512-m4Xmni1klqzEPMWQPyhwpYmjqxvJH4AR5sp3KGQ4uN136k08KkBjHys+8EtSbDlTOGMBlrgy1j254BWxe9KCFA=="
     }
   }
 }

--- a/frameworks/keyed/s2/package.json
+++ b/frameworks/keyed/s2/package.json
@@ -3,9 +3,11 @@
   "version": "1.0.0",
   "description": "s2 demo",
   "js-framework-benchmark": {
-    "frameworkVersion": "1.0.0",
-    "frameworkHomeURL": "",
-    "issues": [800]
+    "frameworkVersionFromPackage": "s2-engine",
+    "frameworkHomeURL": "https://gr0uch.github.io/s2",
+    "issues": [
+      800
+    ]
   },
   "scripts": {
     "build-dev": "echo 0",
@@ -20,5 +22,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "dependencies": {
+    "s2-engine": "^1.0.17"
   }
 }

--- a/frameworks/keyed/s2/src/bench.js
+++ b/frameworks/keyed/s2/src/bench.js
@@ -75,6 +75,15 @@ var id = 0
 function create (label, number) {
   return function () {
     bench(label, function () {
+      // Technical note: the keyed behavior for array replacement can be forced
+      // by resetting it first. Removing this would default to non-keyed behavior.
+      //
+      // This *could* be the default behavior in the library itself, but would be
+      // a de-optimization for the common use case of replacing an array with another.
+      // Even if the default behavior was keyed, non-keyed could still be forced by
+      // mutating objects in the array.
+      proxy.rows = null
+
       proxy.rows = buildData(number)
     })
   }

--- a/frameworks/keyed/s2/src/bench.js
+++ b/frameworks/keyed/s2/src/bench.js
@@ -1,4 +1,4 @@
-import s2 from './main.min.js'
+import s2 from '../node_modules/s2-engine/dist/main.mjs';
 //s2.debug=true
 cleanupTemplates();
 
@@ -49,7 +49,7 @@ function select () {
   this.cls = 'danger';
 }
 
-const [node, proxy] = s2(state, document.querySelector('#main'))
+const [proxy, node] = s2(state, document.querySelector('#main'))
 document.body.appendChild(node)
 window.p = proxy
 


### PR DESCRIPTION
Since I got pinged [here](https://github.com/krausest/js-framework-benchmark/issues/1421), I might as well update it.