### PR TITLE
[Ember]: Use native onclick

### DIFF
--- a/frameworks/keyed/ember/app/components/my-table.gjs
+++ b/frameworks/keyed/ember/app/components/my-table.gjs
@@ -116,8 +116,8 @@ export default class MyTable extends Component {
           {{#each this.data key="id" as |item|}}
             <tr class={{if (eq item.id this.selected) 'danger'}}>
               <td class="col-md-1">{{item.id}}</td>
-              <td class="col-md-4"><a {{on 'click' (fn this.select item)}}>{{item.label}}</a></td>
-              <td class="col-md-1"><a {{on 'click' (fn this.remove item)}}><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td>
+              <td class="col-md-4"><a onclick={{fn this.select item}}>{{item.label}}</a></td>
+              <td class="col-md-1"><a onclick={{fn this.remove item}}><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td>
               <td class="col-md-6"></td>
             </tr>
           {{/each}}


### PR DESCRIPTION
It's idiomatic to use `{{on}}` for event listening, and `{{on}}` is the only way to have _conditionally applied_ / dynamic event listeners, but for performance sensitive situations, we can _do less_ by using the platform, and we don't need any cleanup behavior, so native `onclick` should be sufficient, and I think I'm going to push for this being default in the ember learning materials

The improvement to speed _is noticeable_

There was a concern mentioned by a community member about `onclick` only being able to be set once, but [here is how this works in a real app](https://limber.glimdown.com/edit?c=MQAg9gdgxgNgllA1iALgUwM4oFDYLQgDaAUgMogBiATgIYC2aA7mFcgEJrQAWdNrIcOgAcqYAG5oGEFBgC6ACi4oUQjAC4A9BoDmcFFwCuAIwB0UMHQ2JaBjJhQaAVhjwAzWg2as8RzlB58iBpCBjAwGgCMAGwADAAcAJQg%2BEQAInAYULYYcJCoYCD%2BNBDaaCAAJmiuNKEoIGgS0iDwWJxoVKhoNP5wJXKKyqqaOnqGpuaWkr5UeDBdVBA6BnCVLhhgBlRQaBoZGAaYGgBMMTEAnAkphABKFADCqFw0dVh86OWPGQIQElhw2s9chAFEoVOotLp9MYzBYNFN2s4NFRXFAMMFQuEIqcAOyXbAAA0J2mczTgEhAIgacCY2EEQhYdTuFnpEE4dXcFhAAHIAALaeB0BhUDQTFlsrkAblpwgZIAA3qhaEg0B8AL4gDl0bl8gVCjQoJWIXraSXS%2BlUOoKvLqzXa%2BHCuhgcpwVzUqimumyhWuCAgG2iLW8%2B0aLhoGBCdqm7BoAAe5rqlWqtUKMBoGAwIAAEmGYGAAOosGAfWPoCDlDNMmWsppy7AgEA8g3dRAqwobJoAXhAMSl9cbhtbvSgVEkbLYAE8QF2IlK699h6POyB5EZx0kOwA%2BT4YGEGJoAai7q97ICMBmEAEloCOpHUu-J11v9BkTEOb2Px-v97P6wAedDCKm6AbnOf5CCB9aQSAAAqoZtnudRfHKcrPju5gIaqqomL%2BRhUBBUEgAAciWIAAESwAgiCkSAjBwGEp7nkIjxlOhTSrvKKFcC%2Bb6LigE6YaBIC-sEIGCThBjKHkkAUUgHbIT626vtevGKTxt78aqG53PASDCWekkQPhf76SgUnQDpiByZxL5npeym3phG5XguaZlM577SHpEmmYZc7CQBQhAWgIGqgShLYEAA&format=glimdown), and it appears to update as one would expect.


Results:

<table>
<thead>
<tr><th>Current</th>
<th>This PR</th>
</thead>
<tr><td>

![image](https://github.com/krausest/js-framework-benchmark/assets/199018/d31f497e-6f64-420e-b794-b20f72ed8960)


</td><td>

![image](https://github.com/krausest/js-framework-benchmark/assets/199018/6db8c9f6-2999-4273-8425-382672a46cf7)


</td>
</tr>

<tr><td>

![image](https://github.com/krausest/js-framework-benchmark/assets/199018/98de091e-0543-4f45-a3ce-58ae7583eea8)


</td>
<td>

![image](https://github.com/krausest/js-framework-benchmark/assets/199018/e82827f1-dbde-4a65-8bb8-354799165ee1)


</td></tr>
</table>

```
OS: Ubuntu 23.10 mantic
Kernel: x86_64 Linux 6.5.0-15-generic
Uptime: 10d 1h 29m
Packages: 1863
Shell: bash 5.2.15
Resolution: 2256x1504
DE: GNOME 45.0
WM: Mutter
WM Theme: Adwaita
GTK Theme: Yaru-dark [GTK2/3]
Icon Theme: Yaru
Font: Ubuntu 11
Disk: 88G / 458G (21%)
CPU: AMD Ryzen 5 7640U w/ Radeon 760M Graphics @ 12x 4.971GHz
GPU: AMD/ATI
RAM: 14358MiB / 63474MiB
```
![image](https://github.com/krausest/js-framework-benchmark/assets/199018/f3041b76-f499-4089-8f3c-c839fe014c74)
