### PR TITLE
Update cample to 3.2.0-alpha.44

### DIFF
--- a/frameworks/keyed/cample/package-lock.json
+++ b/frameworks/keyed/cample/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.42",
+  "version": "3.2.0-alpha.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-cample",
-      "version": "3.2.0-alpha.42",
+      "version": "3.2.0-alpha.43",
       "license": "MIT",
       "dependencies": {
-        "cample": "3.2.0-alpha.42"
+        "cample": "3.2.0-alpha.43"
       },
       "devDependencies": {
         "@babel/core": "7.23.9",
@@ -2169,9 +2169,9 @@
       "dev": true
     },
     "node_modules/cample": {
-      "version": "3.2.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.42.tgz",
-      "integrity": "sha512-7E4cH0jqhy96XtBhyikIc/S2L40gl03psU3Xbic1/noPsiNIpio38GerjniCxwkGh9Bwwu0fQHGrQIxkLUhW6Q==",
+      "version": "3.2.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.43.tgz",
+      "integrity": "sha512-zd3RAYQAUvAGjTDp8F5Mm6NtJaA8Qp3LYEv7PG6DbRqyPPRTYIgRlMRLH/Vxg3mRWJOMLfI6CwXy4bWnfKz2IA==",
       "engines": {
         "node": ">=10.12.0"
       }

--- a/frameworks/keyed/cample/package-lock.json
+++ b/frameworks/keyed/cample/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.40",
+  "version": "3.2.0-alpha.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-cample",
-      "version": "3.2.0-alpha.40",
+      "version": "3.2.0-alpha.42",
       "license": "MIT",
       "dependencies": {
-        "cample": "3.2.0-alpha.40"
+        "cample": "3.2.0-alpha.42"
       },
       "devDependencies": {
         "@babel/core": "7.23.9",
@@ -2169,9 +2169,9 @@
       "dev": true
     },
     "node_modules/cample": {
-      "version": "3.2.0-alpha.40",
-      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.40.tgz",
-      "integrity": "sha512-mpSku+o+yt0JFs56czGwHW/qcvKSgYB9seLsXflo87HxxxfP8d1L2g2u+223AFS3qEZUilV9Qh6bK5B252T7aw==",
+      "version": "3.2.0-alpha.42",
+      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.42.tgz",
+      "integrity": "sha512-7E4cH0jqhy96XtBhyikIc/S2L40gl03psU3Xbic1/noPsiNIpio38GerjniCxwkGh9Bwwu0fQHGrQIxkLUhW6Q==",
       "engines": {
         "node": ">=10.12.0"
       }

--- a/frameworks/keyed/cample/package-lock.json
+++ b/frameworks/keyed/cample/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.43",
+  "version": "3.2.0-alpha.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-cample",
-      "version": "3.2.0-alpha.43",
+      "version": "3.2.0-alpha.44",
       "license": "MIT",
       "dependencies": {
-        "cample": "3.2.0-alpha.43"
+        "cample": "3.2.0-alpha.44"
       },
       "devDependencies": {
         "@babel/core": "7.23.9",
@@ -2169,9 +2169,9 @@
       "dev": true
     },
     "node_modules/cample": {
-      "version": "3.2.0-alpha.43",
-      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.43.tgz",
-      "integrity": "sha512-zd3RAYQAUvAGjTDp8F5Mm6NtJaA8Qp3LYEv7PG6DbRqyPPRTYIgRlMRLH/Vxg3mRWJOMLfI6CwXy4bWnfKz2IA==",
+      "version": "3.2.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.44.tgz",
+      "integrity": "sha512-lKJyHt4YkzpjHJca1Y5vzz0ZXQEqDHgaqrs+zNAfv3h8dWDDQJJq8BEyfhWR/eKwhnkx5OxHtfvvgICN3Nna9A==",
       "engines": {
         "node": ">=10.12.0"
       }

--- a/frameworks/keyed/cample/package-lock.json
+++ b/frameworks/keyed/cample/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.39",
+  "version": "3.2.0-alpha.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-cample",
-      "version": "3.2.0-alpha.39",
+      "version": "3.2.0-alpha.40",
       "license": "MIT",
       "dependencies": {
-        "cample": "3.2.0-alpha.39"
+        "cample": "3.2.0-alpha.40"
       },
       "devDependencies": {
         "@babel/core": "7.23.9",
@@ -2169,9 +2169,9 @@
       "dev": true
     },
     "node_modules/cample": {
-      "version": "3.2.0-alpha.39",
-      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.39.tgz",
-      "integrity": "sha512-5AHUHsqsSu9dWanvFx2skteZAfoNQZYvc/Vq+kz8NmbtJY+b2JJeRrN1TwbqIqwzJfFdFWRxm9wHYgJKhkWsVA==",
+      "version": "3.2.0-alpha.40",
+      "resolved": "https://registry.npmjs.org/cample/-/cample-3.2.0-alpha.40.tgz",
+      "integrity": "sha512-mpSku+o+yt0JFs56czGwHW/qcvKSgYB9seLsXflo87HxxxfP8d1L2g2u+223AFS3qEZUilV9Qh6bK5B252T7aw==",
       "engines": {
         "node": ">=10.12.0"
       }

--- a/frameworks/keyed/cample/package.json
+++ b/frameworks/keyed/cample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.39",
+  "version": "3.2.0-alpha.40",
   "description": "cample demo",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -30,6 +30,6 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    "cample": "3.2.0-alpha.39"
+    "cample": "3.2.0-alpha.40"
   }
 }

--- a/frameworks/keyed/cample/package.json
+++ b/frameworks/keyed/cample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.42",
+  "version": "3.2.0-alpha.43",
   "description": "cample demo",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -30,6 +30,6 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    "cample": "3.2.0-alpha.42"
+    "cample": "3.2.0-alpha.43"
   }
 }

--- a/frameworks/keyed/cample/package.json
+++ b/frameworks/keyed/cample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.43",
+  "version": "3.2.0-alpha.44",
   "description": "cample demo",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -30,6 +30,6 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    "cample": "3.2.0-alpha.43"
+    "cample": "3.2.0-alpha.44"
   }
 }

--- a/frameworks/keyed/cample/package.json
+++ b/frameworks/keyed/cample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.41",
+  "version": "3.2.0-alpha.42",
   "description": "cample demo",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -30,6 +30,6 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    "cample": "3.2.0-alpha.41"
+    "cample": "3.2.0-alpha.42"
   }
 }

--- a/frameworks/keyed/cample/package.json
+++ b/frameworks/keyed/cample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-cample",
-  "version": "3.2.0-alpha.40",
+  "version": "3.2.0-alpha.41",
   "description": "cample demo",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -30,6 +30,6 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    "cample": "3.2.0-alpha.40"
+    "cample": "3.2.0-alpha.41"
   }
 }

--- a/frameworks/keyed/cample/src/main.js
+++ b/frameworks/keyed/cample/src/main.js
@@ -150,25 +150,29 @@ const mainComponent = component(
     },
     functions: {
       run: [
-        (setData) => () => {
+        (setData, event) => () => {
+          event.preventDefault();
           setData(() => buildData(1000));
         },
         "updateRows",
       ],
       runLots: [
-        (setData) => () => {
+        (setData, event) => () => {
+          event.preventDefault();
           setData(() => buildData(10000));
         },
         "updateRows",
       ],
       add: [
-        (setData) => () => {
+        (setData, event) => () => {
+          event.preventDefault();
           setData((d) => [...d, ...buildData(1000)]);
         },
         "updateRows",
       ],
       update: [
-        (setData) => () => {
+        (setData, event) => () => {
+          event.preventDefault();
           setData((d) => {
             const value = d.slice();
             for (let i = 0; i < value.length; i += 10) {
@@ -181,13 +185,15 @@ const mainComponent = component(
         "updateRows",
       ],
       clear: [
-        (setData) => () => {
+        (setData, event) => () => {
+          event.preventDefault();
           setData(() => []);
         },
         "updateRows",
       ],
       swapRows: [
-        (setData) => () => {
+        (setData, event) => () => {
+          event.preventDefault();
           setData((d) => {
             const tmp = d[1];
             d[1] = d[998];


### PR DESCRIPTION
That's it, I understood how the code would work faster and better. I'll combine the code from version 29 and version 39 and it will work fine. In version 29, "select row" was super slower, the rest was normal. Now, "select row" is fixed, so I think it's better this way. I hope the framework has time to get into the results of version 124