### PR TITLE
Add Reken framework version 0.9.6

### DIFF
--- a/frameworks/non-keyed/reken/index.html
+++ b/frameworks/non-keyed/reken/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <link href="/css/currentStyle.css" rel="stylesheet" />
+</head>
+
+<body>
+  <div id="main">
+    <div class="container">
+      <div class="jumbotron">
+        <div class="row">
+          <div class="col-md-6">
+            <h1>Reken</h1>
+          </div>
+          <div class="col-md-6">
+            <div class="row">
+              <div class="col-sm-6 smallpad">
+                <button type="button" class="btn btn-primary btn-block" id="run"
+                  data-action="store.run()">
+                  Create 1,000 rows
+                </button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button type="button" class="btn btn-primary btn-block" id="runlots"
+                  data-action="store.runLots()">
+                  Create 10,000 rows
+                </button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button type="button" class="btn btn-primary btn-block" id="add"
+                  data-action="store.add()">
+                  Append 1,000 rows
+                </button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button type="button" class="btn btn-primary btn-block" id="update"
+                  data-action="store.update()">
+                  Update every 10th row
+                </button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button type="button" class="btn btn-primary btn-block" id="clear"
+                  data-action="store.clear()">
+                  Clear
+                </button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button type="button" class="btn btn-primary btn-block" id="swaprows"
+                  data-action="store.swapRows()">
+                  Swap Rows
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <table class="table table-hover table-striped test-data">
+        <tbody id="tbody" data-for="row:store.data">
+          <tr data-class="danger:store.selected===row.item.id">
+            <td class="col-md-1" data-text="${row.item.id}"></td>
+            <td class="col-md-4">
+              <a class="lbl" data-text="${row.item.label}" data-action="store.select(row.item.id)"></a>
+            </td>
+            <td class="col-md-1">
+              <a class="remove" data-action="store.delete(row.item.id)">
+                <span class="remove glyphicon glyphicon-remove" aria-hidden="true"></span>
+              </a>
+            </td>
+            <td class="col-md-6"></td>
+          </tr>
+        </tbody>
+      </table>
+      <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
+    </div>
+  </div>
+  <script src="js/Main.js"></script>
+  <script src="js/reken.js"></script>
+</body>
+
+</html>

--- a/frameworks/non-keyed/reken/js/Main.js
+++ b/frameworks/non-keyed/reken/js/Main.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/* Derived from the vanillajs Main.js, just the Store class */
+
+function _random(max) {
+    return Math.round(Math.random()*1000)%max;
+}
+
+class Store {
+    constructor() {
+        this.data = [];
+        this.backup = null;
+        this.selected = null;
+        this.id = 1;
+    }
+    buildData(count = 1000) {
+        var adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"];
+        var colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"];
+        var nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+        var data = [];
+        for (var i = 0; i < count; i++)
+            data.push({id: this.id++, label: adjectives[_random(adjectives.length)] + " " + colours[_random(colours.length)] + " " + nouns[_random(nouns.length)] });
+        return data;
+    }
+    updateData(mod = 10) {
+        for (let i=0;i<this.data.length;i+=10) {
+            this.data[i].label += ' !!!';
+        }
+    }
+    delete(id) {
+        const idx = this.data.findIndex(d => d.id==id);
+        this.data = this.data.filter((e,i) => i!=idx);
+        return this;
+    }
+    run() {
+        this.data = this.buildData();
+        this.selected = null;
+    }
+    add() {
+        this.data = this.data.concat(this.buildData(1000));
+        this.selected = null;
+    }
+    update() {
+        this.updateData();
+        this.selected = null;
+    }
+    select(id) {
+        this.selected = id;
+    }
+    hideAll() {
+        this.backup = this.data;
+        this.data = [];
+        this.selected = null;
+    }
+    showAll() {
+        this.data = this.backup;
+        this.backup = null;
+        this.selected = null;
+    }
+    runLots() {
+        this.data = this.buildData(10000);
+        this.selected = null;
+    }
+    clear() {
+        this.data = [];
+        this.selected = null;
+    }
+    swapRows() {
+        if(this.data.length > 998) {
+            var a = this.data[1];
+            this.data[1] = this.data[998];
+            this.data[998] = a;
+        }
+    }
+}
+
+const store = new Store();
+function runXTimes(func, times) {
+    console.time('XTimes')
+    const start = performance.now();
+    for (let i = 0; i<times;i++) {
+        store.runLots();
+        reken.force_calculate();
+    }
+    const end = performance.now();
+    const duration = end-start;
+    const avg = duration/times;
+    console.timeEnd('XTimes')
+    console.log(duration, avg)
+}

--- a/frameworks/non-keyed/reken/js/reken.js
+++ b/frameworks/non-keyed/reken/js/reken.js
@@ -1,0 +1,1 @@
+/Users/henry/develop/reken/src/reken.js

--- a/frameworks/non-keyed/reken/package-lock.json
+++ b/frameworks/non-keyed/reken/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "js-framework-benchmark-reken",
+  "version": "0.9.6",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "js-framework-benchmark-reken",
+      "version": "0.9.6",
+      "license": "MIT"
+    }
+  }
+}

--- a/frameworks/non-keyed/reken/package.json
+++ b/frameworks/non-keyed/reken/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "js-framework-benchmark-reken",
+  "version": "0.9.6",
+  "description": "Benchmark for Reken framework",
+  "main": "index.js",
+  "js-framework-benchmark": {
+    "frameworkVersion": "0.9.6",
+    "frameworkHomeURL": "https://reken.dev",
+    "issues": [
+      1139
+    ]
+  },
+  "scripts": {
+    "dev": "exit 0",
+    "build-prod": "exit 0"
+  },
+  "keywords": [
+    "Reken",
+    "HTML first",
+    "UI",
+    "UI Framework",
+    "Reactive",
+    "DOM",
+    "DOM Manipulation",
+    "Zero-Dependency",
+    "React"
+  ],
+  "author": "Henry van den Broek",
+  "license": "MIT",
+  "homepage": "https://reken.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hbroek/reken.git"
+  }
+}


### PR DESCRIPTION
Add Reken version v0.9.6 to non-keyed js-framework-benchmark.

I ran the verification:

<img width="569" alt="Screenshot 2024-01-07 at 2 46 01 PM" src="https://github.com/krausest/js-framework-benchmark/assets/17624088/46d70059-bede-4491-925a-9244725c4807">

Also ran the benchmark and a comparison against non-keyed vanillajs:

<img width="245" alt="Screenshot 2024-01-07 at 2 33 22 PM" src="https://github.com/krausest/js-framework-benchmark/assets/17624088/81068539-90d1-40c2-85e5-7cc77c3bf5e3">


