### PR TITLE
feat: Add benchmark for several successive updates

### DIFF
--- a/webdriver-ts/src/benchmarksCommon.ts
+++ b/webdriver-ts/src/benchmarksCommon.ts
@@ -21,7 +21,8 @@ export interface CPUBenchmarkInfo extends BenchmarkInfoBase {
   type: BenchmarkType.CPU;
   layoutEventRequired: boolean;
   additionalNumberOfRuns: number;
-  warmupCount: number
+  warmupCount: number;
+  expectedClickEvents?: number;
 }
 
 export interface MemBenchmarkInfo extends BenchmarkInfoBase {
@@ -79,6 +80,7 @@ export enum Benchmark {
   _07 = "07_create10k",
   _08 = "08_create1k-after1k_x2",
   _09 = "09_clear1k_x8",
+  _10 = "10_update_many_times",
   _21 = "21_ready-memory",
   _22 = "22_run-memory",
   _23 = "23_update5-memory",
@@ -99,6 +101,7 @@ export type BenchmarkId =
   | typeof Benchmark._07
   | typeof Benchmark._08
   | typeof Benchmark._09
+  | typeof Benchmark._10
   | typeof Benchmark._30
   | typeof Benchmark._40;
 
@@ -213,6 +216,17 @@ export const cpuBenchmarkInfosArray: Array<CPUBenchmarkInfo> = [
     allowBatching: true,
     layoutEventRequired: true,
     additionalNumberOfRuns: 0,
+  },
+  {
+    id: Benchmark._10,
+    label: "partial update, 5 times",
+    warmupCount: 5,
+    description: "updating every 10th row for 1,000 row, 5 times",
+    type: BenchmarkType.CPU,
+    allowBatching: true,
+    layoutEventRequired: true,
+    additionalNumberOfRuns: 0,
+    expectedClickEvents: 5
   },
 ];
 

--- a/webdriver-ts/src/benchmarksPlaywright.ts
+++ b/webdriver-ts/src/benchmarksPlaywright.ts
@@ -40,7 +40,7 @@ export let benchRun = new (class extends CPUBenchmarkPlaywright {
   constructor() {
     super(cpuBenchmarkInfos[Benchmark._01]);
   }
-  async init(browser: Browser, page: Page) { 
+  async init(browser: Browser, page: Page) {
     await checkElementExists(page, "#run");
     for (let i = 0; i < this.benchmarkInfo.warmupCount; i++) {
       await clickElement(page, "#run");
@@ -50,9 +50,9 @@ export let benchRun = new (class extends CPUBenchmarkPlaywright {
     }
   }
   async run(browser: Browser, page: Page) {
-      await clickElement(page, "#run");
+    await clickElement(page, "#run");
       await checkElementContainsText(page, "tbody>tr:nth-of-type(1000)>td:nth-of-type(1)", ((this.benchmarkInfo.warmupCount+1)*1000).toFixed());
-  }  
+  }
 })();
 
 export const benchReplaceAll = new (class extends CPUBenchmarkPlaywright {
@@ -60,11 +60,11 @@ export const benchReplaceAll = new (class extends CPUBenchmarkPlaywright {
     super(cpuBenchmarkInfos[Benchmark._02]);
   }
   async init(browser: Browser, page: Page) {
-      await checkElementExists(page, "#run");
-      for (let i = 0; i < this.benchmarkInfo.warmupCount; i++) {
-        await clickElement(page, "#run");
+    await checkElementExists(page, "#run");
+    for (let i = 0; i < this.benchmarkInfo.warmupCount; i++) {
+      await clickElement(page, "#run");
         await checkElementContainsText(page, "tbody>tr:nth-of-type(1)>td:nth-of-type(1)", (i*1000+1).toFixed());
-      }
+    }
   }
   async run(browser: Browser, page: Page) {
     await clickElement(page, "#run");
@@ -80,10 +80,10 @@ export const benchUpdate = new (class extends CPUBenchmarkPlaywright {
     await checkElementExists(page, "#run");
     await clickElement(page, "#run");
     await checkElementExists(page, "tbody>tr:nth-of-type(1000)>td:nth-of-type(1)");
-      for (let i = 0; i < 3; i++) {
-        await clickElement(page, "#update");
+    for (let i = 0; i < 3; i++) {
+      await clickElement(page, "#update");
         await checkElementContainsText(page, "tbody>tr:nth-of-type(991)>td:nth-of-type(2)>a", ' !!!'.repeat(i + 1));
-      }
+    }
   }
   async run(browser: Browser, page: Page) {
     await clickElement(page, "#update");
@@ -106,8 +106,8 @@ export const benchSelect = new (class extends CPUBenchmarkPlaywright {
     }
   }
   async run(browser: Browser, page: Page) {
-      await clickElement(page, "tbody>tr:nth-of-type(2)>td:nth-of-type(2)>a");
-      await checkElementHasClass(page, "tbody>tr:nth-of-type(2)", "danger");
+    await clickElement(page, "tbody>tr:nth-of-type(2)>td:nth-of-type(2)>a");
+    await checkElementHasClass(page, "tbody>tr:nth-of-type(2)", "danger");
   }
 })();
 
@@ -116,21 +116,21 @@ export const benchSwapRows = new (class extends CPUBenchmarkPlaywright {
     super(cpuBenchmarkInfos[Benchmark._05]);
   }
   async init(browser: Browser, page: Page) {
-      await checkElementExists(page, "#run");
-      await clickElement(page, "#run");
-      await checkElementExists(page, "tbody>tr:nth-of-type(1000)>td:nth-of-type(1)");
-      for (let i = 0; i <= this.benchmarkInfo.warmupCount; i++) {
-        let text = i % 2 == 0 ? "2" : "999";
-        await clickElement(page, "#swaprows");
-        await checkElementContainsText(page, "tbody>tr:nth-of-type(999)>td:nth-of-type(1)", text);
-      }
+    await checkElementExists(page, "#run");
+    await clickElement(page, "#run");
+    await checkElementExists(page, "tbody>tr:nth-of-type(1000)>td:nth-of-type(1)");
+    for (let i = 0; i <= this.benchmarkInfo.warmupCount; i++) {
+      let text = i % 2 == 0 ? "2" : "999";
+      await clickElement(page, "#swaprows");
+      await checkElementContainsText(page, "tbody>tr:nth-of-type(999)>td:nth-of-type(1)", text);
+    }
   }
   async run(browser: Browser, page: Page) {
-      await clickElement(page, "#swaprows");
-      let text999 = this.benchmarkInfo.warmupCount % 2 == 0 ? "999" : "2";
-      let text2 = this.benchmarkInfo.warmupCount % 2 == 0 ? "2" : "999";
-      await checkElementContainsText(page, "tbody>tr:nth-of-type(999)>td:nth-of-type(1)", text999);
-      await checkElementContainsText(page, "tbody>tr:nth-of-type(2)>td:nth-of-type(1)", text2);
+    await clickElement(page, "#swaprows");
+    let text999 = this.benchmarkInfo.warmupCount % 2 == 0 ? "999" : "2";
+    let text2 = this.benchmarkInfo.warmupCount % 2 == 0 ? "2" : "999";
+    await checkElementContainsText(page, "tbody>tr:nth-of-type(999)>td:nth-of-type(1)", text999);
+    await checkElementContainsText(page, "tbody>tr:nth-of-type(2)>td:nth-of-type(1)", text2);
   }
 })();
 
@@ -143,18 +143,18 @@ export const benchRemove = new (class extends CPUBenchmarkPlaywright {
     await checkElementExists(page, "#run");
     await clickElement(page, "#run");
     await checkElementExists(page, "tbody>tr:nth-of-type(1000)>td:nth-of-type(1)");
-      for (let i = 0; i < this.benchmarkInfo.warmupCount; i++) {
-        const rowToClick = this.benchmarkInfo.warmupCount - i + this.rowsToSkip;
+    for (let i = 0; i < this.benchmarkInfo.warmupCount; i++) {
+      const rowToClick = this.benchmarkInfo.warmupCount - i + this.rowsToSkip;
         await checkElementContainsText(page, `tbody>tr:nth-of-type(${rowToClick})>td:nth-of-type(1)`, rowToClick.toString());
-        await clickElement(page, `tbody>tr:nth-of-type(${rowToClick})>td:nth-of-type(3)>a>span:nth-of-type(1)`);
+      await clickElement(page, `tbody>tr:nth-of-type(${rowToClick})>td:nth-of-type(3)>a>span:nth-of-type(1)`);
         await checkElementContainsText(page, `tbody>tr:nth-of-type(${rowToClick})>td:nth-of-type(1)`, `${this.rowsToSkip + this.benchmarkInfo.warmupCount + 1}`);
-      }
+    }
       await checkElementContainsText(page, `tbody>tr:nth-of-type(${this.rowsToSkip + 1})>td:nth-of-type(1)`, `${this.rowsToSkip + this.benchmarkInfo.warmupCount + 1}`);
       await checkElementContainsText(page, `tbody>tr:nth-of-type(${this.rowsToSkip})>td:nth-of-type(1)`, `${this.rowsToSkip}`);
 
-      // Click on a row the second time
+    // Click on a row the second time
       await checkElementContainsText(page, `tbody>tr:nth-of-type(${this.rowsToSkip + 2})>td:nth-of-type(1)`, `${this.rowsToSkip + this.benchmarkInfo.warmupCount + 2}`);
-      await clickElement(page, `tbody>tr:nth-of-type(${this.rowsToSkip + 2})>td:nth-of-type(3)>a>span:nth-of-type(1)`);
+    await clickElement(page, `tbody>tr:nth-of-type(${this.rowsToSkip + 2})>td:nth-of-type(3)>a>span:nth-of-type(1)`);
       await checkElementContainsText(page, `tbody>tr:nth-of-type(${this.rowsToSkip + 2})>td:nth-of-type(1)`, `${this.rowsToSkip + this.benchmarkInfo.warmupCount + 3}`);
   }
   async run(browser: Browser, page: Page) {
@@ -182,7 +182,7 @@ export const benchRunBig = new (class extends CPUBenchmarkPlaywright {
     await checkElementExists(page, "tbody>tr:nth-of-type(10000)>td:nth-of-type(2)>a");
   }
 })();
-  
+
 export const benchAppendToManyRows = new (class extends CPUBenchmarkPlaywright {
   constructor() {
     super(cpuBenchmarkInfos[Benchmark._08]);
@@ -204,6 +204,29 @@ export const benchAppendToManyRows = new (class extends CPUBenchmarkPlaywright {
   }
 })();
 
+export const benchUpdateManyTimes = new (class extends CPUBenchmarkPlaywright {
+  constructor() {
+    super(cpuBenchmarkInfos[Benchmark._10]);
+  }
+  async init(browser: Browser, page: Page) {
+    await checkElementExists(page, "#run");
+    await clickElement(page, "#run");
+    await checkElementExists(page, "tbody>tr:nth-of-type(1000)>td:nth-of-type(1)");
+    for (let i = 0; i < 3; i++) {
+      await clickElement(page, "#update");
+      await checkElementContainsText(page, "tbody>tr:nth-of-type(991)>td:nth-of-type(2)>a", " !!!".repeat(i + 1));
+    }
+  }
+  async run(browser: Browser, page: Page) {
+    const clicks: Array<Promise<void>> = [];
+    for (let i = 0; i < 5; i++) {
+      clicks.push(clickElement(page, "#update"));
+    }
+    await Promise.all(clicks);
+    await checkElementContainsText(page, "tbody>tr:nth-of-type(991)>td:nth-of-type(2)>a", " !!!".repeat(this.benchmarkInfo.warmupCount + clicks.length));
+  }
+})();
+
 export const benchClear = new (class extends CPUBenchmarkPlaywright {
   constructor() {
     super(cpuBenchmarkInfos[Benchmark._09]);
@@ -220,8 +243,8 @@ export const benchClear = new (class extends CPUBenchmarkPlaywright {
     await checkElementContainsText(page, "tbody>tr:nth-of-type(1)>td:nth-of-type(1)", (this.benchmarkInfo.warmupCount*1000+1).toFixed());
   }
   async run(browser: Browser, page: Page) {
-      await clickElement(page, "#clear");
-      await checkElementNotExists(page, "tbody>tr:nth-of-type(1000)>td:nth-of-type(1)");
+    await clickElement(page, "#clear");
+    await checkElementNotExists(page, "tbody>tr:nth-of-type(1000)>td:nth-of-type(1)");
   }
 })();
 

--- a/webdriver-ts/src/benchmarksPuppeteer.ts
+++ b/webdriver-ts/src/benchmarksPuppeteer.ts
@@ -265,6 +265,38 @@ export const benchAppendToManyRows = new (class extends CPUBenchmarkPuppeteer {
   }
 })();
 
+export const benchUpdateManyTimes = new (class extends CPUBenchmarkPuppeteer {
+  constructor() {
+    super(cpuBenchmarkInfos[Benchmark._10]);
+  }
+  async init(page: Page) {
+    await checkElementExists(page, "pierce/#run");
+    await clickElement(page, "pierce/#run");
+    await checkElementExists(page, "pierce/tbody>tr:nth-of-type(1000)>td:nth-of-type(1)");
+    for (let i = 0; i < this.benchmarkInfo.warmupCount; i++) {
+      await clickElement(page, "pierce/#update");
+      await checkElementContainsText(
+        page,
+        "pierce/tbody>tr:nth-of-type(991)>td:nth-of-type(2)>a",
+        " !!!".repeat(i + 1)
+      );
+    }
+  }
+  async run(page: Page) {
+    const clicks: Array<Promise<void>> = [];
+    for (let i = 0; i < 5; i++){ 
+      clicks.push(clickElement(page, "pierce/#update"));
+    }
+    ;
+    await Promise.all(clicks);
+    await checkElementContainsText(
+      page,
+      "pierce/tbody>tr:nth-of-type(991)>td:nth-of-type(2)>a",
+      " !!!".repeat(this.benchmarkInfo.warmupCount + clicks.length)
+    );
+  }
+})();
+
 export const benchClear = new (class extends CPUBenchmarkPuppeteer {
   constructor() {
     super(cpuBenchmarkInfos[Benchmark._09]);

--- a/webdriver-ts/src/forkedBenchmarkRunnerPlaywright.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunnerPlaywright.ts
@@ -113,7 +113,7 @@ async function runCPUBenchmark(
       if (throttleCPU) {
         await client.send("Emulation.setCPUThrottlingRate", { rate: 1 });
       }
-      let result = await computeResultsCPU(fileNameTrace(framework, benchmark.benchmarkInfo, i, benchmarkOptions), framework.startLogicEventName);
+      let result = await computeResultsCPU(fileNameTrace(framework, benchmark.benchmarkInfo, i, benchmarkOptions), framework.startLogicEventName, benchmark.benchmarkInfo.expectedClickEvents ?? 1);
       let resultScript = await computeResultsJS(
         result,
         config,
@@ -223,7 +223,7 @@ export async function executeBenchmark(
   benchmarkOptions: BenchmarkOptions
 ): Promise<ErrorAndWarning<number | CPUBenchmarkResult>> {
   let runBenchmarks: Array<BenchmarkPlaywright> = benchmarks.filter(
-    (b) =>
+    (b:any) =>
       benchmarkId === b.benchmarkInfo.id && (b instanceof CPUBenchmarkPlaywright || b instanceof MemBenchmarkPlaywright)
   ) as Array<BenchmarkPlaywright>;
 

--- a/webdriver-ts/src/forkedBenchmarkRunnerWebdriverCDP.ts
+++ b/webdriver-ts/src/forkedBenchmarkRunnerWebdriverCDP.ts
@@ -162,7 +162,7 @@ async function runCPUBenchmark(
       await cdpConnection.execute("Tracing.end", {});
       await p;
 
-      let result = await computeResultsCPU(fileNameTrace(framework, benchmark.benchmarkInfo, i, benchmarkOptions), framework.startLogicEventName);
+      let result = await computeResultsCPU(fileNameTrace(framework, benchmark.benchmarkInfo, i, benchmarkOptions), framework.startLogicEventName, benchmark.benchmarkInfo.expectedClickEvents ?? 1);
       let resultScript = await computeResultsJS(
         result,
         config,

--- a/webdriver-ts/src/parseTrace.ts
+++ b/webdriver-ts/src/parseTrace.ts
@@ -15,7 +15,7 @@ async function debugSingle() {
     const trace = `traces/targetjs-v1.0.137-keyed_09_clear1k_x8_3.json`;
     // const trace = `traces/vanillajs-keyed_01_run1k_0.json`;
     console.log("analyzing trace", trace);
-    const cpuTrace = await computeResultsCPU(trace, "click");
+    const cpuTrace = await computeResultsCPU(trace, "click", 1);
     console.log(trace, cpuTrace);
     values.push(cpuTrace.duration);
     let resultJS = await computeResultsJS(cpuTrace, config, trace);


### PR DESCRIPTION
The current set of benchmarks all update the application state a single time, either with a large change or a small one. This commit adds a test that updates the state many times by clicking the update button 5 times.

fixes #1866

(Draft proposal while the issue above is discussed)