### PR TITLE
Update Stencil to v4.11

### DIFF
--- a/frameworks/keyed/stencil/package-lock.json
+++ b/frameworks/keyed/stencil/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stencil/core": "^4.4.1"
+        "@stencil/core": "^4.11.0"
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.4.1.tgz",
-      "integrity": "sha512-SirGcrb5yKHCn2BwdM7HGVXuvCdmwiXlVczEj8jJxQIm42CAUQCUECxtZidTzp+oZBZnWLnoAvfanchJsgkQzA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.11.0.tgz",
+      "integrity": "sha512-zsKhgIkTGo+s7IthitxR/MKiMS3Ck1yIypOdXr0aE6ofboKqe9NdffTcxZ0vel0wD2bZYOb6WfPMzuhRKk6+FA==",
       "bin": {
         "stencil": "bin/stencil"
       },

--- a/frameworks/keyed/stencil/package.json
+++ b/frameworks/keyed/stencil/package.json
@@ -19,7 +19,7 @@
     "dev": "stencil build --dev --watch"
   },
   "dependencies": {
-    "@stencil/core": "^4.4.1"
+    "@stencil/core": "^4.11.0"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
This patch updates StencilJS to `v4.11`