### PR TITLE
Update pota, implements throwing `moveBefore`

### DIFF
--- a/frameworks/keyed/pota/package.json
+++ b/frameworks/keyed/pota/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-pota",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -20,7 +20,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "pota": "^0.16.163"
+    "pota": "^0.16.165"
   },
   "devDependencies": {
     "@babel/core": "7.25.2",


### PR DESCRIPTION
This change implements the new "node state preserving api" `moveBefore`.   see: https://github.com/whatwg/dom/issues/1255

This is the set of changes I had to do https://github.com/potahtml/pota/commit/51da4b85e57d3eb56d1b0ec5554adb88d1119a9a

Unfortunately, they are making it throw., you check a ridiculous amount of conditions or just wrap it in a try and catch, I suspect the performance of the swap rows will degrade on frameworks implementing  this. The benchmark unfortunately only tests 2 moves[when the framework does the optimal thing]. So I'm not sure if it would be representative of the degradation. I am still curious what the results would be.

Thanks!