### PR TITLE
feat(plaited): uses new features and improved  function for templating

### DIFF
--- a/frameworks/keyed/plaited/package-lock.json
+++ b/frameworks/keyed/plaited/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "plaited": "5.0.3"
+        "plaited": "5.3.0"
       },
       "devDependencies": {
-        "esbuild": "0.19.5"
+        "esbuild": "0.19.6"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.5.tgz",
-      "integrity": "sha512-bhvbzWFF3CwMs5tbjf3ObfGqbl/17ict2/uwOSfr3wmxDE6VdS2GqY/FuzIPe0q0bdhj65zQsvqfArI9MY6+AA==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.6.tgz",
+      "integrity": "sha512-muPzBqXJKCbMYoNbb1JpZh/ynl0xS6/+pLjrofcR3Nad82SbsCogYzUE6Aq9QT3cLP0jR/IVK/NHC9b90mSHtg==",
       "cpu": [
         "arm"
       ],
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.5.tgz",
-      "integrity": "sha512-5d1OkoJxnYQfmC+Zd8NBFjkhyCNYwM4n9ODrycTFY6Jk1IGiZ+tjVJDDSwDt77nK+tfpGP4T50iMtVi4dEGzhQ==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.6.tgz",
+      "integrity": "sha512-KQ/hbe9SJvIJ4sR+2PcZ41IBV+LPJyYp6V1K1P1xcMRup9iYsBoQn4MzE3mhMLOld27Au2eDcLlIREeKGUXpHQ==",
       "cpu": [
         "arm64"
       ],
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.5.tgz",
-      "integrity": "sha512-9t+28jHGL7uBdkBjL90QFxe7DVA+KGqWlHCF8ChTKyaKO//VLuoBricQCgwhOjA1/qOczsw843Fy4cbs4H3DVA==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.6.tgz",
+      "integrity": "sha512-VVJVZQ7p5BBOKoNxd0Ly3xUM78Y4DyOoFKdkdAe2m11jbh0LEU4bPles4e/72EMl4tapko8o915UalN/5zhspg==",
       "cpu": [
         "x64"
       ],
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.5.tgz",
-      "integrity": "sha512-mvXGcKqqIqyKoxq26qEDPHJuBYUA5KizJncKOAf9eJQez+L9O+KfvNFu6nl7SCZ/gFb2QPaRqqmG0doSWlgkqw==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.6.tgz",
+      "integrity": "sha512-91LoRp/uZAKx6ESNspL3I46ypwzdqyDLXZH7x2QYCLgtnaU08+AXEbabY2yExIz03/am0DivsTtbdxzGejfXpA==",
       "cpu": [
         "arm64"
       ],
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.5.tgz",
-      "integrity": "sha512-Ly8cn6fGLNet19s0X4unjcniX24I0RqjPv+kurpXabZYSXGM4Pwpmf85WHJN3lAgB8GSth7s5A0r856S+4DyiA==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.6.tgz",
+      "integrity": "sha512-QCGHw770ubjBU1J3ZkFJh671MFajGTYMZumPs9E/rqU52md6lIil97BR0CbPq6U+vTh3xnTNDHKRdR8ggHnmxQ==",
       "cpu": [
         "x64"
       ],
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.5.tgz",
-      "integrity": "sha512-GGDNnPWTmWE+DMchq1W8Sd0mUkL+APvJg3b11klSGUDvRXh70JqLAO56tubmq1s2cgpVCSKYywEiKBfju8JztQ==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.6.tgz",
+      "integrity": "sha512-J53d0jGsDcLzWk9d9SPmlyF+wzVxjXpOH7jVW5ae7PvrDst4kiAz6sX+E8btz0GB6oH12zC+aHRD945jdjF2Vg==",
       "cpu": [
         "arm64"
       ],
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.5.tgz",
-      "integrity": "sha512-1CCwDHnSSoA0HNwdfoNY0jLfJpd7ygaLAp5EHFos3VWJCRX9DMwWODf96s9TSse39Br7oOTLryRVmBoFwXbuuQ==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.6.tgz",
+      "integrity": "sha512-hn9qvkjHSIB5Z9JgCCjED6YYVGCNpqB7dEGavBdG6EjBD8S/UcNUIlGcB35NCkMETkdYwfZSvD9VoDJX6VeUVA==",
       "cpu": [
         "x64"
       ],
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.5.tgz",
-      "integrity": "sha512-lrWXLY/vJBzCPC51QN0HM71uWgIEpGSjSZZADQhq7DKhPcI6NH1IdzjfHkDQws2oNpJKpR13kv7/pFHBbDQDwQ==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.6.tgz",
+      "integrity": "sha512-G8IR5zFgpXad/Zp7gr7ZyTKyqZuThU6z1JjmRyN1vSF8j0bOlGzUwFSMTbctLAdd7QHpeyu0cRiuKrqK1ZTwvQ==",
       "cpu": [
         "arm"
       ],
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.5.tgz",
-      "integrity": "sha512-o3vYippBmSrjjQUCEEiTZ2l+4yC0pVJD/Dl57WfPwwlvFkrxoSO7rmBZFii6kQB3Wrn/6GwJUPLU5t52eq2meA==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.6.tgz",
+      "integrity": "sha512-HQCOrk9XlH3KngASLaBfHpcoYEGUt829A9MyxaI8RMkfRA8SakG6YQEITAuwmtzFdEu5GU4eyhKcpv27dFaOBg==",
       "cpu": [
         "arm64"
       ],
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.5.tgz",
-      "integrity": "sha512-MkjHXS03AXAkNp1KKkhSKPOCYztRtK+KXDNkBa6P78F8Bw0ynknCSClO/ztGszILZtyO/lVKpa7MolbBZ6oJtQ==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.6.tgz",
+      "integrity": "sha512-22eOR08zL/OXkmEhxOfshfOGo8P69k8oKHkwkDrUlcB12S/sw/+COM4PhAPT0cAYW/gpqY2uXp3TpjQVJitz7w==",
       "cpu": [
         "ia32"
       ],
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.5.tgz",
-      "integrity": "sha512-42GwZMm5oYOD/JHqHska3Jg0r+XFb/fdZRX+WjADm3nLWLcIsN27YKtqxzQmGNJgu0AyXg4HtcSK9HuOk3v1Dw==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.6.tgz",
+      "integrity": "sha512-82RvaYAh/SUJyjWA8jDpyZCHQjmEggL//sC7F3VKYcBMumQjUL3C5WDl/tJpEiKtt7XrWmgjaLkrk205zfvwTA==",
       "cpu": [
         "loong64"
       ],
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.5.tgz",
-      "integrity": "sha512-kcjndCSMitUuPJobWCnwQ9lLjiLZUR3QLQmlgaBfMX23UEa7ZOrtufnRds+6WZtIS9HdTXqND4yH8NLoVVIkcg==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.6.tgz",
+      "integrity": "sha512-8tvnwyYJpR618vboIv2l8tK2SuK/RqUIGMfMENkeDGo3hsEIrpGldMGYFcWxWeEILe5Fi72zoXLmhZ7PR23oQA==",
       "cpu": [
         "mips64el"
       ],
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.5.tgz",
-      "integrity": "sha512-yJAxJfHVm0ZbsiljbtFFP1BQKLc8kUF6+17tjQ78QjqjAQDnhULWiTA6u0FCDmYT1oOKS9PzZ2z0aBI+Mcyj7Q==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.6.tgz",
+      "integrity": "sha512-Qt+D7xiPajxVNk5tQiEJwhmarNnLPdjXAoA5uWMpbfStZB0+YU6a3CtbWYSy+sgAsnyx4IGZjWsTzBzrvg/fMA==",
       "cpu": [
         "ppc64"
       ],
@@ -220,9 +220,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.5.tgz",
-      "integrity": "sha512-5u8cIR/t3gaD6ad3wNt1MNRstAZO+aNyBxu2We8X31bA8XUNyamTVQwLDA1SLoPCUehNCymhBhK3Qim1433Zag==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.6.tgz",
+      "integrity": "sha512-lxRdk0iJ9CWYDH1Wpnnnc640ajF4RmQ+w6oHFZmAIYu577meE9Ka/DCtpOrwr9McMY11ocbp4jirgGgCi7Ls/g==",
       "cpu": [
         "riscv64"
       ],
@@ -236,9 +236,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.5.tgz",
-      "integrity": "sha512-Z6JrMyEw/EmZBD/OFEFpb+gao9xJ59ATsoTNlj39jVBbXqoZm4Xntu6wVmGPB/OATi1uk/DB+yeDPv2E8PqZGw==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.6.tgz",
+      "integrity": "sha512-MopyYV39vnfuykHanRWHGRcRC3AwU7b0QY4TI8ISLfAGfK+tMkXyFuyT1epw/lM0pflQlS53JoD22yN83DHZgA==",
       "cpu": [
         "s390x"
       ],
@@ -252,9 +252,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.5.tgz",
-      "integrity": "sha512-psagl+2RlK1z8zWZOmVdImisMtrUxvwereIdyJTmtmHahJTKb64pAcqoPlx6CewPdvGvUKe2Jw+0Z/0qhSbG1A==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.6.tgz",
+      "integrity": "sha512-UWcieaBzsN8WYbzFF5Jq7QULETPcQvlX7KL4xWGIB54OknXJjBO37sPqk7N82WU13JGWvmDzFBi1weVBajPovg==",
       "cpu": [
         "x64"
       ],
@@ -268,9 +268,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.5.tgz",
-      "integrity": "sha512-kL2l+xScnAy/E/3119OggX8SrWyBEcqAh8aOY1gr4gPvw76la2GlD4Ymf832UCVbmuWeTf2adkZDK+h0Z/fB4g==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.6.tgz",
+      "integrity": "sha512-EpWiLX0fzvZn1wxtLxZrEW+oQED9Pwpnh+w4Ffv8ZLuMhUoqR9q9rL4+qHW8F4Mg5oQEKxAoT0G+8JYNqCiR6g==",
       "cpu": [
         "x64"
       ],
@@ -284,9 +284,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.5.tgz",
-      "integrity": "sha512-sPOfhtzFufQfTBgRnE1DIJjzsXukKSvZxloZbkJDG383q0awVAq600pc1nfqBcl0ice/WN9p4qLc39WhBShRTA==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.6.tgz",
+      "integrity": "sha512-fFqTVEktM1PGs2sLKH4M5mhAVEzGpeZJuasAMRnvDZNCV0Cjvm1Hu35moL2vC0DOrAQjNTvj4zWrol/lwQ8Deg==",
       "cpu": [
         "x64"
       ],
@@ -300,9 +300,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.5.tgz",
-      "integrity": "sha512-dGZkBXaafuKLpDSjKcB0ax0FL36YXCvJNnztjKV+6CO82tTYVDSH2lifitJ29jxRMoUhgkg9a+VA/B03WK5lcg==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.6.tgz",
+      "integrity": "sha512-M+XIAnBpaNvaVAhbe3uBXtgWyWynSdlww/JNZws0FlMPSBy+EpatPXNIlKAdtbFVII9OpX91ZfMb17TU3JKTBA==",
       "cpu": [
         "x64"
       ],
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.5.tgz",
-      "integrity": "sha512-dWVjD9y03ilhdRQ6Xig1NWNgfLtf2o/STKTS+eZuF90fI2BhbwD6WlaiCGKptlqXlURVB5AUOxUj09LuwKGDTg==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.6.tgz",
+      "integrity": "sha512-2DchFXn7vp/B6Tc2eKdTsLzE0ygqKkNUhUBCNtMx2Llk4POIVMUq5rUYjdcedFlGLeRe1uLCpVvCmE+G8XYybA==",
       "cpu": [
         "arm64"
       ],
@@ -332,9 +332,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.5.tgz",
-      "integrity": "sha512-4liggWIA4oDgUxqpZwrDhmEfAH4d0iljanDOK7AnVU89T6CzHon/ony8C5LeOdfgx60x5cnQJFZwEydVlYx4iw==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.6.tgz",
+      "integrity": "sha512-PBo/HPDQllyWdjwAVX+Gl2hH0dfBydL97BAH/grHKC8fubqp02aL4S63otZ25q3sBdINtOBbz1qTZQfXbP4VBg==",
       "cpu": [
         "ia32"
       ],
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.5.tgz",
-      "integrity": "sha512-czTrygUsB/jlM8qEW5MD8bgYU2Xg14lo6kBDXW6HdxKjh8M5PzETGiSHaz9MtbXBYDloHNUAUW2tMiKW4KM9Mw==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.6.tgz",
+      "integrity": "sha512-OE7yIdbDif2kKfrGa+V0vx/B3FJv2L4KnIiLlvtibPyO9UkgO3rzYE0HhpREo2vmJ1Ixq1zwm9/0er+3VOSZJA==",
       "cpu": [
         "x64"
       ],
@@ -364,51 +364,52 @@
       }
     },
     "node_modules/@plaited/behavioral": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@plaited/behavioral/-/behavioral-5.0.3.tgz",
-      "integrity": "sha512-jDXDIsCZvOqQk98n6tnjR9VQCS96KN26g8B+rD0pyOa1HBP7XRsV5BvTug1jP/CflWxsXlh7tiBfICL1AJ5QJA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@plaited/behavioral/-/behavioral-5.3.0.tgz",
+      "integrity": "sha512-o0678jqSOax4S8a/RWrfQVovTnFBes+sJ19VGVdNoSVOYCxMjhgAg1A2VWklE6Priz0ZSk2zCmDnrSKdNQM2aw==",
       "dependencies": {
-        "@plaited/utils": "5.0.3"
+        "@plaited/utils": "5.3.0"
       },
       "engines": {
         "node": ">= v18.15.0"
       }
     },
     "node_modules/@plaited/component": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@plaited/component/-/component-5.0.3.tgz",
-      "integrity": "sha512-uxcV5lsok91okXiCB1P1SxqFeb5viHEjiKnPvDjif4Fa1NFr9eud6ygKETtJst1GUrs4lULJbOKUb/jYHZbPDg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@plaited/component/-/component-5.3.0.tgz",
+      "integrity": "sha512-MWdpOYzi55mBhCiCRmzllx5bHSgWpm3GFCsSX+OijFOBLY7v0zkquLIk1mMhBbRunypQ4xzr7taQKdVKa2PsTQ==",
       "dependencies": {
-        "@plaited/behavioral": "5.0.3",
-        "@plaited/jsx": "5.0.3"
+        "@plaited/behavioral": "5.3.0",
+        "@plaited/jsx": "5.3.0",
+        "@plaited/utils": "5.3.0"
       },
       "engines": {
         "node": ">= v18.15.0"
       }
     },
     "node_modules/@plaited/jsx": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@plaited/jsx/-/jsx-5.0.3.tgz",
-      "integrity": "sha512-SanFsGW9Wszvc62PA+PvRPq+gWHFUZxW7CyjQGDryLT1ZpzR+0sncnCfaUf80R1muhAhqfySbhzvmWapXY8OMQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@plaited/jsx/-/jsx-5.3.0.tgz",
+      "integrity": "sha512-RBYVU48tEjEoV7bzNgMqSI485xKgMXn/Z/bV/c4fg5ym9X+GFrv9qYCDVOwM1bUGCMYPLYEBrQu6h7YnkqhKWA==",
       "dependencies": {
-        "@plaited/utils": "5.0.3"
+        "@plaited/utils": "5.3.0"
       },
       "engines": {
         "node": ">= v18.15.0"
       }
     },
     "node_modules/@plaited/utils": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@plaited/utils/-/utils-5.0.3.tgz",
-      "integrity": "sha512-Z82wjdxV9+zslg5MtQ5LjDWshyQMinOkt3YnoUkNntmElUgmTv53lQ6t/Gdee9TP9KaEKsGNmbkGXwAI2ieHfg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@plaited/utils/-/utils-5.3.0.tgz",
+      "integrity": "sha512-J2Cgd8VYGX+wzZ7tTUWnsqlzbEEKeLlW/JkHFqKa9+vJL/pWAx2FtcQ+g56xv+0j4zf13ing2RKVaMdLPFINsw==",
       "engines": {
         "node": ">= v18.15.0"
       }
     },
     "node_modules/esbuild": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.5.tgz",
-      "integrity": "sha512-bUxalY7b1g8vNhQKdB24QDmHeY4V4tw/s6Ak5z+jJX9laP5MoQseTOMemAr0gxssjNcH0MCViG8ONI2kksvfFQ==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.6.tgz",
+      "integrity": "sha512-Xl7dntjA2OEIvpr9j0DVxxnog2fyTGnyVoQXAMQI6eR3mf9zCQds7VIKUDCotDgE/p4ncTgeRqgX8t5d6oP4Gw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -418,39 +419,38 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.19.5",
-        "@esbuild/android-arm64": "0.19.5",
-        "@esbuild/android-x64": "0.19.5",
-        "@esbuild/darwin-arm64": "0.19.5",
-        "@esbuild/darwin-x64": "0.19.5",
-        "@esbuild/freebsd-arm64": "0.19.5",
-        "@esbuild/freebsd-x64": "0.19.5",
-        "@esbuild/linux-arm": "0.19.5",
-        "@esbuild/linux-arm64": "0.19.5",
-        "@esbuild/linux-ia32": "0.19.5",
-        "@esbuild/linux-loong64": "0.19.5",
-        "@esbuild/linux-mips64el": "0.19.5",
-        "@esbuild/linux-ppc64": "0.19.5",
-        "@esbuild/linux-riscv64": "0.19.5",
-        "@esbuild/linux-s390x": "0.19.5",
-        "@esbuild/linux-x64": "0.19.5",
-        "@esbuild/netbsd-x64": "0.19.5",
-        "@esbuild/openbsd-x64": "0.19.5",
-        "@esbuild/sunos-x64": "0.19.5",
-        "@esbuild/win32-arm64": "0.19.5",
-        "@esbuild/win32-ia32": "0.19.5",
-        "@esbuild/win32-x64": "0.19.5"
+        "@esbuild/android-arm": "0.19.6",
+        "@esbuild/android-arm64": "0.19.6",
+        "@esbuild/android-x64": "0.19.6",
+        "@esbuild/darwin-arm64": "0.19.6",
+        "@esbuild/darwin-x64": "0.19.6",
+        "@esbuild/freebsd-arm64": "0.19.6",
+        "@esbuild/freebsd-x64": "0.19.6",
+        "@esbuild/linux-arm": "0.19.6",
+        "@esbuild/linux-arm64": "0.19.6",
+        "@esbuild/linux-ia32": "0.19.6",
+        "@esbuild/linux-loong64": "0.19.6",
+        "@esbuild/linux-mips64el": "0.19.6",
+        "@esbuild/linux-ppc64": "0.19.6",
+        "@esbuild/linux-riscv64": "0.19.6",
+        "@esbuild/linux-s390x": "0.19.6",
+        "@esbuild/linux-x64": "0.19.6",
+        "@esbuild/netbsd-x64": "0.19.6",
+        "@esbuild/openbsd-x64": "0.19.6",
+        "@esbuild/sunos-x64": "0.19.6",
+        "@esbuild/win32-arm64": "0.19.6",
+        "@esbuild/win32-ia32": "0.19.6",
+        "@esbuild/win32-x64": "0.19.6"
       }
     },
     "node_modules/plaited": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/plaited/-/plaited-5.0.3.tgz",
-      "integrity": "sha512-YpHIE+SM1VCIHhPzzhBZIPGPece6an2rv+BH8yXZpb31x5KHwIxoNvMlQIHC0eifzT4onW3uuxNosNWPtsibSw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/plaited/-/plaited-5.3.0.tgz",
+      "integrity": "sha512-wGRAhJ5J8DL8EzbN7yIK7cs1U4fBmgn6zveG0OWdrZoNJmfcwI/nFPVZR+oMLEIPNz4DS+lUL+BXgtQKE8BoyQ==",
       "dependencies": {
-        "@plaited/behavioral": "5.0.3",
-        "@plaited/component": "5.0.3",
-        "@plaited/jsx": "5.0.3",
-        "@plaited/utils": "5.0.3"
+        "@plaited/behavioral": "5.3.0",
+        "@plaited/component": "5.3.0",
+        "@plaited/jsx": "5.3.0"
       },
       "engines": {
         "node": ">= v18.15.0"

--- a/frameworks/keyed/plaited/package.json
+++ b/frameworks/keyed/plaited/package.json
@@ -5,10 +5,10 @@
   },
   "type": "module",
   "dependencies": {
-    "plaited": "5.0.3"
+    "plaited": "5.3.0"
   },
   "devDependencies": {
-    "esbuild": "0.19.5"
+    "esbuild": "0.19.6"
   },
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "plaited",

--- a/frameworks/keyed/plaited/src/main.tsx
+++ b/frameworks/keyed/plaited/src/main.tsx
@@ -1,217 +1,97 @@
-import { Component, PlaitProps, useStore, FT } from 'plaited'
+import { Component, PlaitProps, FT, SugaredElement, QuerySelector } from 'plaited'
 
-const TableRow:FT<{
-  id: number;
-  label: string;
-  selected: boolean
-}> = item => {
-  return (
-    <tr
-      id={item.id}
-      className={item.selected ? 'danger' : ''}
-      data-target={`row-${item.id}`}
-    >
-      <td className='col-md-1'>{item.id}</td>
-      <td className='col-md-4'>
-        <a data-target={`label`}>{item.label}</a>
-      </td>
-      <td data-id={item.id} className='col-md-1' data-interaction='delete'>
-        <a>
-          <span className='glyphicon glyphicon-remove' aria-hidden='true'>
-          </span>
-        </a>
-      </td>
-      <td className='col-md-6'></td>
-    </tr>
-  )
+let did = 1
+const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"],
+  colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"],
+  nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+
+const random = (max: number) => Math.round(Math.random() * 1000) % max
+
+type DataItem = { id: number, label: string }
+type Data = DataItem[]
+const buildData = (count: number): Data => {
+  const data = []
+  for (let i = 0; i < count; i++) {
+    data.push({
+      id: did++,
+      label: `${adjectives[random(adjectives.length)]} ${colours[random(colours.length)]} ${nouns[random(nouns.length)]}`
+    })
+  }
+  return data
 }
 
+const Button:FT<{ id: string, value?: number}> = (attrs) => (
+  <div className="col-sm-6 smallpad">
+    <button type='button' className='btn btn-primary btn-block' {...attrs} />
+  </div>
+)
+
+const template = <><link href="/css/currentStyle.css" rel="stylesheet" />
+<div className="container">
+  <div className="jumbotron"><div className="row">
+    <div className="col-md-6"><h1>Plaited-"keyed"</h1></div>
+    <div className="col-md-6"><div className="row">
+      <Button data-trigger={{ click: 'run' }} id='run' value={1000}>Create 1,000 rows</Button>
+      <Button data-trigger={{ click: 'run' }} id='runlots' value={10000}>Create 10,000 rows</Button>
+      <Button data-trigger={{ click: 'add' }} id='add' value={1000}>Append 1,000 rows</Button>
+      <Button data-trigger={{ click: 'update' }} id='update'>Update every 10th row</Button>
+      <Button data-trigger={{ click: 'clear' }} id='clear'>Clear</Button>
+      <Button data-trigger={{ click: 'swapRows' }} id='swaprows'>Swap Rows</Button>
+    </div></div>
+  </div></div>
+  <table className="table table-hover table-striped test-data"><tbody id="tbody"  data-target='tbody' data-trigger={{click: 'interact'}}/></table>
+</div>
+<span className="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
+<template data-target='template'>
+  <tr data-target="row">
+    <td className='col-md-1' data-target="id"></td>
+    <td className='col-md-4'><a data-target='label'></a></td>
+    <td className='col-md-1'><a><span className='glyphicon glyphicon-remove' aria-hidden='true' data-target='delete'></span></a></td>
+    <td className='col-md-6'></td>
+  </tr>
+</template></> 
+
+const forEachRow = ($: QuerySelector, data: DataItem)=> {
+  $('row')[0].attr('data-target', `${data.id}`)
+  $('id')[0].render(`${data.id}`)
+  $('label')[0].render(data.label)
+}
 
 class BenchMark extends Component({
   tag: 'js-benchmark',
-  template: <><link href="/css/currentStyle.css" rel="stylesheet" />
-    <div className="container">
-      <div className="jumbotron">
-        <div className="row">
-          <div className="col-md-6">
-            <h1>Plaited-next-"keyed"</h1>
-          </div>
-          <div className="col-md-6">
-            <div className="row">
-              <div className="col-sm-6 smallpad">
-                <button type='button' className='btn btn-primary btn-block' id='run'
-                  data-trigger={{ click: 'run' }}>Create 1,000
-                  rows</button>
-              </div>
-              <div className="col-sm-6 smallpad">
-                <button type='button' className='btn btn-primary btn-block' id='runlots'
-                  data-trigger={{ click: 'runLots' }}>Create 10,000
-                  rows</button>
-              </div>
-              <div className="col-sm-6 smallpad">
-                <button type='button' className='btn btn-primary btn-block' id='add'
-                  data-trigger={{ click: 'add' }}>Append 1,000
-                  rows</button>
-              </div>
-              <div className="col-sm-6 smallpad">
-                <button type='button' className='btn btn-primary btn-block' id='update'
-                  data-trigger={{ click: 'update' }}>Update every 10th
-                  row</button>
-              </div>
-              <div className="col-sm-6 smallpad">
-                <button type='button' className='btn btn-primary btn-block' id='clear'
-                  data-trigger={{ click: 'clear' }}>Clear</button>
-              </div>
-              <div className="col-sm-6 smallpad">
-                <button type='button' className='btn btn-primary btn-block' id='swaprows'
-                  data-trigger={{ click: 'swapRows' }}>Swap Rows</button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <table className="table table-hover table-striped test-data">
-        <tbody id="tbody" data-trigger={{ click: 'interact' }} data-target='tbody'>
-        </tbody>
-      </table>
-      <span className="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
-    </div>
-  </> 
+  template,
 }){
-  plait({ feedback, $, trigger }: PlaitProps) {
-    const adjectives = [
-      'pretty',
-      'large',
-      'big',
-      'small',
-      'tall',
-      'short',
-      'long',
-      'handsome',
-      'plain',
-      'quaint',
-      'clean',
-      'elegant',
-      'easy',
-      'angry',
-      'crazy',
-      'helpful',
-      'mushy',
-      'odd',
-      'unsightly',
-      'adorable',
-      'important',
-      'inexpensive',
-      'cheap',
-      'expensive',
-      'fancy',
-    ]
-    const colours = [
-      'red',
-      'yellow',
-      'blue',
-      'green',
-      'pink',
-      'brown',
-      'purple',
-      'brown',
-      'white',
-      'black',
-      'orange',
-    ]
-    const nouns = [
-      'table',
-      'chair',
-      'house',
-      'bbq',
-      'desk',
-      'car',
-      'pony',
-      'cookie',
-      'sandwich',
-      'burger',
-      'pizza',
-      'mouse',
-      'keyboard',
-    ]
-    const [getSelected, setSelected] = useStore(-1)
-    const random = (max: number) => {
-      return Math.round(Math.random() * 1000) % max
-    }
-    const tbody = $('tbody')
-    let did = parseInt(tbody?.lastElementChild?.id) || 1
-    const buildData = (count: number) => {
-      const data = []
-      for (let i = 0; i < count; i++) {
-        data.push({
-          id: did++,
-          label: `${adjectives[random(adjectives.length)]} ${colours[random(colours.length)]
-            } ${nouns[random(nouns.length)]}`,
-          selected: false,
-        })
-      }
-      return data
-    }
+  plait({ feedback, $ }: PlaitProps) {
+    let selected = -1
+    const [tbody] = $('tbody')
+    const cb =  $('template')[0].clone<DataItem>(forEachRow)
     feedback({
-      add() {
-        tbody?.render(
-          <>{buildData(1000).map((d) => <TableRow {...d} />)}</>,
-          'beforeend',
-        )
-      },
-      run() {
-        tbody?.render(
-          <>{buildData(1000).map((data) => <TableRow {...data} />)}</>,
-        )
-      },
-      runLots() {
-        tbody?.render(
-          <>{buildData(10000).map((data) => <TableRow {...data} />)}</>,
-        )
-      },
-      clear() {
-        tbody.replaceChildren()
-      },
-      interact(e: MouseEvent) {
-        const td = (e.target as HTMLElement)?.closest<HTMLTableCellElement>(
-          'td',
-        )
-        if (td) {
-          const interaction = td.dataset.interaction
-          const id = parseInt(td.parentElement.id)
-
-          if (interaction === 'delete') {
-            trigger({ type: 'delete', detail: { id } })
-          } else {
-            trigger({ type: 'select', detail: { id } })
-          }
+      add(evt: MouseEvent& { target: HTMLButtonElement }){tbody.insert('beforeend',...buildData(parseInt(evt.target.value)).map(cb))},
+      run(evt: MouseEvent& { target: HTMLButtonElement }){tbody.render(...buildData(parseInt(evt.target.value)).map(cb))},
+      clear(){tbody.replaceChildren()},
+      interact(evt: MouseEvent & { target: HTMLElement }) {
+        const target = evt.target
+        if (target.dataset.target === 'delete') return target.closest('tr').remove()
+        if(target.dataset.target === 'label') {
+          if (selected > -1) {$(`${selected}`)[0]?.attr('class', null)}
+          const row = target.closest<SugaredElement>('tr')
+          row.attr('class', 'danger')
+          selected = parseInt(row.dataset.target)
         }
-      },
-      delete({ id }: { id: number }) {
-        $(`row-${id}`)?.remove()
-      },
-      select({ id }: { id: number }) {
-        const cur = getSelected()
-        if (cur > -1) {
-          $(`row-${cur}`)?.attr('class', null)
-        }
-        $(`row-${id}`)?.attr('class', 'danger')
-        setSelected(id)
       },
       swapRows() {
-        const rows = $('row', { all: true, mod: '^=' })
-        tbody?.insertBefore(rows[1], rows[999])
-        tbody?.insertBefore(rows[998], rows[2])
+        const rows = Array.from($('tbody')[0].childNodes)
+        tbody.insertBefore(rows[1], rows[999])
+        tbody.insertBefore(rows[998], rows[2])
       },
       update() {
-        const labels = $('label', { all: true })
+        const labels = $('label')
         const length = labels.length
         for (let i = 0; i < length; i += 10) {
-          labels[i].textContent = labels[i].textContent + ' !!!'
+          labels[i].insert('beforeend', ' !!!')
         }
       },
     })
   }
 }
-
-  customElements.define(BenchMark.tag, BenchMark)
+customElements.define(BenchMark.tag, BenchMark)


### PR DESCRIPTION
This PR is for 5.3.0 of Plaited
This version
- drops **useStore** (doesn't make sense with library architecture and coding style)
- splits **$.render** into **$.render** and **$.insert** The later which use the same interface pattern as ` insertAdjacentElement` but takes a spread like `append | prepend | before | after`
- introduces a new **$.clone** method that can be used to clone an element with a **data-target** attribute and apply a callback to the clone before usage. Useful for handling large list and reducing parse time. 
- makes use of a streamlined **createTemplate** aka **h** function to improve templating script times. 

Glad this benchmark repo exist @krausest! It's been super useful in improving my library.