### PR TITLE
Update cample to v3.2.0-beta.8

### DIFF
--- a/frameworks/keyed/cample/package-lock.json
+++ b/frameworks/keyed/cample/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-beta.7",
+  "version": "3.2.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-cample",
-      "version": "3.2.0-beta.7",
+      "version": "3.2.0-beta.8",
       "license": "MIT",
       "dependencies": {
-        "cample": "3.2.0-beta.7"
+        "cample": "3.2.0-beta.8"
       },
       "devDependencies": {
         "@babel/core": "7.21.3",
@@ -2102,9 +2102,9 @@
       "dev": true
     },
     "node_modules/cample": {
-      "version": "3.2.0-beta.7",
-      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-beta.7.tgz",
-      "integrity": "sha512-TsVUvkc9u8aygY7y3fm841XyUtTaIFfTlDMzx6muJRy1ai27drr//ktZsh0qYooJlaCjk7Sk+XPFLGIwHHeooQ==",
+      "version": "3.2.0-beta.8",
+      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-beta.8.tgz",
+      "integrity": "sha512-0BAsra9Q3f6aKrhaLyDza3N2zD+u3Ysx2OWhCMbDRLdKsyI89R2sfBrqtwWMkfHq61gTN9qBfIznuUMsdHz/uQ==",
       "engines": {
         "node": ">=10.12.0"
       }

--- a/frameworks/keyed/cample/package.json
+++ b/frameworks/keyed/cample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-beta.7",
+  "version": "3.2.0-beta.8",
   "description": "cample demo",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -29,6 +29,6 @@
     "webpack-cli": "5.0.1"
   },
   "dependencies": {
-    "cample": "3.2.0-beta.7"
+    "cample": "3.2.0-beta.8"
   }
 }


### PR DESCRIPTION
Overall, I think I've fixed a lot of bugs now that were slowing down results. Perhaps now it will be possible to fix “select row” and make the results for this test satisfactory. I believe that the syntax of the framework will allow the results to reach even the level of 1.04-1.06, but it feels like the code is at level 1.08-1.10 now. Next, it will be necessary to redo the assembly of templates, I think this is already work for about a couple of weeks or months, so I hope the next pull request for the test will be in 2024 (I think I didn’t break anything. I tested , but who knows what could break there).

Thank you very much for devoting your time to review and test the implementation of this framework. Happy New Year 2024!