### PR TITLE
Update Mikado

### DIFF
--- a/frameworks/keyed/mikado-proxy/package-lock.json
+++ b/frameworks/keyed/mikado-proxy/package-lock.json
@@ -7,7 +7,7 @@
       "name": "js-framework-benchmark-keyed-mikado-proxy",
       "license": "Apache-2.0",
       "dependencies": {
-        "mikado": "^0.8.227"
+        "mikado": "^0.8.309"
       },
       "devDependencies": {
         "google-closure-compiler": "^20230802.0.0"
@@ -203,9 +203,9 @@
       "dev": true
     },
     "node_modules/mikado": {
-      "version": "0.8.227",
-      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.8.227.tgz",
-      "integrity": "sha512-2Gwh/cjboIxzpBkVG1uMp/+qQ9LQ31qnL0Y4LDRPnewY80KVzRVEr5gkV/F7B/5/v42Mknq8832SYvuDvxNwzQ==",
+      "version": "0.8.309",
+      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.8.309.tgz",
+      "integrity": "sha512-X5Oh+JVtAt0C0oaunwxILxYtrA0FBD2u0XbJVVov9HO9dew/I1AC3izFel0EzO1vTK8r6Z+3dhRlhg4PQ5ehQA==",
       "dependencies": {
         "html2json": "^1.0.2"
       },

--- a/frameworks/keyed/mikado-proxy/package.json
+++ b/frameworks/keyed/mikado-proxy/package.json
@@ -21,7 +21,7 @@
     "build-prod": "npm run build"
   },
   "dependencies": {
-    "mikado": "^0.8.227"
+    "mikado": "^0.8.309"
   },
   "devDependencies": {
     "google-closure-compiler": "^20230802.0.0"

--- a/frameworks/keyed/mikado/package-lock.json
+++ b/frameworks/keyed/mikado/package-lock.json
@@ -7,7 +7,7 @@
       "name": "js-framework-benchmark-keyed-mikado",
       "license": "Apache-2.0",
       "dependencies": {
-        "mikado": "^0.8.227"
+        "mikado": "^0.8.309"
       },
       "devDependencies": {
         "google-closure-compiler": "^20230802.0.0"
@@ -203,9 +203,9 @@
       "dev": true
     },
     "node_modules/mikado": {
-      "version": "0.8.227",
-      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.8.227.tgz",
-      "integrity": "sha512-2Gwh/cjboIxzpBkVG1uMp/+qQ9LQ31qnL0Y4LDRPnewY80KVzRVEr5gkV/F7B/5/v42Mknq8832SYvuDvxNwzQ==",
+      "version": "0.8.309",
+      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.8.309.tgz",
+      "integrity": "sha512-X5Oh+JVtAt0C0oaunwxILxYtrA0FBD2u0XbJVVov9HO9dew/I1AC3izFel0EzO1vTK8r6Z+3dhRlhg4PQ5ehQA==",
       "dependencies": {
         "html2json": "^1.0.2"
       },

--- a/frameworks/keyed/mikado/package.json
+++ b/frameworks/keyed/mikado/package.json
@@ -21,7 +21,7 @@
     "build-prod": "npm run build"
   },
   "dependencies": {
-    "mikado": "^0.8.227"
+    "mikado": "^0.8.309"
   },
   "devDependencies": {
     "google-closure-compiler": "^20230802.0.0"

--- a/frameworks/non-keyed/mikado/package-lock.json
+++ b/frameworks/non-keyed/mikado/package-lock.json
@@ -7,7 +7,7 @@
       "name": "js-framework-benchmark-non-keyed-mikado",
       "license": "Apache-2.0",
       "dependencies": {
-        "mikado": "^0.8.227"
+        "mikado": "^0.8.309"
       },
       "devDependencies": {
         "google-closure-compiler": "^20230802.0.0"
@@ -203,9 +203,9 @@
       "dev": true
     },
     "node_modules/mikado": {
-      "version": "0.8.227",
-      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.8.227.tgz",
-      "integrity": "sha512-2Gwh/cjboIxzpBkVG1uMp/+qQ9LQ31qnL0Y4LDRPnewY80KVzRVEr5gkV/F7B/5/v42Mknq8832SYvuDvxNwzQ==",
+      "version": "0.8.309",
+      "resolved": "https://registry.npmjs.org/mikado/-/mikado-0.8.309.tgz",
+      "integrity": "sha512-X5Oh+JVtAt0C0oaunwxILxYtrA0FBD2u0XbJVVov9HO9dew/I1AC3izFel0EzO1vTK8r6Z+3dhRlhg4PQ5ehQA==",
       "dependencies": {
         "html2json": "^1.0.2"
       },

--- a/frameworks/non-keyed/mikado/package.json
+++ b/frameworks/non-keyed/mikado/package.json
@@ -21,7 +21,7 @@
     "build-prod": "npm run build"
   },
   "dependencies": {
-    "mikado": "^0.8.227"
+    "mikado": "^0.8.309"
   },
   "devDependencies": {
     "google-closure-compiler": "^20230802.0.0"


### PR DESCRIPTION
I've done some inspection on a Macbook and I found some strange performance issue which prevents the template functions to get optimized by JIT. Probably this will improve the run on your Mac.

My results (keyed):
![image](https://github.com/krausest/js-framework-benchmark/assets/12898005/b80cf5b5-5194-48b6-9889-e300f1d4ca17)
