### PR TITLE
refactor solid & solid-store implementations

### DIFF
--- a/frameworks/keyed/solid-store/rollup.config.js
+++ b/frameworks/keyed/solid-store/rollup.config.js
@@ -1,25 +1,23 @@
 import resolve from "@rollup/plugin-node-resolve";
-import babel from "@rollup/plugin-babel";
-import  terser  from "@rollup/plugin-terser";
+import { babel } from "@rollup/plugin-babel";
+import terser from "@rollup/plugin-terser";
 
-const plugins = [
-  babel({
-    babelHelpers: "bundled",
-    exclude: "node_modules/**",
-    presets: ["solid"],
-  }),
-  resolve({ extensions: [".js", ".jsx"] }),
-];
-
-if (process.env.production) {
-  plugins.push(terser());
-}
+const TERSER_OPTIONS = {
+  module: true,
+  compress: { passes: 3 },
+  mangle: true,
+};
 
 export default {
   input: "src/main.jsx",
-  output: {
-    file: "dist/main.js",
-    format: "iife",
-  },
-  plugins,
+  output: { file: "dist/main.js", format: "iife" },
+  plugins: [
+    babel({
+      babelHelpers: "bundled",
+      exclude: "node_modules/**",
+      presets: [["solid", { omitNestedClosingTags: true }]],
+    }),
+    resolve({ extensions: [".js", ".jsx"] }),
+    process.env.production && terser(TERSER_OPTIONS),
+  ].filter(Boolean),
 };

--- a/frameworks/keyed/solid-store/src/main.jsx
+++ b/frameworks/keyed/solid-store/src/main.jsx
@@ -15,7 +15,7 @@ const buildData = (count) => {
   for (let i = 0; i < count; i++) {
     data[i] = {
       id: nextId++,
-      label: `${adjectives[random(adjectives.length)]} ${colours[random(colours.length)]} ${nouns[random(nouns.length)]}`
+      label: `${adjectives[random(adjectives.length)]} ${colors[random(colors.length)]} ${nouns[random(nouns.length)]}`
     }
   }
   return data;

--- a/frameworks/keyed/solid-store/src/main.jsx
+++ b/frameworks/keyed/solid-store/src/main.jsx
@@ -1,70 +1,87 @@
-import { createSelector } from 'solid-js';
-import { render } from 'solid-js/web';
-import { createStore } from 'solid-js/store'
+import { createSelector } from "solid-js";
+import { render } from "solid-js/web";
+import { createStore } from "solid-js/store";
 
-let idCounter = 1;
-const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"],
-  colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"],
-  nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"]; // prettier-ignore
+const colors = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"]; // prettier-ignore
+const nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"]; // prettier-ignore
 
-function _random (max) { return Math.round(Math.random() * 1000) % max; };
+const random = (max) => Math.round(Math.random() * 1000) % max;
 
-function buildData(count) {
+let nextId = 1;
+
+const buildData = (count) => {
   let data = new Array(count);
   for (let i = 0; i < count; i++) {
     data[i] = {
-      id: idCounter++,
-      label: `${adjectives[_random(adjectives.length)]} ${colours[_random(colours.length)]} ${nouns[_random(nouns.length)]}`
+      id: nextId++,
+      label: `${adjectives[random(adjectives.length)]} ${colours[random(colours.length)]} ${nouns[random(nouns.length)]}`
     }
   }
   return data;
-}
+};
 
-const Button = ({ id, text, fn }) =>
-  <div class='col-sm-6 smallpad'>
-    <button id={ id } class='btn btn-primary btn-block' type='button' onClick={ fn }>{ text }</button>
+const Button = ([id, text, fn]) => (
+  <div class="col-sm-6 smallpad">
+    <button prop:id={id} class="btn btn-primary btn-block" type="button" onClick={fn}>
+      {text}
+    </button>
   </div>
+);
 
-const App = () => {
-  const [state, setState] = createStore({ data: [], selected: null }),
-    run = () => setState({ data: buildData(1000) }),
-    runLots = () => setState({ data: buildData(10000) }),
-    add = () => setState('data', d => [...d, ...buildData(1000)]),
-    update = () => setState('data', { by: 10 }, 'label', l => l + ' !!!'),
-    swapRows = () => setState('data', d => d.length > 998 ? { 1: d[998], 998: d[1] } : d),
-    clear = () => setState({ data: [] }),
-    select = id => setState('selected', id),
-    remove = id => setState('data', d => {
-      const idx = d.findIndex(d => d.id === id);
-      return [...d.slice(0, idx), ...d.slice(idx + 1)];
-    }),
-    isSelected = createSelector(() => state.selected);
+render(() => {
+  const [state, setState] = createStore({ data: [], selected: null });
+  const run = () => setState({ data: buildData(1_000) });
+  const runLots = () => setState({ data: buildData(10_000) });
+  const add = () => setState("data", (d) => [...d, ...buildData(1_000)]);
+  const update = () => setState("data", { by: 10 }, "label", (l) => l + " !!!");
+  const swapRows = () => setState("data", (d) => (d.length > 998 ? { 1: d[998], 998: d[1] } : d));
+  const clear = () => setState({ data: [] });
+  const isSelected = createSelector(() => state.selected);
 
-  return <div class='container'>
-    <div class='jumbotron'><div class='row'>
-      <div class='col-md-6'><h1>SolidJS Store Keyed</h1></div>
-      <div class='col-md-6'><div class='row'>
-        <Button id='run' text='Create 1,000 rows' fn={ run } />
-        <Button id='runlots' text='Create 10,000 rows' fn={ runLots } />
-        <Button id='add' text='Append 1,000 rows' fn={ add } />
-        <Button id='update' text='Update every 10th row' fn={ update } />
-        <Button id='clear' text='Clear' fn={ clear } />
-        <Button id='swaprows' text='Swap Rows' fn={ swapRows } />
-      </div></div>
-    </div></div>
-    <table class='table table-hover table-striped test-data'><tbody>
-      <For each={ state.data }>{ row => {
-        const rowId = row.id;
-        return <tr class={isSelected(rowId) ? "danger": ""}>
-          <td class='col-md-1' textContent={ rowId } />
-          <td class='col-md-4'><a onClick={[select, rowId]} textContent={ row.label } /></td>
-          <td class='col-md-1'><a onClick={[remove, rowId]}><span class='glyphicon glyphicon-remove' aria-hidden="true" /></a></td>
-          <td class='col-md-6'/>
-        </tr>
-      }}</For>
-    </tbody></table>
-    <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
-  </div>;
-}
-
-render(App, document.getElementById("main"));
+  return (
+    <div class="container">
+      <div class="jumbotron">
+        <div class="row">
+          <div class="col-md-6">
+            <h1>Solid Store</h1>
+          </div>
+          <div class="col-md-6">
+            <div class="row">
+              <Button {...["run", "Create 1,000 rows", run]} />
+              <Button {...["runlots", "Create 10,000 rows", runLots]} />
+              <Button {...["add", "Append 1,000 rows", add]} />
+              <Button {...["update", "Update every 10th row", update]} />
+              <Button {...["clear", "Clear", clear]} />
+              <Button {...["swaprows", "Swap Rows", swapRows]} />
+            </div>
+          </div>
+        </div>
+      </div>
+      <table class="table table-hover table-striped test-data">
+        <tbody>
+          <For each={state.data}>
+            {(row) => {
+              const rowId = row.id;
+              return (
+                <tr class={isSelected(rowId) ? "danger" : ""}>
+                  <td class="col-md-1" textContent={rowId} />
+                  <td class="col-md-4">
+                    <a onClick={() => setState("selected", rowId)} textContent={row.label} />
+                  </td>
+                  <td class="col-md-1">
+                    <a onClick={() => setState("data", (d) => d.toSpliced(d.findIndex((d) => d.id === rowId), 1))}>
+                      <span class="glyphicon glyphicon-remove" aria-hidden="true" />
+                    </a>
+                  </td>
+                  <td class="col-md-6" />
+                </tr>
+              ); //prettier-ignore
+            }}
+          </For>
+        </tbody>
+      </table>
+      <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true" />
+    </div>
+  );
+}, document.getElementById("main"));

--- a/frameworks/keyed/solid/rollup.config.js
+++ b/frameworks/keyed/solid/rollup.config.js
@@ -2,24 +2,22 @@ import resolve from "@rollup/plugin-node-resolve";
 import { babel } from "@rollup/plugin-babel";
 import terser from "@rollup/plugin-terser";
 
-const plugins = [
-  babel({
-    babelHelpers: "bundled",
-    exclude: "node_modules/**",
-    presets: ["solid"],
-  }),
-  resolve({ extensions: [".js", ".jsx"] }),
-];
-
-if (process.env.production) {
-  plugins.push(terser());
-}
+const TERSER_OPTIONS = {
+  module: true,
+  compress: { passes: 3 },
+  mangle: true,
+};
 
 export default {
   input: "src/main.jsx",
-  output: {
-    file: "dist/main.js",
-    format: "iife",
-  },
-  plugins,
+  output: { file: "dist/main.js", format: "iife" },
+  plugins: [
+    babel({
+      babelHelpers: "bundled",
+      exclude: "node_modules/**",
+      presets: [["solid", { omitNestedClosingTags: true }]],
+    }),
+    resolve({ extensions: [".js", ".jsx"] }),
+    process.env.production && terser(TERSER_OPTIONS),
+  ].filter(Boolean),
 };

--- a/frameworks/keyed/solid/src/main.jsx
+++ b/frameworks/keyed/solid/src/main.jsx
@@ -1,81 +1,98 @@
-import { createSignal, createSelector, batch } from 'solid-js';
-import { render } from 'solid-js/web';
+import { createSignal, createSelector, batch } from "solid-js";
+import { render } from "solid-js/web";
 
-let idCounter = 1;
-const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"],
-  colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"],
-  nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"]; // prettier-ignore
+const colors = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"]; // prettier-ignore
+const nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"]; // prettier-ignore
 
-function _random (max) { return Math.round(Math.random() * 1000) % max; };
+const random = (max) => Math.round(Math.random() * 1000) % max;
 
-function buildData(count) {
+let nextId = 1;
+
+const buildData = (count) => {
   let data = new Array(count);
   for (let i = 0; i < count; i++) {
-    const [label, setLabel] = createSignal(`${adjectives[_random(adjectives.length)]} ${colours[_random(colours.length)]} ${nouns[_random(nouns.length)]}`);
-    data[i] = {
-      id: idCounter++,
-      label, setLabel
-    }
+    const [label, setLabel] = createSignal(
+      `${adjectives[random(adjectives.length)]} ${colors[random(colors.length)]} ${nouns[random(nouns.length)]}`
+    );
+    data[i] = { id: nextId++, label, setLabel };
   }
   return data;
-}
+};
 
-const Button = ({ id, text, fn }) =>
-  <div class='col-sm-6 smallpad'>
-    <button id={ id } class='btn btn-primary btn-block' type='button' onClick={ fn }>{ text }</button>
+const Button = ([id, text, fn]) => (
+  <div class="col-sm-6 smallpad">
+    <button prop:id={id} class="btn btn-primary btn-block" type="button" onClick={fn}>
+      {text}
+    </button>
   </div>
+);
 
-const App = () => {
-  const [data, setData] = createSignal([]),
-    [selected, setSelected] = createSignal(null),
-    run = () => setData(buildData(1000)),
-    runLots = () => setData(buildData(10000)),
-    add = () => setData(d => [...d, ...buildData(1000)]),
-    update = () => batch(() => {
-      for(let i = 0, d = data(), len = d.length; i < len; i += 10)
-        d[i].setLabel(l => l + ' !!!');
-    }),
-    swapRows = () => {
-      const d = data().slice();
-      if (d.length > 998) {
-        let tmp = d[1];
-        d[1] = d[998];
-        d[998] = tmp;
-        setData(d);
-      }
-    },
-    clear = () => setData([]),
-    remove = id => setData(d => {
-      const idx = d.findIndex(d => d.id === id);
-      return [...d.slice(0, idx), ...d.slice(idx + 1)];
-    }),
-    isSelected = createSelector(selected);
+render(() => {
+  const [data, setData] = createSignal([]);
+  const [selected, setSelected] = createSignal(null);
+  const run = () => setData(buildData(1_000));
+  const runLots = () => setData(buildData(10_000));
+  const add = () => setData((d) => [...d, ...buildData(1_000)]);
+  const update = () =>
+    batch(() => {
+      for (let i = 0, d = data(), len = d.length; i < len; i += 10) d[i].setLabel((l) => l + " !!!");
+    });
+  const clear = () => setData([]);
+  const swapRows = () => {
+    const list = data().slice();
+    if (list.length > 998) {
+      let item = list[1];
+      list[1] = list[998];
+      list[998] = item;
+      setData(list);
+    }
+  };
+  const isSelected = createSelector(selected);
 
-  return <div class='container'>
-    <div class='jumbotron'><div class='row'>
-      <div class='col-md-6'><h1>SolidJS Keyed</h1></div>
-      <div class='col-md-6'><div class='row'>
-        <Button id='run' text='Create 1,000 rows' fn={ run } />
-        <Button id='runlots' text='Create 10,000 rows' fn={ runLots } />
-        <Button id='add' text='Append 1,000 rows' fn={ add } />
-        <Button id='update' text='Update every 10th row' fn={ update } />
-        <Button id='clear' text='Clear' fn={ clear } />
-        <Button id='swaprows' text='Swap Rows' fn={ swapRows } />
-      </div></div>
-    </div></div>
-    <table class='table table-hover table-striped test-data'><tbody>
-      <For each={ data() }>{ row => {
-        let rowId = row.id;
-        return <tr class={isSelected(rowId) ? "danger": ""}>
-          <td class='col-md-1' textContent={ rowId } />
-          <td class='col-md-4'><a onClick={[setSelected, rowId]} textContent={ row.label() } /></td>
-          <td class='col-md-1'><a onClick={[remove, rowId]}><span class='glyphicon glyphicon-remove' aria-hidden="true" /></a></td>
-          <td class='col-md-6'/>
-        </tr>
-      }}</For>
-    </tbody></table>
-    <span class='preloadicon glyphicon glyphicon-remove' aria-hidden="true" />
-  </div>;
-}
-
-render(App, document.getElementById("main"));
+  return (
+    <div class="container">
+      <div class="jumbotron">
+        <div class="row">
+          <div class="col-md-6">
+            <h1>Solid</h1>
+          </div>
+          <div class="col-md-6">
+            <div class="row">
+              <Button {...["run", "Create 1,000 rows", run]} />
+              <Button {...["runlots", "Create 10,000 rows", runLots]} />
+              <Button {...["add", "Append 1,000 rows", add]} />
+              <Button {...["update", "Update every 10th row", update]} />
+              <Button {...["clear", "Clear", clear]} />
+              <Button {...["swaprows", "Swap Rows", swapRows]} />
+            </div>
+          </div>
+        </div>
+      </div>
+      <table class="table table-hover table-striped test-data">
+        <tbody>
+          <For each={data()}>
+            {(row) => {
+              let rowId = row.id;
+              return (
+                <tr class={isSelected(rowId) ? "danger" : ""}>
+                  <td class="col-md-1" textContent={rowId} />
+                  <td class="col-md-4">
+                    <a onClick={() => setSelected(rowId)} textContent={row.label()} />
+                  </td>
+                  <td class="col-md-1">
+                    <a onClick={() => setData((d) => d.toSpliced(d.findIndex((d) => d.id === rowId), 1))}>
+                      <span class="glyphicon glyphicon-remove" aria-hidden="true" />
+                    </a>
+                  </td>
+                  <td class="col-md-6" />
+                </tr>
+              ); // prettier-ignore
+            }}
+          </For>
+        </tbody>
+      </table>
+      <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true" />
+    </div>
+  );
+}, document.getElementById("main"));


### PR DESCRIPTION
### Changes
1. Clean up `keyed/solid` & `keyed/solid-store` implementations by running Prettier & adopting patterns from other framework setups for clearer code & better uniformity
1. Update `keyed/solid` & `keyed/solid-store` rollup configs with a minimal terser setup to more reasonably represent what the average user will experience when using a boilerplate or popular framework like `SolidStart`.

   > Is this over-optimization? _No._ I believe this is firmly in the spirit of representing what an average user will realistically experience with Solid. Plus, this is considerably less bundler customization than what is used in many of the other framework benchmarks, like [million](https://github.com/krausest/js-framework-benchmark/blob/9fcbe016d312baaf4c2a14dff3d5f2fc2ffbe290/frameworks/keyed/million/rollup.config.mjs#L5), [gxt](https://github.com/krausest/js-framework-benchmark/blob/30c247a897cfe147a94ff82edafd8d066f4ffb36/frameworks/keyed/gxt/vite.config.mts#L29), [cydon](https://github.com/krausest/js-framework-benchmark/blob/30c247a897cfe147a94ff82edafd8d066f4ffb36/frameworks/non-keyed/cydon/rollup.config.js#L18), etc.