### PR TITLE
update pota

### DIFF
--- a/frameworks/keyed/pota/package.json
+++ b/frameworks/keyed/pota/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-pota",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -20,7 +20,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "pota": "^0.16.163"
+    "pota": "^0.17.170"
   },
   "devDependencies": {
     "@babel/core": "7.25.2",

--- a/frameworks/keyed/pota/src/main.jsx
+++ b/frameworks/keyed/pota/src/main.jsx
@@ -86,7 +86,7 @@ const Button = ({ id, text, fn }) => (
       id={id}
       class="btn btn-primary btn-block"
       type="button"
-      onClick={fn}
+      on:click={fn}
     />
   </div>
 )
@@ -175,7 +175,7 @@ const App = () => {
       </div>
       <table
         class="table table-hover table-striped test-data"
-        onClick={e => {
+        on:click={e => {
           const element = e.target
           const { selectRow, removeRow } = element
 


### PR DESCRIPTION
I've decided to namespace all event handlers., that lead to some changes. The reason is to easily disambiguate between event handlers, properties, and attributes.

Question, is there something I can do so version '0.17.x' always gets updated before making a full run? That's to be, to always update `0.17.x` to whatever patch version pota is currently in.

Oh, btw, I do not need a partial run, I know these runs are slower, I can wait till the next full run.  Partial runs are not useful to me as these behave differently to full runs. I know there's an issue open about this and I do not mind, I can just wait.

Thanks!