### PR TITLE
Add pota

### DIFF
--- a/frameworks/keyed/pota/.gitignore
+++ b/frameworks/keyed/pota/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+css

--- a/frameworks/keyed/pota/index.html
+++ b/frameworks/keyed/pota/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Pota</title>
+    <link href="/css/currentStyle.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="main"></div>
+    <script src="dist/main.js"></script>
+  </body>
+</html>

--- a/frameworks/keyed/pota/package.json
+++ b/frameworks/keyed/pota/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "js-framework-benchmark-pota",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/main.js",
+  "js-framework-benchmark": {
+    "frameworkVersionFromPackage": "pota",
+    "frameworkHomeURL": "https://github.com/potahtml/pota"
+  },
+  "scripts": {
+    "build-dev": "rollup -c -w",
+    "build-prod": "rollup -c"
+  },
+  "author": "Tito Bouzout",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "dependencies": {
+    "pota": "^0.7.79"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.9",
+    "@rollup/plugin-babel": "^6.0.4",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-terser": "^0.4.4",
+    "rollup": "^4.9.6"
+  }
+}

--- a/frameworks/keyed/pota/rollup.config.js
+++ b/frameworks/keyed/pota/rollup.config.js
@@ -1,0 +1,30 @@
+import babel from "@rollup/plugin-babel";
+import resolve from "@rollup/plugin-node-resolve";
+import terser from "@rollup/plugin-terser";
+
+const outputOptions = {
+  format: "es",
+  sourcemap: false,
+};
+
+const plugins = [
+  resolve({}),
+  babel({
+    babelHelpers: "bundled",
+    presets: [["pota/babel-preset"]],
+  }),
+  terser(),
+];
+
+export default [
+  {
+    input: "./src/main.jsx",
+    plugins,
+    output: [
+      {
+        ...outputOptions,
+        file: "./dist/main.js",
+      },
+    ],
+  },
+];

--- a/frameworks/keyed/pota/src/main.jsx
+++ b/frameworks/keyed/pota/src/main.jsx
@@ -1,0 +1,188 @@
+import { render, signal, batch, For } from "pota";
+import { useSelector } from "pota/hooks";
+
+let idCounter = 1;
+const adjectives = [
+    "pretty",
+    "large",
+    "big",
+    "small",
+    "tall",
+    "short",
+    "long",
+    "handsome",
+    "plain",
+    "quaint",
+    "clean",
+    "elegant",
+    "easy",
+    "angry",
+    "crazy",
+    "helpful",
+    "mushy",
+    "odd",
+    "unsightly",
+    "adorable",
+    "important",
+    "inexpensive",
+    "cheap",
+    "expensive",
+    "fancy",
+  ],
+  colours = [
+    "red",
+    "yellow",
+    "blue",
+    "green",
+    "pink",
+    "brown",
+    "purple",
+    "brown",
+    "white",
+    "black",
+    "orange",
+  ],
+  nouns = [
+    "table",
+    "chair",
+    "house",
+    "bbq",
+    "desk",
+    "car",
+    "pony",
+    "cookie",
+    "sandwich",
+    "burger",
+    "pizza",
+    "mouse",
+    "keyboard",
+  ];
+
+function _random(max) {
+  return Math.round(Math.random() * 1000) % max;
+}
+
+function buildData(count) {
+  let data = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const [label, setLabel] = signal(
+      `${adjectives[_random(adjectives.length)]} ${
+        colours[_random(colours.length)]
+      } ${nouns[_random(nouns.length)]}`,
+    );
+    data[i] = {
+      id: idCounter++,
+      label,
+      setLabel,
+    };
+  }
+  return data;
+}
+
+const Button = ({ id, text, fn }) => (
+  <div class="col-sm-6 smallpad">
+    <button
+      id={id}
+      class="btn btn-primary btn-block"
+      type="button"
+      onClick={fn}
+    >
+      {text}
+    </button>
+  </div>
+);
+
+const App = () => {
+  const [data, setData] = signal([]),
+    [selected, setSelected] = signal(null),
+    run = () => setData(buildData(1000)),
+    runLots = () => {
+      setData(buildData(10000));
+    },
+    add = () => setData((d) => [...d, ...buildData(1000)]),
+    update = () =>
+      batch(() => {
+        for (let i = 0, d = data(), len = d.length; i < len; i += 10)
+          d[i].setLabel((l) => l + " !!!");
+      }),
+    swapRows = () => {
+      const d = data().slice();
+      if (d.length > 998) {
+        let tmp = d[1];
+        d[1] = d[998];
+        d[998] = tmp;
+        setData(d);
+      }
+    },
+    clear = () => setData([]),
+    remove = (id) =>
+      setData((d) => {
+        const idx = d.findIndex((datum) => datum.id === id);
+        d.splice(idx, 1);
+        return [...d];
+      }),
+    isSelected = useSelector(selected);
+
+  return (
+    <div class="container">
+      <div class="jumbotron">
+        <div class="row">
+          <div class="col-md-6">
+            <h1>pota Keyed</h1>
+          </div>
+          <div class="col-md-6">
+            <div class="row">
+              <Button id="run" text="Create 1,000 rows" fn={run} />
+              <Button id="runlots" text="Create 10,000 rows" fn={runLots} />
+              <Button id="add" text="Append 1,000 rows" fn={add} />
+              <Button id="update" text="Update every 10th row" fn={update} />
+              <Button id="clear" text="Clear" fn={clear} />
+              <Button id="swaprows" text="Swap Rows" fn={swapRows} />
+            </div>
+          </div>
+        </div>
+      </div>
+      <table
+        class="table table-hover table-striped test-data"
+        onClick={(e) => {
+          const element = e.target;
+          if (element.setSelected !== undefined) {
+            setSelected(element.setSelected);
+          } else if (element.removeRow !== undefined) {
+            remove(element.removeRow);
+          }
+        }}
+      >
+        <tbody>
+          <For each={data}>
+            {(row) => {
+              const { id, label } = row;
+
+              return (
+                <tr class:danger={isSelected(id)}>
+                  <td class="col-md-1" textContent={id} />
+                  <td class="col-md-4">
+                    <a textContent={label} prop:setSelected={id} />
+                  </td>
+                  <td class="col-md-1">
+                    <a>
+                      <span
+                        class="glyphicon glyphicon-remove"
+                        aria-hidden="true"
+                        prop:removeRow={id}
+                      />
+                    </a>
+                  </td>
+                  <td class="col-md-6" />
+                </tr>
+              );
+            }}
+          </For>
+        </tbody>
+      </table>
+      <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true" />
+    </div>
+  );
+};
+
+render(App, document.getElementById("main"));

--- a/frameworks/keyed/pota/tsconfig.json
+++ b/frameworks/keyed/pota/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "./dist",
+
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+
+    "module": "NodeNext",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "moduleResolution": "NodeNext",
+
+    "jsx": "react-jsx",
+    "jsxImportSource": "pota",
+
+    "sourceMap": true,
+
+    "types": ["pota"]
+  },
+  "exclude": ["./src/dist/*", "node_modules"]
+}


### PR DESCRIPTION
Hey! 

pota is a reactive web renderer for signals based reactive libraries. It's heavy influenced by Solid. The default reactive lib is solid, it can be switched to oby and flimsy, both by @fabiospampinato 
Source code is at https://github.com/potahtml/pota and docs on the website https://pota.quack.uy/

Note: I have been running the benchmark locally for months, but today something broke, and I can't figure out how to fix it.  I made sure it works by firing a server on the folder. Hope nothing is missing for the integration, thanks!
