### PR TITLE
Remove unneeded memo wrapper in the react-compiler-hooks

### DIFF
--- a/frameworks/keyed/react-compiler-hooks/src/main.jsx
+++ b/frameworks/keyed/react-compiler-hooks/src/main.jsx
@@ -1,4 +1,4 @@
-import { useState, memo } from "react";
+import { useState } from "react";
 import { createRoot } from "react-dom/client";
 import { buildData } from "./utils";
 
@@ -12,7 +12,7 @@ const Button = ({ id, title, onClick }) => {
   );
 };
 
-const Row = memo(({ isSelected, item, select, remove }) => {
+const Row = ({ isSelected, item, select, remove }) => {
   return (
     <tr className={isSelected ? "danger" : ""}>
       <td className="col-md-1">{item.id}</td>
@@ -27,7 +27,7 @@ const Row = memo(({ isSelected, item, select, remove }) => {
       <td className="col-md-6" />
     </tr>
   );
-});
+}
 
 const emptyArr = [];
 


### PR DESCRIPTION
This PR removes the unnecessary memo wrapper, that adds overhead by doubling the comparison of the props:
1. Inside the memo func
2. Inside the React component

Note: rerendering of the individual rows is fine - if nothing changed, React will immediately return with the cached result