### PR TITLE
fix wasm-bindgen version

### DIFF
--- a/frameworks/keyed/wasm-bindgen/package.json
+++ b/frameworks/keyed/wasm-bindgen/package.json
@@ -4,7 +4,7 @@
   "description": "Benchmark for wasm-bindgen",
   "license": "ISC",
   "js-framework-benchmark": {
-    "frameworkVersion": "0.2.47",
+    "frameworkVersion": "0.2.84",
     "frameworkHomeURL": "https://rustwasm.github.io/docs/wasm-bindgen/",
     "customURL": "/bundled-dist",
     "issues": [772, 1139]


### PR DESCRIPTION
the cargo.toml says 0.2.84, but the package.json only said 0.2.47