### PR TITLE
chore: replace script `build-dev` with `dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ TL;DR:
 8. Manually testing your app - do this before you run the benchmarks
    1. Open your page and click on the buttons, make sure your app adds 1000 rows, then removes them, or swaps them, or adds/removes 10,000 rows. 
    2. To do this, you'll probably need to watch your local files and compile them into some sort of a bundle, like `frameworks\keyed\fast\dist\bundle.js` which will be loaded through a script tag in your HTML file
-   3. For example, in Fast folder we have webpack watching our files: ` "build-dev": "rimraf dist && webpack --config webpack.config.js --watch --mode=development",` 
+   3. For example, in Fast folder we have webpack watching our files: ` "dev": "rimraf dist && webpack --config webpack.config.js --watch --mode=development",` 
    4. That means we have two terminal tabs running
       1. One for the server from the root folder `npm start`
       2. And another in our local folder where webpack is watching the files
@@ -515,7 +515,7 @@ Contributions are very welcome. Please use the following rules:
 
 - Name your directory frameworks/[keyed|non-keyed]/[FrameworkName]
 - The package.json in your directory must contain some important information see section 4.2 above.
-- Each contribution must be buildable by `npm install` and `npm run build-prod` command in the directory. What build-prod does is up to you. Often there's an `npm run build-dev` that creates a development build
+- Each contribution must be buildable by `npm install` and `npm run build-prod` command in the directory. What build-prod does is up to you. Often there's an `npm run dev` that creates a development build
 - Every implementation must use bootstrap provided in the root css directory.
 - All npm dependencies should be installed locally (i.e. listed in your package.json). Http-server or other local web servers should not be local dependencies. It is installed from the root directory to allow access to bootstrap.
 - Please use _fixed version_ numbers, no ranges, in package.json. Otherwise the build will break sooner or later - believe me. Updating works IMO best with npm-check-updates, which keeps the version format.

--- a/broken-frameworks/keyed/glimmer/package.json
+++ b/broken-frameworks/keyed/glimmer/package.json
@@ -19,7 +19,7 @@
     "start": "ember server",
     "test": "ember test",
     "lint:ts": "tslint -c tslint.json 'src/**/*.ts' -t codeFrame",
-    "build-dev": "ember build",
+    "dev": "ember build",
     "build-prod": "ember build --environment=production"
   },
   "devDependencies": {

--- a/broken-frameworks/keyed/imba/package.json
+++ b/broken-frameworks/keyed/imba/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://imba.io/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode=production"
   },
   "keywords": [

--- a/broken-frameworks/keyed/reflex/package.json
+++ b/broken-frameworks/keyed/reflex/package.json
@@ -7,7 +7,7 @@
   },
   "source": "src/main.html",
   "scripts": {
-    "build-dev": "webpack -w -d",
+    "dev": "webpack -w -d",
     "build-prod": "webpack"
   },
   "author": "Alexis Bouhet",

--- a/broken-frameworks/keyed/san/package.json
+++ b/broken-frameworks/keyed/san/package.json
@@ -8,7 +8,7 @@
     "issues": [800, 1139]
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/broken-frameworks/non-keyed/imba/package.json
+++ b/broken-frameworks/non-keyed/imba/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://imba.io/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode=production"
   },
   "keywords": [

--- a/frameworks/keyed/alpine/package.json
+++ b/frameworks/keyed/alpine/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "license": "Apache-2.0",

--- a/frameworks/keyed/anansi/package.json
+++ b/frameworks/keyed/anansi/package.json
@@ -9,7 +9,7 @@
     "issues": []
   },
   "scripts": {
-    "build-dev": "exit 0",
+    "dev": "exit 0",
     "build-prod": "exit 0"
   },
   "license": "ISC",

--- a/frameworks/keyed/angular-cf-nozone/package.json
+++ b/frameworks/keyed/angular-cf-nozone/package.json
@@ -13,7 +13,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "build-prod": "ng build --configuration production",
-    "build-dev": "ng serve"
+    "dev": "ng serve"
   },
   "private": true,
   "dependencies": {

--- a/frameworks/keyed/angular-cf-signals/package.json
+++ b/frameworks/keyed/angular-cf-signals/package.json
@@ -13,7 +13,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "build-prod": "ng build --configuration production",
-    "build-dev": "ng serve"
+    "dev": "ng serve"
   },
   "private": true,
   "dependencies": {

--- a/frameworks/keyed/angular-cf/package.json
+++ b/frameworks/keyed/angular-cf/package.json
@@ -13,7 +13,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "build-prod": "ng build --configuration production",
-    "build-dev": "ng serve"
+    "dev": "ng serve"
   },
   "private": true,
   "dependencies": {

--- a/frameworks/keyed/angular-ngfor/package.json
+++ b/frameworks/keyed/angular-ngfor/package.json
@@ -13,7 +13,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "build-prod": "ng build --configuration production",
-    "build-dev": "ng serve"
+    "dev": "ng serve"
   },
   "private": true,
   "dependencies": {

--- a/frameworks/keyed/apprun/package.json
+++ b/frameworks/keyed/apprun/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "esbuild src/main.tsx --bundle --outfile=dist/main.js --serve=8080 --servedir=.",
+    "dev": "esbuild src/main.tsx --bundle --outfile=dist/main.js --serve=8080 --servedir=.",
     "build-prod": "esbuild src/main.tsx --bundle --outfile=dist/main.js --minify"
   },
   "keywords": [

--- a/frameworks/keyed/arrowjs/package.json
+++ b/frameworks/keyed/arrowjs/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://www.arrow-js.com/"
   },
   "scripts": {
-    "build-dev": "exit 0",
+    "dev": "exit 0",
     "build-prod": "exit 0"
   },
   "keywords": [

--- a/frameworks/keyed/bdc/package.json
+++ b/frameworks/keyed/bdc/package.json
@@ -25,7 +25,7 @@
     "rollup": "3.26.2"
   },
   "scripts": {
-    "build-dev": "rollup -c --watch",
+    "dev": "rollup -c --watch",
     "build-prod": "rollup -c --environment production"
   }
 }

--- a/frameworks/keyed/better-react/package.json
+++ b/frameworks/keyed/better-react/package.json
@@ -11,7 +11,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "build-dev": "vite",
+    "dev": "vite",
     "build-prod": "vite build"
   },
   "devDependencies": {

--- a/frameworks/keyed/blazor-wasm-aot/package.json
+++ b/frameworks/keyed/blazor-wasm-aot/package.json
@@ -16,9 +16,9 @@
     "install-force": "run-script-os",
     "install-force:win32": "dotnet-install.cmd",
     "install-force:nix": "./dotnet-install.sh",
-    "build-dev": "run-script-os",
-    "build-dev:win32": "cross-env DOTNET_CLI_TELEMETRY_OPTOUT=0 ./dotnet/dotnet.exe build ./src/ -c Debug",
-    "build-dev:nix": "cross-env DOTNET_CLI_TELEMETRY_OPTOUT=0 ./dotnet/dotnet build ./src/ -c Debug",
+    "dev": "run-script-os",
+    "dev:win32": "cross-env DOTNET_CLI_TELEMETRY_OPTOUT=0 ./dotnet/dotnet.exe build ./src/ -c Debug",
+    "dev:nix": "cross-env DOTNET_CLI_TELEMETRY_OPTOUT=0 ./dotnet/dotnet build ./src/ -c Debug",
     "build-prod-force": "rimraf bundeled-dist && run-script-os",
     "build-prod-force:win32": "cross-env DOTNET_CLI_TELEMETRY_OPTOUT=0 ./dotnet/dotnet.exe publish ./src/ -c Release -o ./bundeled-dist",
     "build-prod-force:nix": "cross-env DOTNET_CLI_TELEMETRY_OPTOUT=0 ./dotnet/dotnet publish ./src/ -c Release -o ./bundeled-dist"

--- a/frameworks/keyed/blazor-wasm/package.json
+++ b/frameworks/keyed/blazor-wasm/package.json
@@ -16,9 +16,9 @@
     "install-force": "run-script-os",
     "install-force:win32": "dotnet-install.cmd",
     "install-force:nix": "./dotnet-install.sh",
-    "build-dev": "run-script-os",
-    "build-dev:win32": "cross-env DOTNET_CLI_TELEMETRY_OPTOUT=0 ./dotnet/dotnet.exe build ./src/ -c Debug",
-    "build-dev:nix": "cross-env DOTNET_CLI_TELEMETRY_OPTOUT=0 ./dotnet/dotnet build ./src/ -c Debug",
+    "dev": "run-script-os",
+    "dev:win32": "cross-env DOTNET_CLI_TELEMETRY_OPTOUT=0 ./dotnet/dotnet.exe build ./src/ -c Debug",
+    "dev:nix": "cross-env DOTNET_CLI_TELEMETRY_OPTOUT=0 ./dotnet/dotnet build ./src/ -c Debug",
     "build-prod-force": "rimraf bundeled-dist && run-script-os",
     "build-prod-force:win32": "cross-env DOTNET_CLI_TELEMETRY_OPTOUT=0 ./dotnet/dotnet.exe publish ./src/ -c Release -o ./bundeled-dist",
     "build-prod-force:nix": "cross-env DOTNET_CLI_TELEMETRY_OPTOUT=0 ./dotnet/dotnet publish ./src/ -c Release -o ./bundeled-dist"

--- a/frameworks/keyed/blockdom/package.json
+++ b/frameworks/keyed/blockdom/package.json
@@ -9,7 +9,7 @@
     "issues": [1261]
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c"
   },
   "keywords": [

--- a/frameworks/keyed/bobril/package.json
+++ b/frameworks/keyed/bobril/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://bobril.com/"
   },
   "scripts": {
-    "build-dev": "bb",
+    "dev": "bb",
     "build-prod": "bb b --verbose"
   },
   "keywords": [

--- a/frameworks/keyed/cample/package.json
+++ b/frameworks/keyed/cample/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build-prod": "webpack --mode=production",
-    "build-dev": "webpack --mode=development"
+    "dev": "webpack --mode=development"
   },
   "keywords": [
     "cample"

--- a/frameworks/keyed/crank/package.json
+++ b/frameworks/keyed/crank/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://crank.js.org/"
   },
   "scripts": {
-    "build-dev": "CRANK_ENV=development rollup -c",
+    "dev": "CRANK_ENV=development rollup -c",
     "build-prod": "rollup -c"
   },
   "keywords": [

--- a/frameworks/keyed/dark/package.json
+++ b/frameworks/keyed/dark/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://github.com/atellmer/dark"
   },
   "scripts": {
-    "build-dev": "npx webpack --watch",
+    "dev": "npx webpack --watch",
     "build-prod": "npx webpack"
   },
   "keywords": [

--- a/frameworks/keyed/dlightjs/package.json
+++ b/frameworks/keyed/dlightjs/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://github.com/dlight-js/dlight"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Ian Duan",

--- a/frameworks/keyed/doohtml-dom/package.json
+++ b/frameworks/keyed/doohtml-dom/package.json
@@ -9,7 +9,7 @@
       "issues": [772, 1139]
     },
     "scripts": {
-      "build-dev": "exit 0",
+      "dev": "exit 0",
       "build-prod": "exit 0"
     },
     "keywords": [],

--- a/frameworks/keyed/doohtml/package.json
+++ b/frameworks/keyed/doohtml/package.json
@@ -12,7 +12,7 @@
       "issues": [772, 1139]
     },
     "scripts": {
-      "build-dev": "exit 0",
+      "dev": "exit 0",
       "build-prod": "exit 0"
     },
     "keywords": [],

--- a/frameworks/keyed/doz/package.json
+++ b/frameworks/keyed/doz/package.json
@@ -12,7 +12,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "esbuild src/index.js --outfile=dist/main.js --bundle --watch",
+    "dev": "esbuild src/index.js --outfile=dist/main.js --bundle --watch",
     "build-prod": "esbuild src/index.js --outfile=dist/main.js --bundle --minify"
   },
   "repository": {

--- a/frameworks/keyed/ef-js/package.json
+++ b/frameworks/keyed/ef-js/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "rollup -c ./config/rollup.config.mjs",
-    "build-dev": "rollup -c ./config/rollup.config.mjs -w",
+    "dev": "rollup -c ./config/rollup.config.mjs -w",
     "build-prod": "cross-env NODE_ENV=production rollup -c ./config/rollup.config.mjs"
   },
   "keywords": [

--- a/frameworks/keyed/ember/package.json
+++ b/frameworks/keyed/ember/package.json
@@ -19,7 +19,7 @@
     "ember": "node_modules/.bin/ember",
     "ember-cli-update": "node_modules/.bin/ember-cli-update",
     "build": "ember build",
-    "build-dev": "ember build --environment=production",
+    "dev": "ember build --environment=production",
     "build-prod": "ember build --environment=production",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:hbs": "ember-template-lint .",

--- a/frameworks/keyed/fntags/package.json
+++ b/frameworks/keyed/fntags/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://srfnstack.github.io/fntags/"
   },
   "scripts": {
-    "build-dev": "npm i && node build.js dev",
+    "dev": "npm i && node build.js dev",
     "build-prod": "npm i && node build.js"
   },
   "author": "Robert Kempton",

--- a/frameworks/keyed/fre/package.json
+++ b/frameworks/keyed/fre/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https:/fre.deno.dev"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/glimmer-2/package.json
+++ b/frameworks/keyed/glimmer-2/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "webpack",
     "start": "webpack serve",
-    "build-dev": "webpack-dev-server",
+    "dev": "webpack-dev-server",
     "build-prod": "webpack"
   },
   "browserslist": {

--- a/frameworks/keyed/gyron/package.json
+++ b/frameworks/keyed/gyron/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://www.npmjs.com/package/gyron"
   },
   "scripts": {
-    "build-dev": "webpack --mode development --watch",
+    "dev": "webpack --mode development --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/frameworks/keyed/helix/package.json
+++ b/frameworks/keyed/helix/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "watch": "shadow-cljs watch :app",
-    "build-dev": "shadow-cljs compile :app",
+    "dev": "shadow-cljs compile :app",
     "build-prod": "shadow-cljs release :app"
   },
   "devDependencies": {

--- a/frameworks/keyed/hullo/package.json
+++ b/frameworks/keyed/hullo/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://hullo.dev/hullo-dom/intro"
   },
   "scripts": {
-    "build-dev": "NODE_ENV=development webpack -w",
+    "dev": "NODE_ENV=development webpack -w",
     "build-prod": "NODE_ENV=production webpack"
   },
   "keywords": [

--- a/frameworks/keyed/hydro-js/package.json
+++ b/frameworks/keyed/hydro-js/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://github.com/Krutsch/hydro-js"
   },
   "scripts": {
-    "build-dev": "html-bundle --hmr",
+    "dev": "html-bundle --hmr",
     "build-prod": "html-bundle",
     "postbuild-prod": "node utils/moveFiles.js"
   },

--- a/frameworks/keyed/imba/package.json
+++ b/frameworks/keyed/imba/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://imba.io/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode=production"
   },
   "keywords": [

--- a/frameworks/keyed/incremental-dom/package.json
+++ b/frameworks/keyed/incremental-dom/package.json
@@ -9,7 +9,7 @@
     "frameworkHomeURL": "http://google.github.io/incremental-dom/"
   },
   "scripts": {
-    "build-dev": "esbuild src/main.ts --bundle --outfile=dist/main.js --watch",
+    "dev": "esbuild src/main.ts --bundle --outfile=dist/main.js --watch",
     "build-prod": "esbuild src/main.ts --bundle --minify --outfile=dist/main.js"
   },
   "keywords": [

--- a/frameworks/keyed/inferno/package.json
+++ b/frameworks/keyed/inferno/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://github.com/infernojs/inferno"
   },
   "scripts": {
-    "build-dev": "rollup -c",
+    "dev": "rollup -c",
     "build-prod": "rollup -c --environment production"
   },
   "keywords": [

--- a/frameworks/keyed/ivi/package.json
+++ b/frameworks/keyed/ivi/package.json
@@ -14,7 +14,7 @@
     "frameworkHomeURL": "https://github.com/localvoid/ivi"
   },
   "scripts": {
-    "build-dev": "rollup -c rollup.config.mjs",
+    "dev": "rollup -c rollup.config.mjs",
     "build-prod": "rollup -c rollup.config.mjs"
   },
   "dependencies": {

--- a/frameworks/keyed/jotai/package.json
+++ b/frameworks/keyed/jotai/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://github.com/pmndrs/jotai"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/karyon/package.json
+++ b/frameworks/keyed/karyon/package.json
@@ -13,7 +13,7 @@
     "esbuild": "0.19.2"
   },
   "scripts": {
-    "build-dev":"esbuild src/app.js --outfile=dist/app.js --bundle --watch",
+    "dev":"esbuild src/app.js --outfile=dist/app.js --bundle --watch",
     "build-prod": "esbuild src/app.js --outfile=dist/app.js --bundle --minify"
   }
 }

--- a/frameworks/keyed/knockout/package.json
+++ b/frameworks/keyed/knockout/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rollup -c --watch",
+    "dev": "rollup -c --watch",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Stefan Krause",

--- a/frameworks/keyed/ko-jsx/package.json
+++ b/frameworks/keyed/ko-jsx/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rollup -c",
+    "dev": "rollup -c",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Ryan Carniato",

--- a/frameworks/keyed/legend-state/package.json
+++ b/frameworks/keyed/legend-state/package.json
@@ -9,7 +9,7 @@
     "frameworkHomeURL": "https://github.com/LegendApp/legend-state"
   },
   "scripts": {
-    "build-dev": "webpack --watch --mode=development",
+    "dev": "webpack --watch --mode=development",
     "build-prod": "webpack --mode=production"
   },
   "keywords": [

--- a/frameworks/keyed/lit-html/package.json
+++ b/frameworks/keyed/lit-html/package.json
@@ -13,7 +13,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c"
   },
   "repository": {

--- a/frameworks/keyed/lit/package.json
+++ b/frameworks/keyed/lit/package.json
@@ -12,7 +12,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c"
   },
   "repository": {

--- a/frameworks/keyed/lui/package.json
+++ b/frameworks/keyed/lui/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "echo 0",
+    "dev": "echo 0",
     "build-prod": "echo 0"
   }
 }

--- a/frameworks/keyed/lwc/package.json
+++ b/frameworks/keyed/lwc/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://lwc.dev/"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "dependencies": {

--- a/frameworks/keyed/malina/package.json
+++ b/frameworks/keyed/malina/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://www.npmjs.com/package/malinajs"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c"
   },
   "keywords": [

--- a/frameworks/keyed/marionette-backbone/package.json
+++ b/frameworks/keyed/marionette-backbone/package.json
@@ -12,7 +12,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "devDependencies": {

--- a/frameworks/keyed/marionette/package.json
+++ b/frameworks/keyed/marionette/package.json
@@ -9,7 +9,7 @@
     "frameworkHomeURL": "https://marionettejs.com/"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "devDependencies": {

--- a/frameworks/keyed/maverick/package.json
+++ b/frameworks/keyed/maverick/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://github.com/maverick-js/maverick"
   },
   "scripts": {
-    "build-dev": "npm run copy:css && node build.js --dev & sirv --dev --port=3001",
+    "dev": "npm run copy:css && node build.js --dev & sirv --dev --port=3001",
     "build-prod": "node build.js",
     "copy:css": "cp -R ../../../css css"
   },

--- a/frameworks/keyed/metron/package.json
+++ b/frameworks/keyed/metron/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Robbie Speed",

--- a/frameworks/keyed/michijs-map/package.json
+++ b/frameworks/keyed/michijs-map/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "start": "michi-server --start",
-    "build-dev": "michi-server --build --env=DEVELOPMENT",
+    "dev": "michi-server --build --env=DEVELOPMENT",
     "build-prod": "michi-server --build"
   },
   "repository": {

--- a/frameworks/keyed/michijs/package.json
+++ b/frameworks/keyed/michijs/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "start": "michi-server --start",
-    "build-dev": "michi-server --build --env=DEVELOPMENT",
+    "dev": "michi-server --build --env=DEVELOPMENT",
     "build-prod": "michi-server --build"
   },
   "repository": {

--- a/frameworks/keyed/million/package.json
+++ b/frameworks/keyed/million/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build-dev": "rollup -cw",
+    "dev": "rollup -cw",
     "build-prod": "rollup -c"
   },
   "dependencies": {

--- a/frameworks/keyed/mithril/package.json
+++ b/frameworks/keyed/mithril/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://mithril.js.org/"
   },
   "scripts": {
-    "build-dev": "webpack -w -d",
+    "dev": "webpack -w -d",
     "build-prod": "webpack -p"
   },
   "devDependencies": {

--- a/frameworks/keyed/mobx-jsx/package.json
+++ b/frameworks/keyed/mobx-jsx/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://github.com/ryansolid/mobx-jsx"
   },
   "scripts": {
-    "build-dev": "rollup -c",
+    "dev": "rollup -c",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Ryan Carniato",

--- a/frameworks/keyed/owl/package.json
+++ b/frameworks/keyed/owl/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://odoo.github.io/owl/"
   },
   "scripts": {
-    "build-dev": "webpack --mode development --watch",
+    "dev": "webpack --mode development --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/frameworks/keyed/petite-vue/package.json
+++ b/frameworks/keyed/petite-vue/package.json
@@ -19,7 +19,7 @@
     "rollup": "^3.15.0"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "type": "module"

--- a/frameworks/keyed/plaited/package.json
+++ b/frameworks/keyed/plaited/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build-dev": "esbuild src/main.tsx --bundle --outfile=dist/main.js --watch",
+    "dev": "esbuild src/main.tsx --bundle --outfile=dist/main.js --watch",
     "build-prod": "esbuild src/main.tsx --bundle --outfile=dist/main.js --minify"
   },
   "type": "module",

--- a/frameworks/keyed/preact-classes/package.json
+++ b/frameworks/keyed/preact-classes/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://preactjs.com/"
   },
   "scripts": {
-    "build-dev": "webpack -w -d",
+    "dev": "webpack -w -d",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/preact-hooks/package.json
+++ b/frameworks/keyed/preact-hooks/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://preactjs.com/guide/v10/hooks"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Ryan Carniato",

--- a/frameworks/keyed/preact-signals/package.json
+++ b/frameworks/keyed/preact-signals/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://preactjs.com/guide/v10/signals"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Ryan Carniato",

--- a/frameworks/keyed/ractive/package.json
+++ b/frameworks/keyed/ractive/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://ractive.js.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/frameworks/keyed/rax/package.json
+++ b/frameworks/keyed/rax/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://github.com/alibaba/rax"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-diagon/package.json
+++ b/frameworks/keyed/react-diagon/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://www.diagon.dev/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-focal/package.json
+++ b/frameworks/keyed/react-focal/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://github.com/grammarly/focal"
   },
   "scripts": {
-    "build-dev": "webpack --watch --mode=development",
+    "dev": "webpack --watch --mode=development",
     "build-prod": "webpack --mode=production"
   },
   "keywords": [

--- a/frameworks/keyed/react-hooks-use-transition/package.json
+++ b/frameworks/keyed/react-hooks-use-transition/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://reactjs.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-hooks/package.json
+++ b/frameworks/keyed/react-hooks/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://reactjs.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-mlyn/package.json
+++ b/frameworks/keyed/react-mlyn/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-mobX/package.json
+++ b/frameworks/keyed/react-mobX/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://mobx.js.org/"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Maxim Molochkov",

--- a/frameworks/keyed/react-recoil/package.json
+++ b/frameworks/keyed/react-recoil/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://recoiljs.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-redux-hooks-immutable/package.json
+++ b/frameworks/keyed/react-redux-hooks-immutable/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://react-redux.js.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-redux-hooks/package.json
+++ b/frameworks/keyed/react-redux-hooks/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://react-redux.js.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-redux-rematch/package.json
+++ b/frameworks/keyed/react-redux-rematch/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://rematchjs.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-redux/package.json
+++ b/frameworks/keyed/react-redux/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://react-redux.js.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-rxjs/package.json
+++ b/frameworks/keyed/react-rxjs/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://react-rxjs.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-signalis/package.json
+++ b/frameworks/keyed/react-signalis/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://github.com/cafreeman/signalis"
   },
   "scripts": {
-    "build-dev": "vite",
+    "dev": "vite",
     "build-prod": "vite build",
     "preview": "vite preview"
   },

--- a/frameworks/keyed/react-starbeam/package.json
+++ b/frameworks/keyed/react-starbeam/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "npx live-server",
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-tagged-state/package.json
+++ b/frameworks/keyed/react-tagged-state/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://github.com/oleggrishechkin/react-tagged-state"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react-tracked/package.json
+++ b/frameworks/keyed/react-tracked/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://react-tracked.js.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/frameworks/keyed/react-zustand/package.json
+++ b/frameworks/keyed/react-zustand/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://github.com/pmndrs/zustand"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack"
   },
   "keywords": [

--- a/frameworks/keyed/react/package.json
+++ b/frameworks/keyed/react/package.json
@@ -9,7 +9,7 @@
     "frameworkHomeURL": "https://www.reactjs.org"
   },
   "scripts": {
-    "build-dev": "node esbuild.config.js --watch",
+    "dev": "node esbuild.config.js --watch",
     "build-prod": "node esbuild.config.js"
   },
   "keywords": [

--- a/frameworks/keyed/reagent/package.json
+++ b/frameworks/keyed/reagent/package.json
@@ -6,7 +6,7 @@
     "frameworkHomeURL": "https://reagent-project.github.io/"
   },
   "scripts": {
-    "build-dev": "LEIN_VERSION=2.9.3 lein cljsbuild auto",
+    "dev": "LEIN_VERSION=2.9.3 lein cljsbuild auto",
     "build-prod": "LEIN_VERSION=2.9.3 lein cljsbuild once prod"
   },
   "dependencies": {

--- a/frameworks/keyed/redom/package.json
+++ b/frameworks/keyed/redom/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rollup -f iife -c rollup.config.dev.js src/main.js -o dist/main.js",
+    "dev": "rollup -f iife -c rollup.config.dev.js src/main.js -o dist/main.js",
     "build-prod": "rollup -f iife -c rollup.config.js src/main.js -o dist/main.js"
   },
   "author": "",

--- a/frameworks/keyed/rendrjs/package.json
+++ b/frameworks/keyed/rendrjs/package.json
@@ -2,7 +2,7 @@
   "name": "js-framework-benchmark-rendrjs",
   "version": "0.0.1",
   "scripts": {
-    "build-dev": "webpack --mode development --watch",
+    "dev": "webpack --mode development --watch",
     "build-prod": "webpack --mode production"
   },
   "devDependencies": {

--- a/frameworks/keyed/rescript-react/package.json
+++ b/frameworks/keyed/rescript-react/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://rescript-lang.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "prebuild-prod": "bsb -clean -make-world",
     "build-prod": "webpack",
     "clean": "bsb -clean-world"

--- a/frameworks/keyed/rezact/package.json
+++ b/frameworks/keyed/rezact/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://rezact.io/"
   },
   "scripts": {
-    "build-dev": "vite",
+    "dev": "vite",
     "build-prod": "tsc && vite build"
   },
   "keywords": [

--- a/frameworks/keyed/riot/package.json
+++ b/frameworks/keyed/riot/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "devDependencies": {

--- a/frameworks/keyed/s2/package.json
+++ b/frameworks/keyed/s2/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "echo 0",
+    "dev": "echo 0",
     "build-prod": "echo 0"
   },
   "keywords": [

--- a/frameworks/keyed/san-composition/package.json
+++ b/frameworks/keyed/san-composition/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/frameworks/keyed/san-store/package.json
+++ b/frameworks/keyed/san-store/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/frameworks/keyed/scarlets-frame/package.json
+++ b/frameworks/keyed/scarlets-frame/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "keywords": [

--- a/frameworks/keyed/sifrr/package.json
+++ b/frameworks/keyed/sifrr/package.json
@@ -4,7 +4,7 @@
   "description": "sifrr demo",
   "main": "dist/app.min.js",
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c",
     "start": "ws"
   },

--- a/frameworks/keyed/sinuous/package.json
+++ b/frameworks/keyed/sinuous/package.json
@@ -12,7 +12,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Wesley Luyten",

--- a/frameworks/keyed/solid-store/package.json
+++ b/frameworks/keyed/solid-store/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://www.solidjs.com/"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Ryan Carniato",

--- a/frameworks/keyed/solid/package.json
+++ b/frameworks/keyed/solid/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://www.solidjs.com/"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Ryan Carniato",

--- a/frameworks/keyed/stencil/package.json
+++ b/frameworks/keyed/stencil/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build-prod": "stencil build",
-    "build-dev": "stencil build --dev --watch"
+    "dev": "stencil build --dev --watch"
   },
   "dependencies": {
     "@stencil/core": "^4.4.1"

--- a/frameworks/keyed/strve/package.json
+++ b/frameworks/keyed/strve/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://maomincoding.github.io/strve-doc/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "devDependencies": {

--- a/frameworks/keyed/svelte/package.json
+++ b/frameworks/keyed/svelte/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://svelte.dev/"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "keywords": [

--- a/frameworks/keyed/udomsay-esx/package.json
+++ b/frameworks/keyed/udomsay-esx/package.json
@@ -11,7 +11,7 @@
         ]
     },
     "scripts": {
-        "build-dev": "rollup -c -w",
+        "dev": "rollup -c -w",
         "build-prod": "rollup -c --environment production"
     },
     "author": "Andrea Giammarchi",

--- a/frameworks/keyed/udomsay-tpl/package.json
+++ b/frameworks/keyed/udomsay-tpl/package.json
@@ -12,7 +12,7 @@
         ]
     },
     "scripts": {
-        "build-dev": "rollup -c -w",
+        "dev": "rollup -c -w",
         "build-prod": "rollup -c --environment production"
     },
     "author": "Andrea Giammarchi",

--- a/frameworks/keyed/uhtml/package.json
+++ b/frameworks/keyed/uhtml/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c"
   },
   "repository": {

--- a/frameworks/keyed/unis/package.json
+++ b/frameworks/keyed/unis/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://www.github.com/anuoua/unis"
   },
   "scripts": {
-    "build-dev": "webpack --mode development --watch",
+    "dev": "webpack --mode development --watch",
     "build-prod": "webpack --mode production"
   },
   "dependencies": {

--- a/frameworks/keyed/valtio/package.json
+++ b/frameworks/keyed/valtio/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://valtio.pmnd.rs/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/frameworks/keyed/vanillajs-1/package.json
+++ b/frameworks/keyed/vanillajs-1/package.json
@@ -9,7 +9,7 @@
     "issues": [772]
   },
   "scripts": {
-    "build-dev": "exit 0",
+    "dev": "exit 0",
     "build-prod": "exit 0"
   },
   "keywords": [],

--- a/frameworks/keyed/vanillajs-wc/package.json
+++ b/frameworks/keyed/vanillajs-wc/package.json
@@ -9,7 +9,7 @@
     "issues": [772]
   },
   "scripts": {
-    "build-dev": "exit 0",
+    "dev": "exit 0",
     "build-prod": "exit 0"
   },
   "devDependencies": {}

--- a/frameworks/keyed/vanillajs/package.json
+++ b/frameworks/keyed/vanillajs/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "exit 0",
+    "dev": "exit 0",
     "build-prod": "exit 0"
   },
   "keywords": [

--- a/frameworks/keyed/vanjs/package.json
+++ b/frameworks/keyed/vanjs/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "bash bundle.sh && cp dist/bundle.js dist/bundle.out.js",
+    "dev": "bash bundle.sh && cp dist/bundle.js dist/bundle.out.js",
     "build-prod": "bash bundle.sh && bash minify.sh"
   },
   "keywords": [

--- a/frameworks/keyed/vue-pinia/package.json
+++ b/frameworks/keyed/vue-pinia/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://vue.js.org/"
   },
   "scripts": {
-    "build-dev": "webpack --mode development --watch",
+    "dev": "webpack --mode development --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/frameworks/keyed/vue/package.json
+++ b/frameworks/keyed/vue/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://vue.js.org/"
   },
   "scripts": {
-    "build-dev": "webpack --mode development --watch",
+    "dev": "webpack --mode development --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/frameworks/keyed/vuerx-jsx/package.json
+++ b/frameworks/keyed/vuerx-jsx/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://github.com/ryansolid/vuerx-jsx"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Ryan Carniato",

--- a/frameworks/keyed/whatsup/package.json
+++ b/frameworks/keyed/whatsup/package.json
@@ -13,7 +13,7 @@
         "url": "https://github.com/krausest/js-framework-benchmark.git"
     },
     "scripts": {
-        "build-dev": "webpack -w --mode development",
+        "dev": "webpack -w --mode development",
         "build-prod": "webpack --mode production"
     },
     "dependencies": {

--- a/frameworks/non-keyed/alins/package.json
+++ b/frameworks/non-keyed/alins/package.json
@@ -10,7 +10,7 @@
     "alins"
   ],
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "devDependencies": {

--- a/frameworks/non-keyed/apprun/package.json
+++ b/frameworks/non-keyed/apprun/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "esbuild src/main.tsx --bundle --outfile=dist/main.js --serve=8080 --servedir=.",
+    "dev": "esbuild src/main.tsx --bundle --outfile=dist/main.js --serve=8080 --servedir=.",
     "build-prod": "esbuild src/main.tsx --bundle --outfile=dist/main.js --minify"
   },
   "keywords": [

--- a/frameworks/non-keyed/arrowjs/package.json
+++ b/frameworks/non-keyed/arrowjs/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://www.arrow-js.com/"
   },
   "scripts": {
-    "build-dev": "exit 0",
+    "dev": "exit 0",
     "build-prod": "exit 0"
   },
   "keywords": [

--- a/frameworks/non-keyed/aurelia/package.json
+++ b/frameworks/non-keyed/aurelia/package.json
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/krausest/js-framework-benchmark",
   "scripts": {
-    "build-dev": "aurelia build --env dev",
+    "dev": "aurelia build --env dev",
     "build-prod": "aurelia build --env prod"
   },
   "dependencies": {

--- a/frameworks/non-keyed/bau/package.json
+++ b/frameworks/non-keyed/bau/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://github.com/grucloud/bau"
   },
   "scripts": {
-    "build-dev": "vite",
+    "dev": "vite",
     "build-prod": "vite build",
     "preview": "vite preview"
   },

--- a/frameworks/non-keyed/bdc/package.json
+++ b/frameworks/non-keyed/bdc/package.json
@@ -25,7 +25,7 @@
     "rollup": "3.26.2"
   },
   "scripts": {
-    "build-dev": "rollup -c --watch",
+    "dev": "rollup -c --watch",
     "build-prod": "rollup -c --environment production"
   }
 }

--- a/frameworks/non-keyed/cyclejs-dom/package.json
+++ b/frameworks/non-keyed/cyclejs-dom/package.json
@@ -6,7 +6,7 @@
     "frameworkVersionFromPackage": "@cycle/dom"
   },
   "scripts": {
-    "build-dev": "webpack --watch --mode=development",
+    "dev": "webpack --watch --mode=development",
     "build-prod": "webpack --mode=production"
   },
   "devDependencies": {

--- a/frameworks/non-keyed/cydon/package.json
+++ b/frameworks/non-keyed/cydon/package.json
@@ -21,7 +21,7 @@
     "terser": "^5.16.9"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "type": "module"

--- a/frameworks/non-keyed/dlightjs/package.json
+++ b/frameworks/non-keyed/dlightjs/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://github.com/dlight-js/dlight"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "author": "Ian Duan",

--- a/frameworks/non-keyed/doz/package.json
+++ b/frameworks/non-keyed/doz/package.json
@@ -12,7 +12,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "esbuild src/index.js --outfile=dist/main.js --bundle --watch",
+    "dev": "esbuild src/index.js --outfile=dist/main.js --bundle --watch",
     "build-prod": "esbuild src/index.js --outfile=dist/main.js --bundle --minify"
   },
   "repository": {

--- a/frameworks/non-keyed/ef-js/package.json
+++ b/frameworks/non-keyed/ef-js/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "rollup -c ./config/rollup.config.mjs",
-    "build-dev": "rollup -c ./config/rollup.config.mjs -w",
+    "dev": "rollup -c ./config/rollup.config.mjs -w",
     "build-prod": "cross-env NODE_ENV=production rollup -c ./config/rollup.config.mjs"
   },
   "keywords": [

--- a/frameworks/non-keyed/fast/package.json
+++ b/frameworks/non-keyed/fast/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build-prod": "rimraf dist && webpack --config webpack.config.js --mode=production",
-    "build-dev": "rimraf dist && webpack --config webpack.config.js --watch --mode=development"
+    "dev": "rimraf dist && webpack --config webpack.config.js --watch --mode=development"
   },
   "author": "Dan Svorcan",
   "license": "Apache-2.0",

--- a/frameworks/non-keyed/gyron/package.json
+++ b/frameworks/non-keyed/gyron/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://www.npmjs.com/package/gyron"
   },
   "scripts": {
-    "build-dev": "webpack --mode development --watch",
+    "dev": "webpack --mode development --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/frameworks/non-keyed/hullo/package.json
+++ b/frameworks/non-keyed/hullo/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://hullo.dev/hullo-dom/intro"
   },
   "scripts": {
-    "build-dev": "NODE_ENV=development webpack -w",
+    "dev": "NODE_ENV=development webpack -w",
     "build-prod": "NODE_ENV=production webpack"
   },
   "keywords": [

--- a/frameworks/non-keyed/hydro-js/package.json
+++ b/frameworks/non-keyed/hydro-js/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://github.com/Krutsch/hydro-js"
   },
   "scripts": {
-    "build-dev": "html-bundle --hmr",
+    "dev": "html-bundle --hmr",
     "build-prod": "html-bundle",
     "postbuild-prod": "node utils/moveFiles.js"
   },

--- a/frameworks/non-keyed/imba/package.json
+++ b/frameworks/non-keyed/imba/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://imba.io/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode=production"
   },
   "keywords": [

--- a/frameworks/non-keyed/incr_dom/package.json
+++ b/frameworks/non-keyed/incr_dom/package.json
@@ -23,7 +23,7 @@
     "build-prod": "esy @esy b dune build --root . -j 8 --verbose --profile release",
     "postbuild-prod": "sh copy.sh",
     "prebuild-dev": "esy @esy install",
-    "build-dev": "esy @esy b dune build --root . -j 8 --verbose --profile dev",
+    "dev": "esy @esy b dune build --root . -j 8 --verbose --profile dev",
     "postbuild-dev": "sh copy.sh"
   },
   "dependencies": {

--- a/frameworks/non-keyed/inferno/package.json
+++ b/frameworks/non-keyed/inferno/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://github.com/infernojs/inferno"
   },
   "scripts": {
-    "build-dev": "rollup -c",
+    "dev": "rollup -c",
     "build-prod": "rollup -c --environment production"
   },
   "keywords": [

--- a/frameworks/non-keyed/legend-state-optimized/package.json
+++ b/frameworks/non-keyed/legend-state-optimized/package.json
@@ -9,7 +9,7 @@
     "frameworkHomeURL": "https://github.com/LegendApp/legend-state"
   },
   "scripts": {
-    "build-dev": "webpack --watch --mode=development",
+    "dev": "webpack --watch --mode=development",
     "build-prod": "webpack --mode=production"
   },
   "keywords": [

--- a/frameworks/non-keyed/lit-html/package.json
+++ b/frameworks/non-keyed/lit-html/package.json
@@ -12,7 +12,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c"
   },
   "repository": {

--- a/frameworks/non-keyed/lit/package.json
+++ b/frameworks/non-keyed/lit/package.json
@@ -9,7 +9,7 @@
     "useShadowRoot": true
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c"
   },
   "repository": {

--- a/frameworks/non-keyed/maquette/package.json
+++ b/frameworks/non-keyed/maquette/package.json
@@ -8,7 +8,7 @@
     "issues": []
   },
   "scripts": {
-    "build-dev": "node build.js",
+    "dev": "node build.js",
     "build-prod": "node build.js"
   },
   "devDependencies": {

--- a/frameworks/non-keyed/petite-vue/package.json
+++ b/frameworks/non-keyed/petite-vue/package.json
@@ -19,7 +19,7 @@
     "rollup": "^3.15.0"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "type": "module"

--- a/frameworks/non-keyed/ractive/package.json
+++ b/frameworks/non-keyed/ractive/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://ractive.js.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/frameworks/non-keyed/react/package.json
+++ b/frameworks/non-keyed/react/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://www.reactjs.org"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "author": "Stefan Krause",

--- a/frameworks/non-keyed/redom/package.json
+++ b/frameworks/non-keyed/redom/package.json
@@ -9,7 +9,7 @@
     "issues": [772]
   },
   "scripts": {
-    "build-dev": "rollup -f iife -c rollup.config.dev.js src/main.js -o dist/main.js",
+    "dev": "rollup -f iife -c rollup.config.dev.js src/main.js -o dist/main.js",
     "build-prod": "rollup -f iife -c rollup.config.js src/main.js -o dist/main.js"
   },
   "author": "",

--- a/frameworks/non-keyed/riot/package.json
+++ b/frameworks/non-keyed/riot/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://riot.js.org/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "devDependencies": {

--- a/frameworks/non-keyed/san/package.json
+++ b/frameworks/non-keyed/san/package.json
@@ -8,7 +8,7 @@
     "issues": [800, 1139]
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [

--- a/frameworks/non-keyed/scarlets-frame/package.json
+++ b/frameworks/non-keyed/scarlets-frame/package.json
@@ -9,7 +9,7 @@
     "issues": [800, 1139]
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "keywords": [

--- a/frameworks/non-keyed/seed/package.json
+++ b/frameworks/non-keyed/seed/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rimraf bundled-dist && wasm-pack build --dev --target web --out-name js-framework-benchmark-non-keyed-seed --out-dir bundled-dist && cpr index.html bundled-dist/index.html && rimraf bundled-dist/.gitignore",
+    "dev": "rimraf bundled-dist && wasm-pack build --dev --target web --out-name js-framework-benchmark-non-keyed-seed --out-dir bundled-dist && cpr index.html bundled-dist/index.html && rimraf bundled-dist/.gitignore",
     "build-prod": "echo This is a no-op. && echo Due to heavy dependencies, the generated javascript is already provided. && echo If you really want to rebuild from source use: && echo npm run build-prod-force",
     "build-prod-force": "rustup target add wasm32-unknown-unknown && cargo install wasm-pack && rimraf bundled-dist && wasm-pack build --release --target web --out-name js-framework-benchmark-non-keyed-seed --out-dir bundled-dist && cpr index.html bundled-dist/index.html && rimraf bundled-dist/.gitignore"
   },

--- a/frameworks/non-keyed/sifrr/package.json
+++ b/frameworks/non-keyed/sifrr/package.json
@@ -4,7 +4,7 @@
   "description": "sifrr demo",
   "main": "dist/app.min.js",
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c",
     "start": "ws"
   },

--- a/frameworks/non-keyed/slingjs/package.json
+++ b/frameworks/non-keyed/slingjs/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://github.com/puckowski/Sling.js"
   },
   "scripts": {
-    "build-dev": "webpack --watch --mode=development",
+    "dev": "webpack --watch --mode=development",
     "build-prod": "webpack --mode=production"
   },
   "devDependencies": {

--- a/frameworks/non-keyed/strve/package.json
+++ b/frameworks/non-keyed/strve/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://maomincoding.github.io/strve-doc/"
   },
   "scripts": {
-    "build-dev": "webpack --watch",
+    "dev": "webpack --watch",
     "build-prod": "webpack --mode production"
   },
   "devDependencies": {

--- a/frameworks/non-keyed/svelte/package.json
+++ b/frameworks/non-keyed/svelte/package.json
@@ -8,7 +8,7 @@
     "frameworkHomeURL": "https://svelte.dev/"
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c --environment production"
   },
   "keywords": [

--- a/frameworks/non-keyed/udomsay-esx/package.json
+++ b/frameworks/non-keyed/udomsay-esx/package.json
@@ -11,7 +11,7 @@
         ]
     },
     "scripts": {
-        "build-dev": "rollup -c -w",
+        "dev": "rollup -c -w",
         "build-prod": "rollup -c --environment production"
     },
     "author": "Andrea Giammarchi",

--- a/frameworks/non-keyed/uhtml/package.json
+++ b/frameworks/non-keyed/uhtml/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "rollup -c -w",
+    "dev": "rollup -c -w",
     "build-prod": "rollup -c"
   },
   "repository": {

--- a/frameworks/non-keyed/vanillajs-1/package.json
+++ b/frameworks/non-keyed/vanillajs-1/package.json
@@ -9,7 +9,7 @@
     "issues": [772]
   },
   "scripts": {
-    "build-dev": "echo 0",
+    "dev": "echo 0",
     "build-prod": "echo 0"
   },
   "keywords": [],

--- a/frameworks/non-keyed/vanillajs/package.json
+++ b/frameworks/non-keyed/vanillajs/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "build-dev": "echo 0",
+    "dev": "echo 0",
     "build-prod": "echo 0"
   },
   "keywords": [

--- a/frameworks/non-keyed/vue/package.json
+++ b/frameworks/non-keyed/vue/package.json
@@ -7,7 +7,7 @@
     "frameworkHomeURL": "https://vue.js.org/"
   },
   "scripts": {
-    "build-dev": "webpack --mode development --watch",
+    "dev": "webpack --mode development --watch",
     "build-prod": "webpack --mode production"
   },
   "keywords": [


### PR DESCRIPTION
Just renamed the `build-dev` scripts to just `dev` to avoid writing the extra `build-` part, since no file has `build-dev` and `dev` scripts at once.