### PR TITLE
Update pota

### DIFF
--- a/frameworks/keyed/pota/package.json
+++ b/frameworks/keyed/pota/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "pota": "^0.19.204"
+    "pota": "^0.19.206"
   },
   "devDependencies": {
     "@babel/core": "7.26.0",


### PR DESCRIPTION
Hey, a small update, 

- fix bug with row swapping v205
- inline confidently evaluated attributes and children v206
- `@static` doesn't call `getValue` so this should remove some useless function calls

Random thing I have noticed, pota shows first than Inferno, both have a geometric mean of `1.10`. But Inferno is like 3ms~ faster. I understand this is kind of meaningless, but would be nice that after sorting by geometric mean it could also sort by the sum of time taken, that way the result of similar frameworks could possibly be more steady. But honestly not sure, because if the variation swings, then its kinda pointless. Just an idea

Thanks!