### PR TITLE
Update Mikado

### DIFF
--- a/frameworks/keyed/mikado-proxy/package-lock.json
+++ b/frameworks/keyed/mikado-proxy/package-lock.json
@@ -7,7 +7,7 @@
       "name": "js-framework-benchmark-keyed-mikado-proxy",
       "license": "Apache-2.0",
       "dependencies": {
-        "mikado": "^0.8.222"
+        "mikado": "^0.8.227"
       },
       "devDependencies": {
         "google-closure-compiler": "^20230802.0.0"
@@ -203,9 +203,9 @@
       "dev": true
     },
     "node_modules/mikado": {
-      "version": "0.8.222",
-      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.8.222.tgz",
-      "integrity": "sha512-q/bxALiBCLNuSZ+JL8LIF+zAsEULjk8dAc+fI5H03IEX9dsLt8fpFx6QfJ8ttIAnAaAOdo+NcI5lhgED9pmF4w==",
+      "version": "0.8.227",
+      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.8.227.tgz",
+      "integrity": "sha512-2Gwh/cjboIxzpBkVG1uMp/+qQ9LQ31qnL0Y4LDRPnewY80KVzRVEr5gkV/F7B/5/v42Mknq8832SYvuDvxNwzQ==",
       "dependencies": {
         "html2json": "^1.0.2"
       },

--- a/frameworks/keyed/mikado-proxy/package.json
+++ b/frameworks/keyed/mikado-proxy/package.json
@@ -17,11 +17,11 @@
   },
   "scripts": {
     "compile": "npx mikado-compile --src src/template --module --inline --force && echo Compile Complete. && exit 0",
-    "build": "npm run compile && node task/build RELEASE=custom DEBUG=false POLYFILL=false SUPPORT_CACHE=true SUPPORT_EVENTS=true SUPPORT_DOM_HELPERS=false SUPPORT_ASYNC=false SUPPORT_REACTIVE=true REACTIVE_ONLY=true SUPPORT_CACHE_HELPERS=false SUPPORT_KEYED=true SUPPORT_POOLS=false SUPPORT_CALLBACKS=false SUPPORT_COMPILE=false SUPPORT_WEB_COMPONENTS=false && exit 0",
+    "build": "npm run compile && node task/build RELEASE=custom DEBUG=false POLYFILL=false SUPPORT_CACHE=true SUPPORT_EVENTS=true SUPPORT_DOM_HELPERS=false SUPPORT_ASYNC=false SUPPORT_REACTIVE=true REACTIVE_ONLY=true SUPPORT_CACHE_HELPERS=false SUPPORT_KEYED=true SUPPORT_POOLS=false SUPPORT_CALLBACKS=false SUPPORT_COMPILE=false SUPPORT_WEB_COMPONENTS=false SUPPORT_COMPACT_TEMPLATE=false && exit 0",
     "build-prod": "npm run build"
   },
   "dependencies": {
-    "mikado": "^0.8.222"
+    "mikado": "^0.8.227"
   },
   "devDependencies": {
     "google-closure-compiler": "^20230802.0.0"

--- a/frameworks/keyed/mikado-proxy/src/main.js
+++ b/frameworks/keyed/mikado-proxy/src/main.js
@@ -7,31 +7,30 @@ import assignData from "./data.js";
 
 once(document.body, tpl_app).eventCache = true;
 
-// This implementation is using a full reactive paradigm.
-// It just applies changes to the store like an Array.
-
 const store = new Array();
-const view = new Mikado(tpl_item, { mount: document.getElementById("tbody"), observe: store });
-const event = { stop: true, cancel: true };
+const view = new Mikado(tpl_item, {
+    mount: document.getElementById("tbody"),
+    observe: store
+});
 
-route("run", () => assignData(store, 1000), event);
-route("runlots", () => assignData(store, 10000), event);
-route("add", () => assignData(store, 1000, /* append */ true), event);
+route("run", () => assignData(store, 1000));
+route("runlots", () => assignData(store, 10000));
+route("add", () => assignData(store, 1000, /* append */ true));
 route("update", () => {
     for(let i = 0, len = store.length; i < len; i += 10)
         store[i].label += " !!!"
-}, event);
-route("clear", () => store.splice(), event);
+});
+route("clear", () => store.splice());
 route("swaprows", () => {
     const tmp = store[998];
     store[998] = store[1];
     store[1] = tmp;
-}, event);
-route("remove", target => store.splice(view.index(target), 1), event);
+});
+route("remove", target => store.splice(view.index(target), 1));
 route("select", target => {
     const state = view.state;
     const current = state.selected;
     state.selected = view.index(target);
     current >= 0 && view.update(current, store[current]);
     view.update(state.selected, store[state.selected]);
-}, event);
+});

--- a/frameworks/keyed/mikado/package-lock.json
+++ b/frameworks/keyed/mikado/package-lock.json
@@ -7,81 +7,10 @@
       "name": "js-framework-benchmark-keyed-mikado",
       "license": "Apache-2.0",
       "dependencies": {
-        "mikado": "^0.8.222"
+        "mikado": "^0.8.227"
       },
       "devDependencies": {
-        "google-closure-compiler": "^20230802.0.0",
-        "terser": "^5.26.0"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
-      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.21",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
-      "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
+        "google-closure-compiler": "^20230802.0.0"
       }
     },
     "node_modules/ansi-styles": {
@@ -98,12 +27,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -280,9 +203,9 @@
       "dev": true
     },
     "node_modules/mikado": {
-      "version": "0.8.222",
-      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.8.222.tgz",
-      "integrity": "sha512-q/bxALiBCLNuSZ+JL8LIF+zAsEULjk8dAc+fI5H03IEX9dsLt8fpFx6QfJ8ttIAnAaAOdo+NcI5lhgED9pmF4w==",
+      "version": "0.8.227",
+      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.8.227.tgz",
+      "integrity": "sha512-2Gwh/cjboIxzpBkVG1uMp/+qQ9LQ31qnL0Y4LDRPnewY80KVzRVEr5gkV/F7B/5/v42Mknq8832SYvuDvxNwzQ==",
       "dependencies": {
         "html2json": "^1.0.2"
       },
@@ -350,25 +273,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -389,30 +293,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/terser": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
-      "integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/frameworks/keyed/mikado/package.json
+++ b/frameworks/keyed/mikado/package.json
@@ -17,11 +17,11 @@
   },
   "scripts": {
     "compile": "npx mikado-compile --src src/template --module --inline --force && echo Compile Complete. && exit 0",
-    "build": "npm run compile && node task/build RELEASE=custom DEBUG=false POLYFILL=false SUPPORT_CACHE=true SUPPORT_EVENTS=true SUPPORT_DOM_HELPERS=false SUPPORT_ASYNC=false SUPPORT_REACTIVE=false SUPPORT_CACHE_HELPERS=false SUPPORT_KEYED=true SUPPORT_POOLS=false SUPPORT_CALLBACKS=false SUPPORT_COMPILE=false SUPPORT_WEB_COMPONENTS=false && exit 0",
+    "build": "npm run compile && node task/build RELEASE=custom DEBUG=false POLYFILL=false SUPPORT_CACHE=true SUPPORT_EVENTS=true SUPPORT_DOM_HELPERS=false SUPPORT_ASYNC=false SUPPORT_REACTIVE=false SUPPORT_CACHE_HELPERS=false SUPPORT_KEYED=true SUPPORT_POOLS=false SUPPORT_CALLBACKS=false SUPPORT_COMPILE=false SUPPORT_WEB_COMPONENTS=false SUPPORT_COMPACT_TEMPLATE=false && exit 0",
     "build-prod": "npm run build"
   },
   "dependencies": {
-    "mikado": "^0.8.222"
+    "mikado": "^0.8.227"
   },
   "devDependencies": {
     "google-closure-compiler": "^20230802.0.0"

--- a/frameworks/keyed/mikado/src/main.js
+++ b/frameworks/keyed/mikado/src/main.js
@@ -7,30 +7,29 @@ import buildData from "./data.js";
 once(document.body, tpl_app).eventCache = true;
 
 const view = new Mikado(tpl_item, { mount: document.getElementById("tbody") });
-const event = { stop: true, cancel: true };
 let data;
 
-route("run", () => view.render(data = buildData(1000)), event);
-route("runlots", () => view.render(buildData(10000)), event);
-route("add", () => view.append(data = buildData(1000)), event);
+route("run", () => view.clear().render(data = buildData(1000)));
+route("runlots", () => view.clear().render(data = buildData(10000)));
+route("add", () => view.append(data = buildData(1000)));
 route("update", () => {
     for(let i = 0; i < data.length; i += 10){
         data[i].label += " !!!";
         view.update(i, data[i]);
     }
-}, event);
-route("clear", () => view.clear(), event);
+});
+route("clear", () => view.clear());
 route("swaprows", () => {
     const tmp = data[1];
     data[1] = data[998]
     data[998] = tmp;
     view.render(data);
-}, event);
-route("remove", target => view.remove(target), event);
+});
+route("remove", target => view.remove(target));
 route("select", target => {
     const state = view.state;
     const current = state.selected;
     state.selected = view.index(target);
     current >= 0 && view.update(current, data[current]);
     view.update(state.selected, data[state.selected]);
-}, event);
+});

--- a/frameworks/non-keyed/mikado/package-lock.json
+++ b/frameworks/non-keyed/mikado/package-lock.json
@@ -7,7 +7,7 @@
       "name": "js-framework-benchmark-non-keyed-mikado",
       "license": "Apache-2.0",
       "dependencies": {
-        "mikado": "^0.8.222"
+        "mikado": "^0.8.227"
       },
       "devDependencies": {
         "google-closure-compiler": "^20230802.0.0"
@@ -203,9 +203,9 @@
       "dev": true
     },
     "node_modules/mikado": {
-      "version": "0.8.222",
-      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.8.222.tgz",
-      "integrity": "sha512-q/bxALiBCLNuSZ+JL8LIF+zAsEULjk8dAc+fI5H03IEX9dsLt8fpFx6QfJ8ttIAnAaAOdo+NcI5lhgED9pmF4w==",
+      "version": "0.8.227",
+      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.8.227.tgz",
+      "integrity": "sha512-2Gwh/cjboIxzpBkVG1uMp/+qQ9LQ31qnL0Y4LDRPnewY80KVzRVEr5gkV/F7B/5/v42Mknq8832SYvuDvxNwzQ==",
       "dependencies": {
         "html2json": "^1.0.2"
       },

--- a/frameworks/non-keyed/mikado/package.json
+++ b/frameworks/non-keyed/mikado/package.json
@@ -17,11 +17,11 @@
   },
   "scripts": {
     "compile": "npx mikado-compile --src src/template --module --inline --force && echo Compile Complete. && exit 0",
-    "build": "npm run compile && node task/build RELEASE=custom DEBUG=false POLYFILL=false SUPPORT_CACHE=true SUPPORT_EVENTS=true SUPPORT_STORAGE=false SUPPORT_DOM_HELPERS=false SUPPORT_ASYNC=false SUPPORT_REACTIVE=false SUPPORT_CACHE_HELPERS=false SUPPORT_KEYED=false SUPPORT_POOLS=false SUPPORT_CALLBACKS=false SUPPORT_COMPILE=false SUPPORT_WEB_COMPONENTS=false && exit 0",
+    "build": "npm run compile && node task/build RELEASE=custom DEBUG=false POLYFILL=false SUPPORT_CACHE=true SUPPORT_EVENTS=true SUPPORT_STORAGE=false SUPPORT_DOM_HELPERS=false SUPPORT_ASYNC=false SUPPORT_REACTIVE=false SUPPORT_CACHE_HELPERS=false SUPPORT_KEYED=false SUPPORT_POOLS=false SUPPORT_CALLBACKS=false SUPPORT_COMPILE=false SUPPORT_WEB_COMPONENTS=false SUPPORT_COMPACT_TEMPLATE=false && exit 0",
     "build-prod": "npm run build"
   },
   "dependencies": {
-    "mikado": "^0.8.222"
+    "mikado": "^0.8.227"
   },
   "devDependencies": {
     "google-closure-compiler": "^20230802.0.0"

--- a/frameworks/non-keyed/mikado/src/main.js
+++ b/frameworks/non-keyed/mikado/src/main.js
@@ -6,30 +6,32 @@ import buildData from "./data.js";
 
 once(document.body, tpl_app).eventCache = true;
 
-const view = new Mikado(tpl_item, { mount: document.getElementById("tbody"), recycle: true });
-const event = { stop: true, cancel: true };
-let data;
+const view = new Mikado(tpl_item, {
+    mount: document.getElementById("tbody"),
+    recycle: true
+});
 
-route("run", () => view.render(data = buildData(1000)), event);
-route("runlots", () => view.render(buildData(10000)), event);
-route("add", () => view.append(data = buildData(1000)), event);
+let data;
+route("run", () => view.render(data = buildData(1000)));
+route("runlots", () => view.render(data = buildData(10000)));
+route("add", () => view.append(data = buildData(1000)));
 route("update", () => {
     for(let i = 0; i < data.length; i += 10){
         data[i].label += " !!!";
         view.update(i, data[i]);
     }
-}, event);
-route("clear", () => view.clear(), event);
+});
+route("clear", () => view.clear());
 route("swaprows", () => {
     const tmp = data[998];
     view.update(998, data[998] = data[1]);
     view.update(1, data[1] = tmp);
-}, event);
-route("remove", target => view.remove(target), event);
+});
+route("remove", target => view.remove(target));
 route("select", target => {
     const state = view.state;
     const current = state.selected;
     state.selected = view.index(target);
     current >= 0 && view.update(current, data[current]);
     view.update(state.selected, data[state.selected]);
-}, event);
+});


### PR DESCRIPTION
The last feature "skip default DOM state" was way too optimistic :)
I found a situation where this optimization leads into a false state, because it collides with another performance ruleset. Mikado heavily uses runtime optimizations. Almost every optimization has its own cost. Since we can't predict the next render iteration (in a real world scenario) it isn't useful to fully apply every optimization in expectation a component will be recycled on next render loop. That's why Mikado uses a technique called "progressive enhancement", on which each iteration adds optimizations successively:

1. factory phase
2. vdom creation phase
3. full vdom access

To just "enhance" components which are already recycled for at least one time is a better approach. This limitation is because to reach "phase 3." isn't for free. I already tried several times to inject logic earlier (without adding too much cost). But this time I found a solid solution, because the "default DOM state" issue get me the hint. The new version is able to save almost 50% of the time needed for "phase 2." by doing this in "phase 1." by almost zero cost. All creation render tasks don't benefit from it, but "select", "swap", "update" should benefit from it. On specific render task I got an improvement of twice as fast. In this js-framework benchmark it might be a plus of 0.2 :)