### PR TITLE
Add `vanillajs-lite` implementation (#1661 fix)

### DIFF
--- a/frameworks/keyed/vanillajs-lite/index.html
+++ b/frameworks/keyed/vanillajs-lite/index.html
@@ -44,7 +44,7 @@
                 <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
             </div>
         </div>
-        <template id="rowTemplate"><tr><td class="col-md-1">?</td><td class="col-md-4"><a>?</a></td><td class="col-md-1"><a><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td><td class="col-md-6"></td></tr></template>
+        <template id="trow"><tr><td class="col-md-1">?</td><td class="col-md-4"><a>?</a></td><td class="col-md-1"><a><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td><td class="col-md-6"></td></tr></template>
         <script src="src/Main.js" type="module"></script>
     </body>
 </html>

--- a/frameworks/keyed/vanillajs-lite/index.html
+++ b/frameworks/keyed/vanillajs-lite/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8"/>
+        <title>VanillaJS-Lite-"keyed"</title>
+        <link href="/css/currentStyle.css" rel="stylesheet"/>
+    </head>
+    <body>
+        <div id="main">
+            <div class="container">
+                <div class="jumbotron">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <h1>VanillaJS-Lite-"keyed"</h1>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="row">
+                                <div class="col-sm-6 smallpad">
+                                    <button type="button" class="btn btn-primary btn-block" id="run">Create 1,000 rows</button>
+                                </div>
+                                <div class="col-sm-6 smallpad">
+                                    <button type="button" class="btn btn-primary btn-block" id="runlots">Create 10,000 rows</button>
+                                </div>
+                                <div class="col-sm-6 smallpad">
+                                    <button type="button" class="btn btn-primary btn-block" id="add">Append 1,000 rows</button>
+                                </div>
+                                <div class="col-sm-6 smallpad">
+                                    <button type="button" class="btn btn-primary btn-block" id="update">Update every 10th row</button>
+                                </div>
+                                <div class="col-sm-6 smallpad">
+                                    <button type="button" class="btn btn-primary btn-block" id="clear">Clear</button>
+                                </div>
+                                <div class="col-sm-6 smallpad">
+                                    <button type="button" class="btn btn-primary btn-block" id="swaprows">Swap Rows</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <table class="table table-hover table-striped test-data">
+                    <tbody id="tbody">
+                    </tbody>
+                </table>
+                <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
+            </div>
+        </div>
+        <template id="rowTemplate"><tr><td class="col-md-1">?</td><td class="col-md-4"><a>?</a></td><td class="col-md-1"><a><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td><td class="col-md-6"></td></tr></template>
+        <script src="src/Main.js" type="module"></script>
+    </body>
+</html>

--- a/frameworks/keyed/vanillajs-lite/package-lock.json
+++ b/frameworks/keyed/vanillajs-lite/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "js-framework-benchmark-vanillajs-lite",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "js-framework-benchmark-vanillajs-lite",
+      "version": "1.0.0",
+      "devDependencies": {}
+    }
+  }
+}

--- a/frameworks/keyed/vanillajs-lite/package.json
+++ b/frameworks/keyed/vanillajs-lite/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "name": "js-framework-benchmark-vanillajs-lite",
+  "version": "1.0.0",
+  "description": "Vanilla.JS Lite Demo",
+  "js-framework-benchmark": {
+    "frameworkVersion": "",
+    "frameworkHomeURL": "",
+    "issues": [772]
+  },
+  "scripts": {
+    "dev": "exit 0",
+    "build-prod": "exit 0"
+  },
+  "devDependencies": {}
+}

--- a/frameworks/keyed/vanillajs-lite/src/Main.js
+++ b/frameworks/keyed/vanillajs-lite/src/Main.js
@@ -1,0 +1,67 @@
+const adjectives = ['pretty', 'large', 'big', 'small', 'tall', 'short', 'long', 'handsome', 'plain', 'quaint', 'clean', 'elegant', 'easy', 'angry', 'crazy', 'helpful', 'mushy', 'odd', 'unsightly', 'adorable', 'important', 'inexpensive', 'cheap', 'expensive', 'fancy'];
+const colours = ['red', 'yellow', 'blue', 'green', 'pink', 'brown', 'purple', 'brown', 'white', 'black', 'orange'];
+const nouns = ['table', 'chair', 'house', 'bbq', 'desk', 'car', 'pony', 'cookie', 'sandwich', 'burger', 'pizza', 'mouse', 'keyboard'];
+
+const pick = dict => dict[Math.round(Math.random() * 1000) % dict.length];
+
+let ID = 1, rows = [], selection;
+const ROW = Symbol(), ACTION = Symbol();
+
+const rowTemplate = document.querySelector('#rowTemplate').content.firstChild;
+const table = document.querySelector('table');
+let tbody = document.querySelector('tbody');
+
+const {cloneNode, insertBefore} = Node.prototype;
+const clone = (cloneNode.bind(rowTemplate, true));
+const insert = ((row, before = null) => insertBefore.call(tbody, row, before));
+
+const build = (() => {
+    const tr = clone();
+    const td1 = tr.firstChild, td2 = td1.nextSibling, td3 = td2.nextSibling;
+    const a1 = td2.firstChild, a2 = td3.firstChild;
+    const label = `${pick(adjectives)} ${pick(colours)} ${pick(nouns)}`;
+    td1.firstChild.nodeValue = ID++;
+    (tr.label = a1.firstChild).nodeValue = label;
+    a1[ACTION] = select, a2[ACTION] = remove;
+    return insert(a1[ROW] = a2[ROW] = tr);
+});
+
+const create = count => [...Array(count)].map(build);
+
+const select = (set => row => {
+    set('remove'), selection = row, set('add');
+})(setter => selection?.classList[setter]('danger'));
+
+const remove = (match => row => {
+    rows = rows.filter(match, row), row.remove();
+})(function (row) { return row !== this; });
+
+const clear = () => {
+    rows = [], selection = null;
+    const clone = tbody.cloneNode();
+    tbody.remove(), insertBefore.call(table, tbody = clone, null);
+};
+
+document.querySelectorAll('button').forEach(function (button) {
+    button.addEventListener('click', this[button.id]);
+}, {
+    run () { clear(), rows = create(1000); },
+    runlots () { clear(), rows = create(10000); },
+    add () { rows = [...rows, ...create(1000)]; },
+    clear,
+    update () {
+        for (let i = 0; i < rows.length; i += 10)
+            rows[i].label.nodeValue += ' !!!';
+    },
+    swaprows () {
+        if (rows.length > 998)
+            insert(rows[1], rows[998]), insert(rows[998], rows[2]),
+            [rows[1], rows[998]] = [rows[998], rows[1]];
+    }
+});
+
+table.addEventListener('click', e => {
+    let {target: t} = e;
+    e.stopPropagation(), (t[ACTION] ?? (t = t.parentNode)[ACTION])?.(t[ROW]);
+});
+

--- a/frameworks/keyed/vanillajs-lite/src/Main.js
+++ b/frameworks/keyed/vanillajs-lite/src/Main.js
@@ -7,12 +7,12 @@ const pick = dict => dict[Math.round(Math.random() * 1000) % dict.length];
 let ID = 1, rows = [], selection;
 const ROW = Symbol(), ACTION = Symbol();
 
-const rowTemplate = document.querySelector('#rowTemplate').content.firstChild;
 const table = document.querySelector('table');
 let tbody = document.querySelector('tbody');
+const trow = document.querySelector('#trow');
 
 const {cloneNode, insertBefore} = Node.prototype;
-const clone = (cloneNode.bind(rowTemplate, true));
+const clone = (cloneNode.bind(trow.content.firstChild, true));
 const insert = ((row, before = null) => insertBefore.call(tbody, row, before));
 
 const build = (() => {
@@ -64,4 +64,3 @@ table.addEventListener('click', e => {
     let {target: t} = e;
     e.stopPropagation(), (t[ACTION] ?? (t = t.parentNode)[ACTION])?.(t[ROW]);
 });
-


### PR DESCRIPTION
This is intended as a fix for issue #1661 (you may need to test it first in your environment before making a decision).
Due to convoluted [vanillajs](https://github.com/krausest/js-framework-benchmark/blob/master/frameworks/keyed/vanillajs/src/Main.js) implementation which makes the optimization difficult, I did a complete rewrite with minimal abstractions and cleaner execution flow, for a better visibility of current and future optimization paths.

It shows promising results in my environment (Ubuntu 23.10, Google Chrome for Testing
 Version 124.0.6367.91 (Official Build) (64-bit)):

[results.json](https://github.com/krausest/js-framework-benchmark/files/15237974/results.json)

![image](https://github.com/krausest/js-framework-benchmark/assets/10994439/64d39fa8-5609-4c61-876f-125bbe7d337a)
![image](https://github.com/krausest/js-framework-benchmark/assets/10994439/4e7a5ce3-2cff-4d59-8936-20d34f292913)