### PR TITLE
Bump to Svelte next.61

### DIFF
--- a/frameworks/keyed/svelte-classic/package-lock.json
+++ b/frameworks/keyed/svelte-classic/package-lock.json
@@ -13,7 +13,7 @@
         "@rollup/plugin-terser": "^0.4.4",
         "rollup": "^4.9.4",
         "rollup-plugin-svelte": "^7.1.6",
-        "svelte": "^5.0.0-next.35"
+        "svelte": "^5.0.0-next.61"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -717,24 +717,24 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.0.0-next.35",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.35.tgz",
-      "integrity": "sha512-UjAHN7fuGZ+gSMtGCJyEMcESMVlYBd3dH2cwg2VlMkgpiYn6RQWyu3kPn5rqwOgW3zbILWicZP0eXyiJXBujPQ==",
+      "version": "5.0.0-next.61",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.61.tgz",
+      "integrity": "sha512-ptGAzwZtytButBuf3lIZyFKg51bnVsq/dFEH3Hb5OAkToEwa+Gd4M+URUjP56fxJyF7x3k327S8TPEp++cDrBw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@types/estree": "^1.0.5",
-        "acorn": "^8.10.0",
+        "acorn": "^8.11.3",
         "acorn-typescript": "^1.4.13",
         "aria-query": "^5.3.0",
         "axobject-query": "^4.0.0",
         "esm-env": "^1.0.0",
         "esrap": "^1.2.1",
-        "is-reference": "^3.0.1",
+        "is-reference": "^3.0.2",
         "locate-character": "^3.0.0",
-        "magic-string": "^0.30.4",
-        "zimmerframe": "^1.1.0"
+        "magic-string": "^0.30.5",
+        "zimmerframe": "^1.1.2"
       },
       "engines": {
         "node": ">=18"
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/zimmerframe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.0.tgz",
-      "integrity": "sha512-+AmV37r9NPUy7KcuG0Fde9AAFSD88kN5pnqvD7Pkp5WLLK0jct7hAtIDXXFDCRk3l5Mc1r2Sth3gfP2ZLE+/Qw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+      "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
       "dev": true
     }
   }

--- a/frameworks/keyed/svelte-classic/package.json
+++ b/frameworks/keyed/svelte-classic/package.json
@@ -26,6 +26,6 @@
     "@rollup/plugin-terser": "^0.4.4",
     "rollup": "^4.9.4",
     "rollup-plugin-svelte": "^7.1.6",
-    "svelte": "^5.0.0-next.35"
+    "svelte": "^5.0.0-next.61"
   }
 }

--- a/frameworks/keyed/svelte-classic/src/Main.svelte
+++ b/frameworks/keyed/svelte-classic/src/Main.svelte
@@ -66,8 +66,7 @@
     partialUpdate = () => {
       const clone = data.slice();
       for (let i = 0; i < data.length; i += 10) {
-        // clone[i].label += " !!!"; (see https://github.com/sveltejs/svelte/issues/9521)
-				clone[i] = {...clone[i], label: clone[i].label + ` !!!`}
+        clone[i].label += " !!!";
       }
       data = clone;
     },

--- a/frameworks/keyed/svelte/package-lock.json
+++ b/frameworks/keyed/svelte/package-lock.json
@@ -13,7 +13,7 @@
         "@rollup/plugin-terser": "^0.4.4",
         "rollup": "^4.9.4",
         "rollup-plugin-svelte": "^7.1.6",
-        "svelte": "^5.0.0-next.35"
+        "svelte": "^5.0.0-next.61"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -717,24 +717,24 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.0.0-next.35",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.35.tgz",
-      "integrity": "sha512-UjAHN7fuGZ+gSMtGCJyEMcESMVlYBd3dH2cwg2VlMkgpiYn6RQWyu3kPn5rqwOgW3zbILWicZP0eXyiJXBujPQ==",
+      "version": "5.0.0-next.61",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.61.tgz",
+      "integrity": "sha512-ptGAzwZtytButBuf3lIZyFKg51bnVsq/dFEH3Hb5OAkToEwa+Gd4M+URUjP56fxJyF7x3k327S8TPEp++cDrBw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@types/estree": "^1.0.5",
-        "acorn": "^8.10.0",
+        "acorn": "^8.11.3",
         "acorn-typescript": "^1.4.13",
         "aria-query": "^5.3.0",
         "axobject-query": "^4.0.0",
         "esm-env": "^1.0.0",
         "esrap": "^1.2.1",
-        "is-reference": "^3.0.1",
+        "is-reference": "^3.0.2",
         "locate-character": "^3.0.0",
-        "magic-string": "^0.30.4",
-        "zimmerframe": "^1.1.0"
+        "magic-string": "^0.30.5",
+        "zimmerframe": "^1.1.2"
       },
       "engines": {
         "node": ">=18"
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/zimmerframe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.0.tgz",
-      "integrity": "sha512-+AmV37r9NPUy7KcuG0Fde9AAFSD88kN5pnqvD7Pkp5WLLK0jct7hAtIDXXFDCRk3l5Mc1r2Sth3gfP2ZLE+/Qw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+      "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
       "dev": true
     }
   }

--- a/frameworks/keyed/svelte/package.json
+++ b/frameworks/keyed/svelte/package.json
@@ -26,6 +26,6 @@
     "@rollup/plugin-terser": "^0.4.4",
     "rollup": "^4.9.4",
     "rollup-plugin-svelte": "^7.1.6",
-    "svelte": "^5.0.0-next.35"
+    "svelte": "^5.0.0-next.61"
   }
 }

--- a/frameworks/non-keyed/svelte-classic/package-lock.json
+++ b/frameworks/non-keyed/svelte-classic/package-lock.json
@@ -13,7 +13,7 @@
         "@rollup/plugin-terser": "^0.4.4",
         "rollup": "^4.9.4",
         "rollup-plugin-svelte": "^7.1.6",
-        "svelte": "^5.0.0-next.35"
+        "svelte": "^5.0.0-next.61"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -717,24 +717,24 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.0.0-next.35",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.35.tgz",
-      "integrity": "sha512-UjAHN7fuGZ+gSMtGCJyEMcESMVlYBd3dH2cwg2VlMkgpiYn6RQWyu3kPn5rqwOgW3zbILWicZP0eXyiJXBujPQ==",
+      "version": "5.0.0-next.61",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.61.tgz",
+      "integrity": "sha512-ptGAzwZtytButBuf3lIZyFKg51bnVsq/dFEH3Hb5OAkToEwa+Gd4M+URUjP56fxJyF7x3k327S8TPEp++cDrBw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@types/estree": "^1.0.5",
-        "acorn": "^8.10.0",
+        "acorn": "^8.11.3",
         "acorn-typescript": "^1.4.13",
         "aria-query": "^5.3.0",
         "axobject-query": "^4.0.0",
         "esm-env": "^1.0.0",
         "esrap": "^1.2.1",
-        "is-reference": "^3.0.1",
+        "is-reference": "^3.0.2",
         "locate-character": "^3.0.0",
-        "magic-string": "^0.30.4",
-        "zimmerframe": "^1.1.0"
+        "magic-string": "^0.30.5",
+        "zimmerframe": "^1.1.2"
       },
       "engines": {
         "node": ">=18"
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/zimmerframe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.0.tgz",
-      "integrity": "sha512-+AmV37r9NPUy7KcuG0Fde9AAFSD88kN5pnqvD7Pkp5WLLK0jct7hAtIDXXFDCRk3l5Mc1r2Sth3gfP2ZLE+/Qw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+      "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
       "dev": true
     }
   }

--- a/frameworks/non-keyed/svelte-classic/package.json
+++ b/frameworks/non-keyed/svelte-classic/package.json
@@ -26,6 +26,6 @@
     "@rollup/plugin-terser": "^0.4.4",
     "rollup": "^4.9.4",
     "rollup-plugin-svelte": "^7.1.6",
-    "svelte": "^5.0.0-next.35"
+    "svelte": "^5.0.0-next.61"
   }
 }

--- a/frameworks/non-keyed/svelte-classic/src/Main.svelte
+++ b/frameworks/non-keyed/svelte-classic/src/Main.svelte
@@ -57,8 +57,7 @@
     },
     partialUpdate = () => {
       for (let i = 0; i < data.length; i += 10) {
-        // data[i].label += " !!!"; (see https://github.com/sveltejs/svelte/issues/9521)
-				data[i] = {...data[i], label: data[i].label + ` !!!`}
+        data[i].label += " !!!";
       }
     },
     remove = (num) => {


### PR DESCRIPTION
Since below mentioned issue is resolved, "svelte 5 classic" can now (next.61) run the and significantly speed up the code from "svelte 4" without any modification.

- https://github.com/sveltejs/svelte/issues/9521

This is really impressive @trueadm ! Svelte 5 is gonna be a great success with this level of backwards compat