### PR TITLE
Update preact to v10.27.1

### DIFF
--- a/frameworks/keyed/preact-classes/package-lock.json
+++ b/frameworks/keyed/preact-classes/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "7.25.9",
-        "preact": "10.25.2"
+        "preact": "^10.27.1"
       },
       "devDependencies": {
         "@babel/core": "7.26.0",
@@ -2916,9 +2916,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.25.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.2.tgz",
-      "integrity": "sha512-GEts1EH3oMnqdOIeXhlbBSddZ9nrINd070WBOiPO2ous1orrKGUM4SMDbwyjSWD1iMS2dBvaDjAa5qUhz3TXqw==",
+      "version": "10.27.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.1.tgz",
+      "integrity": "sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/frameworks/keyed/preact-classes/package.json
+++ b/frameworks/keyed/preact-classes/package.json
@@ -32,6 +32,6 @@
   },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "7.25.9",
-    "preact": "10.25.2"
+    "preact": "^10.27.1"
   }
 }

--- a/frameworks/keyed/preact-hooks/package-lock.json
+++ b/frameworks/keyed/preact-hooks/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "preact": "^10.25.2"
+        "preact": "^10.27.1"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -1082,9 +1082,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.25.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.2.tgz",
-      "integrity": "sha512-GEts1EH3oMnqdOIeXhlbBSddZ9nrINd070WBOiPO2ous1orrKGUM4SMDbwyjSWD1iMS2dBvaDjAa5qUhz3TXqw==",
+      "version": "10.27.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.1.tgz",
+      "integrity": "sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/frameworks/keyed/preact-hooks/package.json
+++ b/frameworks/keyed/preact-hooks/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "preact": "^10.25.2"
+    "preact": "^10.27.1"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/frameworks/keyed/preact-kr-observable/package-lock.json
+++ b/frameworks/keyed/preact-kr-observable/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "kr-observable": "3.0.8",
-        "preact": "^10.25.0"
+        "preact": "^10.27.1"
       },
       "devDependencies": {
         "@babel/core": "7.21.8",
@@ -2553,9 +2553,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.26.4",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.4.tgz",
-      "integrity": "sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==",
+      "version": "10.27.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.1.tgz",
+      "integrity": "sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/frameworks/keyed/preact-kr-observable/package.json
+++ b/frameworks/keyed/preact-kr-observable/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "kr-observable": "3.0.8",
-    "preact": "^10.25.0"
+    "preact": "^10.27.1"
   },
   "devDependencies": {
     "@babel/core": "7.21.8",

--- a/frameworks/keyed/preact-signals/package-lock.json
+++ b/frameworks/keyed/preact-signals/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals": "^1.3.1",
-        "preact": "^10.25.2"
+        "preact": "^10.27.1"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -1109,9 +1109,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.25.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.2.tgz",
-      "integrity": "sha512-GEts1EH3oMnqdOIeXhlbBSddZ9nrINd070WBOiPO2ous1orrKGUM4SMDbwyjSWD1iMS2dBvaDjAa5qUhz3TXqw==",
+      "version": "10.27.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.1.tgz",
+      "integrity": "sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/frameworks/keyed/preact-signals/package.json
+++ b/frameworks/keyed/preact-signals/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@preact/signals": "^1.3.1",
-    "preact": "^10.25.2"
+    "preact": "^10.27.1"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",


### PR DESCRIPTION
Hey @krausest, big fan of this repo, thank you for all of your hard work!

I wanted to submit a small PR to bump all of the Preact implementations to `10.27.1` because the latest [release](https://github.com/preactjs/preact/releases/tag/10.27.1) has a small fix related to re-ordering of memoized rows.

It should remove majority of `swap-rows` cost in `preact-classes` and `preact-kr-observable`, since these are using memozied rows and were affected by the edge case that was fixed.

Other implementations, `preact-hooks` and `preact-signals`, do not use memoized rows and currently have faster swap performance (before this release), but end up having to eat the cost of not being able to skip processing rows in `select-row` and `partial-update`. 

<img width="558" height="764" alt="Screenshot 2025-08-18 at 7 28 51 PM" src="https://github.com/user-attachments/assets/d2d5bdba-0dff-4577-b0c0-0fa552e83a49" />


I am guessing that the reason why hooks and signals implementations do not use memoized rows is because of the said swap deopt that was fixed. So I was also planning on submitting another PR to update `preact-hooks` and `preact-signals` to use memoization. Please let me know if you'd rather have it all in one PR, I can also push it here later.

