### PR TITLE
update glimmer-next [fix remove rows regression]

### DIFF
--- a/frameworks/keyed/gxt/package-lock.json
+++ b/frameworks/keyed/gxt/package-lock.json
@@ -13,7 +13,7 @@
         "@glint/environment-ember-template-imports": "^1.2.2",
         "@glint/environment-glimmerx": "^1.2.2",
         "@glint/template": "^1.2.2",
-        "@lifeart/gxt": "0.0.16",
+        "@lifeart/gxt": "0.0.21",
         "prettier": "^3.1.1",
         "prettier-plugin-ember-template-tag": "^2.0.0",
         "terser": "^5.26.0",
@@ -2684,9 +2684,9 @@
       }
     },
     "node_modules/@lifeart/gxt": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@lifeart/gxt/-/gxt-0.0.16.tgz",
-      "integrity": "sha512-gULBtpk3ks2CCBEFoLcdD7NNYEsPiTY/ECgBhQwlyQef0YZBRkSmTSuOWN73bNN09Lk6/+bExLtHZnYPN4Ulmg==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@lifeart/gxt/-/gxt-0.0.21.tgz",
+      "integrity": "sha512-mSmatvLSXmyStHQKS/GEZ3avPMlJRd0gD/UiLSekIvoOjaXOAxkpd4Mkve0VOT4mOe47VR/U6lKY5ep+/mC1tw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.23.6",

--- a/frameworks/keyed/gxt/package.json
+++ b/frameworks/keyed/gxt/package.json
@@ -22,7 +22,7 @@
     "@glint/environment-ember-template-imports": "^1.2.2",
     "@glint/environment-glimmerx": "^1.2.2",
     "@glint/template": "^1.2.2",
-    "@lifeart/gxt": "0.0.16",
+    "@lifeart/gxt": "0.0.21",
     "prettier": "^3.1.1",
     "prettier-plugin-ember-template-tag": "^2.0.0",
     "terser": "^5.26.0"

--- a/frameworks/keyed/gxt/src/main.ts
+++ b/frameworks/keyed/gxt/src/main.ts
@@ -1,5 +1,4 @@
 import { renderComponent } from '@lifeart/gxt';
 import { Application } from './App.gts';
-
 // @ts-expect-error app is unknown
-renderComponent(new Application().template(), window['app']);
+renderComponent(new Application({}), window['app']);

--- a/frameworks/keyed/gxt/vite.config.mts
+++ b/frameworks/keyed/gxt/vite.config.mts
@@ -27,9 +27,7 @@ export default defineConfig(({ mode }) => ({
       mangle: {
         module: true,
         toplevel: true,
-        properties: {
-          builtins: false,
-        },
+        properties: false,
       },
     },
   },


### PR DESCRIPTION
Fixed `clear row regression` (44ms -> 25ms)

<img width="518" alt="image" src="https://github.com/krausest/js-framework-benchmark/assets/1360552/0abc0f69-114e-41fa-b7cc-d740dba39fa4">

