### PR TITLE
feat(preact-hook, preact-signals): use memo to render row component

### DIFF
--- a/frameworks/keyed/preact-hooks/src/main.jsx
+++ b/frameworks/keyed/preact-hooks/src/main.jsx
@@ -141,7 +141,7 @@ const App = () => {
       <div class="jumbotron">
         <div class="row">
           <div class="col-md-6">
-            <h1>Preact Signals Keyed</h1>
+            <h1>Preact Hooks Keyed</h1>
           </div>
           <div class="col-md-6">
             <div class="row">

--- a/frameworks/keyed/preact-hooks/src/main.jsx
+++ b/frameworks/keyed/preact-hooks/src/main.jsx
@@ -1,4 +1,5 @@
 import { useState } from "preact/hooks";
+import { memo } from "preact/compat";
 import { render, h } from "preact";
 
 let idCounter = 1;
@@ -156,31 +157,38 @@ const App = () => {
       </div>
       <table class="table table-hover table-striped test-data">
         <tbody>
-          {data.map((row) => {
-            let rowId = row.id;
-            return (
-              <tr key={rowId} class={selected === rowId ? "danger" : ""}>
-                <td class="col-md-1">{rowId}</td>
-                <td class="col-md-4">
-                  <a onClick={() => setSelected(rowId)}>{row.label}</a>
-                </td>
-                <td class="col-md-1">
-                  <a onClick={() => remove(rowId)}>
-                    <span
-                      class="glyphicon glyphicon-remove"
-                      aria-hidden="true"
-                    />
-                  </a>
-                </td>
-                <td class="col-md-6" />
-              </tr>
-            );
-          })}
+          {data.map((item) => (
+            <Row
+              key={item.id}
+              item={item}
+              selected={selected === item.id}
+              setSelected={setSelected}
+              remove={remove}
+            />
+          ))}
         </tbody>
       </table>
       <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true" />
     </div>
   );
 };
+
+const Row = memo(
+  ({ item, selected, remove, setSelected }) => (
+    <tr className={selected ? "danger" : ""}>
+      <td className="col-md-1">{item.id}</td>
+      <td className="col-md-4">
+        <a onClick={() => setSelected(item.id)}>{item.label}</a>
+      </td>
+      <td className="col-md-1">
+        <a onClick={() => remove(item.id)}>
+          <span className="glyphicon glyphicon-remove" aria-hidden="true" />
+        </a>
+      </td>
+      <td className="col-md-6" />
+    </tr>
+  ),
+  (prevProps, nextProps) => prevProps.selected === nextProps.selected && prevProps.item === nextProps.item
+);
 
 render(<App />, document.getElementById("main"));

--- a/frameworks/keyed/preact-signals/index.html
+++ b/frameworks/keyed/preact-signals/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
-    <title>Solid-keyed</title>
+    <title>preact-signals-keyed</title>
     <link href="/css/currentStyle.css" rel="stylesheet"/>
 </head>
 <body>

--- a/frameworks/keyed/preact-signals/src/main.jsx
+++ b/frameworks/keyed/preact-signals/src/main.jsx
@@ -1,4 +1,5 @@
 import { signal, batch } from "@preact/signals";
+import { memo } from "preact/compat";
 import { render, h } from "preact";
 
 let idCounter = 1;
@@ -146,19 +147,14 @@ const App = () => {
       </div>
       <table class="table table-hover table-striped test-data">
         <tbody>
-          {data.value.map((row) => (
-            <tr key={row.id} class={selected.value === row.id ? "danger" : ""}>
-              <td class="col-md-1" textContent={row.id} />
-              <td class="col-md-4">
-                <a onClick={() => select(row.id)} textContent={row.label} />
-              </td>
-              <td class="col-md-1">
-                <a onClick={() => remove(row.id)}>
-                  <span class="glyphicon glyphicon-remove" aria-hidden="true" />
-                </a>
-              </td>
-              <td class="col-md-6" />
-            </tr>
+          {data.value.map((item) => (
+            <Row
+              key={item.id}
+              item={item}
+              selected={selected.value === item.id}
+              setSelected={select}
+              remove={remove}
+            />
           ))}
         </tbody>
       </table>
@@ -166,5 +162,23 @@ const App = () => {
     </div>
   );
 };
+
+const Row = memo(
+  ({ item, selected, remove, setSelected }) => (
+    <tr className={selected ? "danger" : ""}>
+      <td className="col-md-1">{item.id}</td>
+      <td className="col-md-4">
+        <a onClick={() => setSelected(item.id)}>{item.label}</a>
+      </td>
+      <td className="col-md-1">
+        <a onClick={() => remove(item.id)}>
+          <span className="glyphicon glyphicon-remove" aria-hidden="true" />
+        </a>
+      </td>
+      <td className="col-md-6" />
+    </tr>
+  ),
+  (prevProps, nextProps) => prevProps.selected === nextProps.selected && prevProps.item === nextProps.item
+);
 
 render(<App />, document.getElementById("main"));


### PR DESCRIPTION
- related to https://github.com/krausest/js-framework-benchmark/pull/1425

I noticed that preact hooks/signals is recently introduced in https://github.com/krausest/js-framework-benchmark/pull/1425 and it seems it has a huge gap both from preact-class and react-hooks for "select 1k" bench.
If I'm not mistaken, the lack of memo for row rendering has a significant effect for "select 1k" bench since "memo"-ed version can skip most of reconcilation work for the rows with the same "selected" state, which is essentially the case for `998 = 1000 - 2` rows.
(preact-classes doesn't have "memo", but I think `shouldComponentUpdate` achieves mostly the same thing as `memo`).

(EDIT: now I put the generated table below) ~As I recently discovered this repo, I haven't managed to generate complete html result table for the comparison, but I observed some effect on timing when checking devtools directly.~

<details><summary>reveal devtools screenshot</summary>

- before

![스크린샷 2023-10-28 11-42-59](https://github.com/krausest/js-framework-benchmark/assets/4232207/9b5610c6-8519-4e2a-b0f9-78600ffef0f9)

- after

![스크린샷 2023-10-28 11-47-31](https://github.com/krausest/js-framework-benchmark/assets/4232207/a1c6ab31-0d68-4d87-b351-b6f7aabb4968)

</details>

~Such primitive measurement might not be reliable and maybe I'm missing something, but I was wondering what others think about the effect of "memo" in general.~

@birkskyum Hi. I'm curious whether you've experimented with "memo"-ed version while you were working on https://github.com/krausest/js-framework-benchmark/pull/1425. I'd appreciate any feedback. Thanks!

---

~Sorry about the lack of bench table screenshot. I'll follow README.md and will provide a new comparison preact-classes and preact-hooks later.~

On my PC, I got a following result. So, it looks like the use of `memo` might have negative impact on "swap rows", which was not observed in https://github.com/krausest/js-framework-benchmark/pull/1425.

(EDIT: added also react-hooks)

![image](https://github.com/krausest/js-framework-benchmark/assets/4232207/4e6e4277-e02e-4eda-a23b-e3b3f01b1c51)
