### PR TITLE
Update Bobril 20.6.4 without dynamically creating css

### DIFF
--- a/frameworks/keyed/bobril/index.html
+++ b/frameworks/keyed/bobril/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Bobril v20.6.0</title>
+    <title>Bobril v20.6.4</title>
     <link rel="stylesheet" href="dist/a.css">
 </head>
 

--- a/frameworks/keyed/bobril/package-lock.json
+++ b/frameworks/keyed/bobril/package-lock.json
@@ -9,16 +9,16 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "bobril": "20.6.0"
+        "bobril": "20.6.4"
       },
       "devDependencies": {
         "bobril-build": "*"
       }
     },
     "node_modules/bobril": {
-      "version": "20.6.0",
-      "resolved": "https://registry.npmjs.org/bobril/-/bobril-20.6.0.tgz",
-      "integrity": "sha512-PfCIuPdjUY5RD7+Z3Q3bg4/4GMEhuAssKuBBOM+U+scRjQxrJFS8l92Qym8WLrImORwEU7+AkSM5mn1zB7aHaw=="
+      "version": "20.6.4",
+      "resolved": "https://registry.npmjs.org/bobril/-/bobril-20.6.4.tgz",
+      "integrity": "sha512-wXIUOvNAUG5ySpuq+z2WbBmdKZ2+FssdPUf+dMsLZmgJbr/0i+q231UJIiRt51sSBKOZk39nNq59te962IwXYg=="
     },
     "node_modules/bobril-build": {
       "version": "2.4.0",

--- a/frameworks/keyed/bobril/package.json
+++ b/frameworks/keyed/bobril/package.json
@@ -5,8 +5,7 @@
   "main": "src/app.js",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "bobril",
-    "frameworkHomeURL": "https://bobril.com/",
-    "issues": [1139]
+    "frameworkHomeURL": "https://bobril.com/"
   },
   "scripts": {
     "dev": "bb",
@@ -27,6 +26,6 @@
     "bobril-build": "*"
   },
   "dependencies": {
-    "bobril": "20.6.0"
+    "bobril": "20.6.4"
   }
 }

--- a/frameworks/keyed/bobril/src/app.ts
+++ b/frameworks/keyed/bobril/src/app.ts
@@ -55,7 +55,7 @@ const Header = b.createComponent<IHeaderData>({
     const d = ctx.data;
     me.className = "jumbotron";
     me.children = divWithClass("row", [
-      divWithClass("col-md-6", { tag: "h1", children: "Bobril v20.4.1" }),
+      divWithClass("col-md-6", { tag: "h1", children: "Bobril v20.6.4" }),
       divWithClass("col-md-6", [
         divWithClass(
           "col-sm-6 smallpad",


### PR DESCRIPTION
Solve #1620 for Bobril.