### PR TITLE
Fix Crank to use non-deprecated key prop

### DIFF
--- a/frameworks/keyed/crank/src/main.jsx
+++ b/frameworks/keyed/crank/src/main.jsx
@@ -34,7 +34,6 @@ function Button({id, title}) {
   );
 }
 
-
 function Jumbotron() {
   this.addEventListener("click", (ev) => {
     if (ev.target.tagName === "BUTTON") {
@@ -175,7 +174,7 @@ function *Main() {
     this.refresh();
   });
 
-  while (true) {
+  for ({} of this) {
     yield (
       <div class="container">
         <Jumbotron />
@@ -183,7 +182,7 @@ function *Main() {
           <tbody>
             {data.map((item) => (
               <Row
-                crank-key={item.id}
+                key={item.id}
                 item={item}
                 selected={item.id === selected}
               />


### PR DESCRIPTION
The usage of `crank-key` is probably causing regressions because of console deprecation warnings. 0.7 will be released soon and I’d love to have an accurate comparison.

Thanks for this project!