### PR TITLE
Update cample to 3.2.0-alpha.15

### DIFF
--- a/frameworks/keyed/cample/package-lock.json
+++ b/frameworks/keyed/cample/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.14",
+  "version": "3.2.0-alpha.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-cample",
-      "version": "3.2.0-alpha.14",
+      "version": "3.2.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "cample": "3.2.0-alpha.14"
+        "cample": "3.2.0-alpha.15"
       },
       "devDependencies": {
         "@babel/core": "7.23.9",
@@ -2169,9 +2169,9 @@
       "dev": true
     },
     "node_modules/cample": {
-      "version": "3.2.0-alpha.14",
-      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.14.tgz",
-      "integrity": "sha512-Dr3sjuFnAYYkZSJFBkSLF4U0QfzKlUj7xiOhEA2WieT/AesUr9owXeYQ1XurAoOTXis9GDps9zOA9q5By6hszQ==",
+      "version": "3.2.0-alpha.15",
+      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.15.tgz",
+      "integrity": "sha512-Qqjre6KZL66H1xcL7xz5zekPYlhTmO+xjTxvAzH1F2gTcBOBCbuzSueWQPaFR7C3Ep8cnmW7TeKGXjyXtCNgLw==",
       "engines": {
         "node": ">=10.12.0"
       }

--- a/frameworks/keyed/cample/package-lock.json
+++ b/frameworks/keyed/cample/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.12",
+  "version": "3.2.0-alpha.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-cample",
-      "version": "3.2.0-alpha.12",
+      "version": "3.2.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "cample": "3.2.0-alpha.12"
+        "cample": "3.2.0-alpha.14"
       },
       "devDependencies": {
         "@babel/core": "7.23.9",
@@ -2169,9 +2169,9 @@
       "dev": true
     },
     "node_modules/cample": {
-      "version": "3.2.0-alpha.12",
-      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.12.tgz",
-      "integrity": "sha512-RHXTL2K9cwZIZE49ORoU6eDFfdQIl4QUVCFOx+07WKtUSxKtd/XJVBssfQwQWNDI9BqWWy4IvQ5GQLzZds/DxQ==",
+      "version": "3.2.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.14.tgz",
+      "integrity": "sha512-Dr3sjuFnAYYkZSJFBkSLF4U0QfzKlUj7xiOhEA2WieT/AesUr9owXeYQ1XurAoOTXis9GDps9zOA9q5By6hszQ==",
       "engines": {
         "node": ">=10.12.0"
       }

--- a/frameworks/keyed/cample/package.json
+++ b/frameworks/keyed/cample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.14",
+  "version": "3.2.0-alpha.15",
   "description": "cample demo",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -29,6 +29,6 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    "cample": "3.2.0-alpha.14"
+    "cample": "3.2.0-alpha.15"
   }
 }

--- a/frameworks/keyed/cample/package.json
+++ b/frameworks/keyed/cample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.12",
+  "version": "3.2.0-alpha.14",
   "description": "cample demo",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -29,6 +29,6 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    "cample": "3.2.0-alpha.12"
+    "cample": "3.2.0-alpha.14"
   }
 }


### PR DESCRIPTION
I think that it will no longer be 1.09, but will be somewhere around 1.06 - 1.07! Even if it’s 1.08, I think that it will be quite possible to finish up to 1.03 - 1.06 in the near future. I found a lot of stupid errors in the code, I think there will be more. I think I’ll finish it up to 1.03 - 1.06, although I see that I seem to have accelerated "select row" to almost maximum on the local machine, and the values are higher than others. In principle, I have almost completed the maximum of the framework. Maybe I’ll do a couple of PRs and we can say that the implementation will be ready. It will only be updated as new functionality is introduced, such as working with asynchronous data, etc.

P.S. Well, this time I’m not even 99.99999% sure, but 109% sure)