### PR TITLE
`karyon` update

### DIFF
--- a/frameworks/keyed/karyon/package.json
+++ b/frameworks/keyed/karyon/package.json
@@ -7,7 +7,7 @@
     "issues": [801]
   },
   "dependencies": {
-    "karyon": "1.8.1"
+    "karyon": "^2.0.0"
   },
   "devDependencies": {
     "esbuild": "0.19.2"

--- a/frameworks/keyed/karyon/package.json
+++ b/frameworks/keyed/karyon/package.json
@@ -10,7 +10,7 @@
     "karyon": "^2.0.0"
   },
   "devDependencies": {
-    "esbuild": "0.19.2"
+    "esbuild": "^0.19.7"
   },
   "scripts": {
     "dev":"esbuild src/app.js --outfile=dist/app.js --bundle --watch",

--- a/frameworks/keyed/karyon/src/app.js
+++ b/frameworks/keyed/karyon/src/app.js
@@ -17,6 +17,13 @@ const remove = (filter => function () {
     rows(rows().filter(filter, this.ID));
 })(function (row) { return row?.ID !== this; });
 
+const track = (ref, value, resolve) => {
+    const tracker = State(resolve(State.peek(ref) === value));
+    return State.on(ref, (i, o) =>
+        i === value ? tracker(resolve(true)) :
+        o === value && tracker(resolve(false))), tracker;
+};
+
 const Row = (selected => (ID, text) =>
     ({is: 'tr', content: [
         {is: 'td', class: 'col-md-1', content: ID},
@@ -25,7 +32,7 @@ const Row = (selected => (ID, text) =>
         {is: 'td', class: 'col-md-1', content:
             {is: 'a', action: remove, content: Icon('')}},
         {is: 'td', class: 'col-md-6'}
-    ], class: State.track(selection, ID, selected), ID, text})
+    ], class: track(selection, ID, selected), ID, text})
 )(on => on && 'danger');
 
 const Icon = name =>


### PR DESCRIPTION
This updates the `karyon` module version, also implementation due to removal of the so-called "selector" API, a peculiar feature not really compliant with the module concept. Frankly speaking, it was just a crutch for [#800](https://github.com/krausest/js-framework-benchmark/issues/800) issue. However, a naive approach will hurt performance, thus a similar "selector" was added into the implementation itself, hopefully it won't be a subject for new note, sort of "explicit select delegation".