### PR TITLE
Update pota

### DIFF
--- a/frameworks/keyed/pota/package.json
+++ b/frameworks/keyed/pota/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-pota",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "type": "module",
   "main": "dist/main.js",
   "js-framework-benchmark": {
@@ -20,7 +20,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "pota": "^0.19.203"
+    "pota": "^0.19.204"
   },
   "devDependencies": {
     "@babel/core": "7.26.0",


### PR DESCRIPTION
I've removed the `postinstall` script that compiles the babel transform from `es` to `cjs`, and instead NPM already host the compiled version. Hoping this doesn't cause any problem. Besides, there are some minor regression fixes and improvements.

Thanks! 