### PR TITLE
Use last-resort gc, fixes #1667

### DIFF
--- a/webdriver-ts/src/forkedBenchmarkRunnerPlaywright.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunnerPlaywright.ts
@@ -191,7 +191,7 @@ async function runMemBenchmark(
 
       console.log("runBenchmark");
       await runBenchmark(browser, page, benchmark, framework);
-      await forceGC(page, client);
+      await forceGC(page);
       await wait(40);
       // let result = (await client.send('Performance.getMetrics')).metrics.filter((m) => m.name==='JSHeapUsedSize')[0].value / 1024 / 1024;
 

--- a/webdriver-ts/src/forkedBenchmarkRunnerPlaywright.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunnerPlaywright.ts
@@ -60,12 +60,8 @@ function convertError(error: any): string {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function forceGC(page: Page, client?: CDPSession) {
-  for (let i = 0; i < 7; i++) {
-    // await client.send('HeapProfiler.collectGarbage');
-    await page.evaluate("window.gc()");
-  }
+async function forceGC(page: Page) {
+  await page.evaluate("window.gc({type:'major',execution:'sync',flavor:'last-resort'})");
 }
 
 async function runCPUBenchmark(
@@ -128,7 +124,7 @@ async function runCPUBenchmark(
         config,
         fileNameTrace(framework, benchmark.benchmarkInfo, i, benchmarkOptions)
       );
-      
+
       let res = { total: result.duration, script: resultScript, paint: resultPaint };
       results.push(res);
       console.log(`duration for ${framework.name} and ${benchmark.benchmarkInfo.id}: ${JSON.stringify(res)}`);

--- a/webdriver-ts/src/forkedBenchmarkRunnerPuppeteer.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunnerPuppeteer.ts
@@ -49,12 +49,8 @@ function convertError(error: any): string {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function forceGC(page: Page, client: CDPSession) {
-  for (let i = 0; i < 7; i++) {
-    await client.send("HeapProfiler.collectGarbage");
-    await page.evaluate("window.gc()");
-  }
+async function forceGC(page: Page) {
+  await page.evaluate("window.gc({type:'major',execution:'sync',flavor:'last-resort'})");
 }
 
 async function runCPUBenchmark(

--- a/webdriver-ts/src/forkedBenchmarkRunnerPuppeteer.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunnerPuppeteer.ts
@@ -107,7 +107,6 @@ async function runCPUBenchmark(
         "devtools.timeline",
         "disabled-by-default-devtools.timeline",
       ];
-      const client = await page.createCDPSession();
 
       // let categories = [
       //   "-*", // exclude default
@@ -139,7 +138,7 @@ async function runCPUBenchmark(
       await wait(50);
       await puppeteerWait();
 
-      await forceGC(page, client);
+      await forceGC(page);
       await puppeteerWait();
 
       console.log("runBenchmark");
@@ -252,7 +251,7 @@ async function runMemBenchmark(
 
       console.log("runBenchmark");
       await runBenchmark(page, benchmark, framework);
-      await forceGC(page, client);
+      await forceGC(page);
       await wait(40);
       let result = ((await page.evaluate("performance.measureUserAgentSpecificMemory()")) as any).bytes / 1024 / 1024;
       console.log("afterBenchmark");


### PR DESCRIPTION
Use last-resort gc, fixes #1667

Relevant discussion here as to why this change is being made https://github.com/krausest/js-framework-benchmark/issues/1661#issuecomment-2099578793. TLDR: regular GC passes no longer seem enough to collect all orphaned dom nodes from warm-up runs.