### PR TITLE
`vanillajs-lite` update

### DIFF
--- a/frameworks/keyed/vanillajs-lite/src/Main.js
+++ b/frameworks/keyed/vanillajs-lite/src/Main.js
@@ -22,7 +22,7 @@ const build = (TRow => () => {
     return a1[ROW] = a2[ROW] = tr;
 })(cloneNode.bind(trow.content.firstChild, true));
 
-const insert = ((row, before) => insertBefore.call(tbody, row, before));
+const insert = (insertBefore.bind(tbody));
 
 const create = (count, old) => {
     !old && clear();

--- a/frameworks/keyed/vanillajs-lite/src/Main.js
+++ b/frameworks/keyed/vanillajs-lite/src/Main.js
@@ -53,7 +53,7 @@ buttons.forEach(function (b) { b.onclick = this[b.id]; }, {
     swaprows () {
         if (rows.length > 998)
             insert(rows[1], rows[998]), insert(rows[998], rows[2]),
-            [rows[1], rows[998]] = [rows[998], rows[1]]
+            [rows[1], rows[998]] = [rows[998], rows[1]];
     }
 });
 

--- a/frameworks/keyed/vanillajs-lite/src/Main.js
+++ b/frameworks/keyed/vanillajs-lite/src/Main.js
@@ -2,57 +2,50 @@ const adjectives = ['pretty', 'large', 'big', 'small', 'tall', 'short', 'long', 
 const colours = ['red', 'yellow', 'blue', 'green', 'pink', 'brown', 'purple', 'brown', 'white', 'black', 'orange'];
 const nouns = ['table', 'chair', 'house', 'bbq', 'desk', 'car', 'pony', 'cookie', 'sandwich', 'burger', 'pizza', 'mouse', 'keyboard'];
 
-const pick = dict => dict[Math.round(Math.random() * 1000) % dict.length];
+const pick = (dict => dict[Math.round(Math.random() * 1000) % dict.length]);
+const label = (() =>`${pick(adjectives)} ${pick(colours)} ${pick(nouns)}`);
+
+const {cloneNode, insertBefore} = Node.prototype;
 
 let ID = 1, rows = [], selection;
 const ROW = Symbol(), ACTION = Symbol();
+const [[table], [tbody], [trow], buttons] = 'table,tbody,#trow,button'
+    .split(',').map(s => document.querySelectorAll(s));
 
-const table = document.querySelector('table');
-let tbody = document.querySelector('tbody');
-const trow = document.querySelector('#trow');
-
-const {cloneNode, insertBefore} = Node.prototype;
-const TBody = (cloneNode.bind(tbody, false));
-const TRow = (cloneNode.bind(trow.content.firstChild, true));
-const insert = ((row, before = null) => insertBefore.call(tbody, row, before));
-
-const build = (() => {
+const build = (TRow => () => {
     const tr = TRow();
     const td1 = tr.firstChild, td2 = td1.nextSibling, td3 = td2.nextSibling;
     const a1 = td2.firstChild, a2 = td3.firstChild;
-    const label = `${pick(adjectives)} ${pick(colours)} ${pick(nouns)}`;
     td1.firstChild.nodeValue = ID++;
-    (tr.label = a1.firstChild).nodeValue = label;
+    (tr.label = a1.firstChild).nodeValue = label();
     a1[ACTION] = select, a2[ACTION] = remove;
-    return insert(a1[ROW] = a2[ROW] = tr);
-});
+    return a1[ROW] = a2[ROW] = tr;
+})(cloneNode.bind(trow.content.firstChild, true));
 
-const create = count => [...Array(count)].map(build);
+const insert = ((row, before) => insertBefore.call(tbody, row, before));
 
-const select = (set => row => {
-    set('remove'), selection = row, set('add');
-})(setter => selection?.classList[setter]('danger'));
-
-const remove = (match => row => {
-    rows = rows.filter(match, row), row.remove();
-})(function (row) { return row !== this; });
-
-const clear = patch => {
-    rows = [], selection = null;
-    const empty = !tbody.firstChild;
-    if (!empty || patch)
-        !empty && patch ? (tbody.textContent = '', patch()) :
-            (tbody.remove(), tbody = TBody(), patch?.(),
-            insertBefore.call(table, tbody, null));
+const create = (count, old) => {
+    !old && clear();
+    const data = [];
+    for (let i = 0; i < count; i++)
+        data[i] = insert(build(), null);
+    rows = [...(old ?? []), ...data];
 };
 
-document.querySelectorAll('button').forEach(function (button) {
-    button.addEventListener('click', this[button.id]);
-}, {
-    run () { clear(() => rows = create(1000)); },
-    runlots () { clear(() => rows = create(10000)); },
-    add () { rows = [...rows, ...create(1000)]; },
-    clear () { clear(); },
+const select = row => (selection && (selection.className = ''),
+    (selection = row).className = 'danger');
+
+const remove = row =>
+    (row.remove(), (rows = new Set(rows)).delete(row), rows = [...rows]);
+
+const clear = () => (rows.length && (tbody.textContent = ''),
+    rows = [], selection = null);
+
+buttons.forEach(function (b) { b.onclick = this[b.id]; }, {
+    run () { create(1000); },
+    runlots () { create(10000); },
+    add () { create(1000, rows); },
+    clear,
     update () {
         for (let i = 0; i < rows.length; i += 10)
             rows[i].label.nodeValue += ' !!!';
@@ -60,11 +53,11 @@ document.querySelectorAll('button').forEach(function (button) {
     swaprows () {
         if (rows.length > 998)
             insert(rows[1], rows[998]), insert(rows[998], rows[2]),
-            [rows[1], rows[998]] = [rows[998], rows[1]];
+            [rows[1], rows[998]] = [rows[998], rows[1]]
     }
 });
 
-table.addEventListener('click', e => {
+table.onclick = e => {
     let {target: t} = e;
     e.stopPropagation(), (t[ACTION] ?? (t = t.parentNode)[ACTION])?.(t[ROW]);
-});
+};


### PR DESCRIPTION
This update fixes memory issue for "creating/clearing 1k rows" test which seems to be caused by hybrid rows clearing feature (tbody.remove()/tbody.textContent = '') issued in the most recent update. Also, some refactoring to reduce the file size.
The changes seems to not have much impact on CPU tests results:

![image](https://github.com/krausest/js-framework-benchmark/assets/10994439/144368f3-5c13-49dc-b9bf-e78a6635c990)
![image](https://github.com/krausest/js-framework-benchmark/assets/10994439/9385fab7-3c5d-4c6f-ab72-3c1949b3fbd3)
