### PR TITLE
Update cample to v.3.2.0-beta.7

### DIFF
--- a/frameworks/keyed/cample/package-lock.json
+++ b/frameworks/keyed/cample/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-beta.6",
+  "version": "3.2.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-cample",
-      "version": "3.2.0-beta.6",
+      "version": "3.2.0-beta.7",
       "license": "MIT",
       "dependencies": {
-        "cample": "3.2.0-beta.6"
+        "cample": "3.2.0-beta.7"
       },
       "devDependencies": {
         "@babel/core": "7.21.3",
@@ -2102,9 +2102,9 @@
       "dev": true
     },
     "node_modules/cample": {
-      "version": "3.2.0-beta.6",
-      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-beta.6.tgz",
-      "integrity": "sha512-2xHKpyGXJetU5IxJtVE6/dq5veMBbLu1zP70X06djfL2pb4w5YAnlzJ7Eh85/+uMNk2AGzOjPxoru5MiKe19qw==",
+      "version": "3.2.0-beta.7",
+      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-beta.7.tgz",
+      "integrity": "sha512-TsVUvkc9u8aygY7y3fm841XyUtTaIFfTlDMzx6muJRy1ai27drr//ktZsh0qYooJlaCjk7Sk+XPFLGIwHHeooQ==",
       "engines": {
         "node": ">=10.12.0"
       }

--- a/frameworks/keyed/cample/package.json
+++ b/frameworks/keyed/cample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-beta.6",
+  "version": "3.2.0-beta.7",
   "description": "cample demo",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -29,6 +29,6 @@
     "webpack-cli": "5.0.1"
   },
   "dependencies": {
-    "cample": "3.2.0-beta.6"
+    "cample": "3.2.0-beta.7"
   }
 }


### PR DESCRIPTION
Optimized the assembly of templates for rows, made select row a little faster. I think this will work for 1.10, but not 1.08-1.09. I don’t know anymore, it’s unlikely that before the new year it will be possible to implement the code that I had in mind, but I think the result will be cool. Due to the specific syntax, “select row” is of course too slow, result certainly stands out from all the green ones, but I think there are still optimization ideas, so that’s fine.