### PR TITLE
Update cample to v.3.2.0-alpha.12

### DIFF
--- a/frameworks/keyed/cample/package-lock.json
+++ b/frameworks/keyed/cample/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.11",
+  "version": "3.2.0-alpha.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-cample",
-      "version": "3.2.0-alpha.11",
+      "version": "3.2.0-alpha.12",
       "license": "MIT",
       "dependencies": {
-        "cample": "3.2.0-alpha.11"
+        "cample": "3.2.0-alpha.12"
       },
       "devDependencies": {
         "@babel/core": "7.23.9",
@@ -2169,9 +2169,9 @@
       "dev": true
     },
     "node_modules/cample": {
-      "version": "3.2.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.11.tgz",
-      "integrity": "sha512-RCxco9iG+WEAYgcrPB7TMtWwdmQfH0CfC4c3z/uQaThFh/K0/QX9lTAe1p5NTDYnR+lsRbOKHmtt5DD+35/7tQ==",
+      "version": "3.2.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.12.tgz",
+      "integrity": "sha512-RHXTL2K9cwZIZE49ORoU6eDFfdQIl4QUVCFOx+07WKtUSxKtd/XJVBssfQwQWNDI9BqWWy4IvQ5GQLzZds/DxQ==",
       "engines": {
         "node": ">=10.12.0"
       }

--- a/frameworks/keyed/cample/package.json
+++ b/frameworks/keyed/cample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.11",
+  "version": "3.2.0-alpha.12",
   "description": "cample demo",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -29,6 +29,6 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    "cample": "3.2.0-alpha.11"
+    "cample": "3.2.0-alpha.12"
   }
 }


### PR DESCRIPTION
Hello! I hope the framework will have time to get into the results for version 122. In general, this pr I am 99.99999% sure that it will be 1.09 or lower!