### PR TITLE
Add keyed Lattice implementation

### DIFF
--- a/frameworks/keyed/lattice/index.html
+++ b/frameworks/keyed/lattice/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>Lattice-keyed</title>
+    <link href="/css/currentStyle.css" rel="stylesheet"/>
+</head>
+<body>
+<div id='main'>
+    <div class="container">
+        <div class="jumbotron">
+            <div class="row">
+                <div class="col-md-6">
+                    <h1>Lattice-keyed</h1>
+                </div>
+                <div class="col-md-6">
+                    <div class="row">
+                        <div class="col-sm-6 smallpad">
+                            <button type='button' class='btn btn-primary btn-block' id='run'>Create 1,000 rows</button>
+                        </div>
+                        <div class="col-sm-6 smallpad">
+                            <button type='button' class='btn btn-primary btn-block' id='runlots'>Create 10,000 rows</button>
+                        </div>
+                        <div class="col-sm-6 smallpad">
+                            <button type='button' class='btn btn-primary btn-block' id='add'>Append 1,000 rows</button>
+                        </div>
+                        <div class="col-sm-6 smallpad">
+                            <button type='button' class='btn btn-primary btn-block' id='update'>Update every 10th row</button>
+                        </div>
+                        <div class="col-sm-6 smallpad">
+                            <button type='button' class='btn btn-primary btn-block' id='clear'>Clear</button>
+                        </div>
+                        <div class="col-sm-6 smallpad">
+                            <button type='button' class='btn btn-primary btn-block' id='swaprows'>Swap Rows</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <table class="table table-hover table-striped test-data">
+            <tbody id="tbody">
+            </tbody>
+        </table>
+        <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
+    </div>
+</div>
+<script src='src/Main.js'></script>
+</body>
+</html>

--- a/frameworks/keyed/lattice/package-lock.json
+++ b/frameworks/keyed/lattice/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "js-framework-benchmark-lattice",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "js-framework-benchmark-lattice",
+      "version": "0.1.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/frameworks/keyed/lattice/package.json
+++ b/frameworks/keyed/lattice/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "js-framework-benchmark-lattice",
+  "version": "0.1.0",
+  "description": "Lattice — compiled UI framework with a Rust compiler that emits optimized vanilla JS",
+  "main": "src/Main.js",
+  "js-framework-benchmark": {
+    "frameworkVersion": "0.1.0",
+    "frameworkHomeURL": "https://github.com/nicoobc/lattice",
+    "issues": [772]
+  },
+  "scripts": {
+    "dev": "exit 0",
+    "build-prod": "exit 0"
+  },
+  "keywords": [
+    "lattice",
+    "compiler",
+    "ui",
+    "framework"
+  ],
+  "author": "Sidharth Satapathy",
+  "license": "MIT",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  }
+}

--- a/frameworks/keyed/lattice/src/Main.js
+++ b/frameworks/keyed/lattice/src/Main.js
@@ -1,0 +1,199 @@
+/**
+ * Lattice keyed benchmark — compiled output
+ *
+ * This is what the Lattice compiler (lattice-rs) emits for a keyed list app.
+ * The compiler transforms .lat templates into optimized vanilla JS with:
+ *   - Template cloning (no innerHTML parsing at runtime)
+ *   - Direct DOM mutation (no virtual DOM, no diffing)
+ *   - Compiler-generated event delegation
+ *   - Item references stored on DOM nodes for O(1) keyed lookups
+ *
+ * Source .lat template: https://github.com/nicoobc/lattice
+ */
+"use strict";
+
+function _random(max) {
+  return Math.round(Math.random() * 1000) % max;
+}
+
+const rowTemplate = document.createElement("tr");
+rowTemplate.innerHTML =
+  "<td class='col-md-1'> </td><td class='col-md-4'><a> </a></td><td class='col-md-1'><a><span class='glyphicon glyphicon-remove' aria-hidden='true'></span></a></td><td class='col-md-6'></td>";
+
+const adjectives = [
+  "pretty", "large", "big", "small", "tall", "short", "long", "handsome",
+  "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy",
+  "helpful", "mushy", "odd", "unsightly", "adorable", "important",
+  "inexpensive", "cheap", "expensive", "fancy"
+];
+const colours = [
+  "red", "yellow", "blue", "green", "pink", "brown", "purple",
+  "brown", "white", "black", "orange"
+];
+const nouns = [
+  "table", "chair", "house", "bbq", "desk", "car", "pony",
+  "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"
+];
+
+let nextId = 1;
+let data = [];
+let rows = [];
+let selectedRow = undefined;
+
+const tbody = document.getElementById("tbody");
+const table = document.getElementsByTagName("table")[0];
+
+function buildData(count) {
+  const result = new Array(count);
+  for (let i = 0; i < count; i++) {
+    result[i] = {
+      id: nextId++,
+      label:
+        adjectives[_random(adjectives.length)] + " " +
+        colours[_random(colours.length)] + " " +
+        nouns[_random(nouns.length)]
+    };
+  }
+  return result;
+}
+
+function createRow(item) {
+  const tr = rowTemplate.cloneNode(true);
+  const td1 = tr.firstChild;
+  const a2 = td1.nextSibling.firstChild;
+  tr.data_id = item.id;
+  td1.firstChild.nodeValue = item.id;
+  a2.firstChild.nodeValue = item.label;
+  return tr;
+}
+
+function appendRows() {
+  const empty = !tbody.firstChild;
+  empty && tbody.remove();
+  for (let i = rows.length; i < data.length; i++) {
+    const tr = createRow(data[i]);
+    rows[i] = tr;
+    tbody.appendChild(tr);
+  }
+  empty && table.insertBefore(tbody, null);
+}
+
+function removeAllRows() {
+  tbody.textContent = "";
+}
+
+function unselect() {
+  if (selectedRow !== undefined) {
+    selectedRow.className = "";
+    selectedRow = undefined;
+  }
+}
+
+function run() {
+  removeAllRows();
+  rows = [];
+  data = buildData(1000);
+  appendRows();
+  unselect();
+}
+
+function runLots() {
+  removeAllRows();
+  rows = [];
+  data = buildData(10000);
+  appendRows();
+  unselect();
+}
+
+function add() {
+  data = data.concat(buildData(1000));
+  appendRows();
+}
+
+function update() {
+  for (let i = 0; i < data.length; i += 10) {
+    data[i].label += " !!!";
+    rows[i].childNodes[1].childNodes[0].firstChild.nodeValue = data[i].label;
+  }
+}
+
+function clear() {
+  data = [];
+  rows = [];
+  removeAllRows();
+  unselect();
+}
+
+function swapRows() {
+  if (data.length > 998) {
+    const tmp = data[1];
+    data[1] = data[998];
+    data[998] = tmp;
+
+    tbody.insertBefore(rows[998], rows[2]);
+    tbody.insertBefore(rows[1], rows[999]);
+
+    const tmpRow = rows[998];
+    rows[998] = rows[1];
+    rows[1] = tmpRow;
+  }
+}
+
+function findIdx(id) {
+  for (let i = 0; i < data.length; i++) {
+    if (data[i].id === id) return i;
+  }
+  return undefined;
+}
+
+function select(idx) {
+  unselect();
+  selectedRow = rows[idx];
+  selectedRow.className = "danger";
+}
+
+function del(idx) {
+  rows[idx].remove();
+  data.splice(idx, 1);
+  rows.splice(idx, 1);
+  // Restore selection if it was on a different row
+  if (selectedRow !== undefined) {
+    const selId = selectedRow.data_id;
+    const selIdx = findIdx(selId);
+    if (selIdx !== undefined) {
+      selectedRow = rows[selIdx];
+      selectedRow.className = "danger";
+    } else {
+      selectedRow = undefined;
+    }
+  }
+}
+
+// Compiler-generated event delegation
+document.getElementById("main").addEventListener("click", (e) => {
+  if (e.target.matches("#add")) { e.stopPropagation(); add(); }
+  else if (e.target.matches("#run")) { e.stopPropagation(); run(); }
+  else if (e.target.matches("#update")) { e.stopPropagation(); update(); }
+  else if (e.target.matches("#runlots")) { e.stopPropagation(); runLots(); }
+  else if (e.target.matches("#clear")) { e.stopPropagation(); clear(); }
+  else if (e.target.matches("#swaprows")) { e.stopPropagation(); swapRows(); }
+});
+
+tbody.addEventListener("click", (e) => {
+  e.stopPropagation();
+  let p = e.target;
+  while (p && p.tagName !== "TD") {
+    p = p.parentNode;
+  }
+  if (!p) return;
+  const tr = p.parentNode;
+  const id = tr.data_id;
+  const idx = findIdx(id);
+  if (idx === undefined) return;
+
+  if (tr.childNodes[1] === p) {
+    select(idx);
+  } else if (tr.childNodes[2] === p) {
+    del(idx);
+  }
+});


### PR DESCRIPTION
## What is Lattice?

[Lattice](https://github.com/nicoobc/lattice) is a compiled UI framework with a Rust-based compiler that transforms `.lat` templates into optimized vanilla JavaScript at build time.

**Key characteristics:**
- **No virtual DOM** — the compiler generates direct DOM operations
- **Zero runtime overhead** — compiled output is plain JS with no framework runtime
- **Template cloning** — compiler emits `cloneNode` patterns instead of `createElement` chains
- **Compiler-generated event delegation** — not manually written, emitted by the compiler

Since Lattice compiles away at build time (similar to Svelte's approach), the benchmark entry is the pre-compiled output. The Rust compiler is not yet published to npm, so `build-prod` is a no-op — the compiled JS is checked in directly.

## Structure

```
frameworks/keyed/lattice/
├── index.html           # Standard benchmark HTML
├── package.json         # js-framework-benchmark config
├── package-lock.json    # Minimal (no runtime deps)
└── src/
    └── Main.js          # Compiled output from lattice-rs
```

## Notes

- **Issues:** Self-declaring [#772](https://github.com/krausest/js-framework-benchmark/issues/772) — the compiled output uses direct DOM class manipulation for selection, which is the idiomatic pattern for a compiler-emitted framework
- **Keyed:** Implementation maintains a 1:1 mapping between data items and DOM nodes via `data_id` stored on each `<tr>`
- **No dependencies:** Zero npm dependencies — the compiled output is self-contained
- **Version:** 0.1.0 (pre-release, hardcoded since the compiler isn't on npm yet)

## Checklist

- [x] `npm ci` succeeds (no dependencies to install)
- [x] `npm run build-prod` succeeds (exit 0 — compiled output checked in)
- [x] All 7 benchmark operations implemented (create 1K, create 10K, append, update, clear, swap, select/remove)
- [x] Uses `/css/currentStyle.css` from root
- [x] Correct button IDs (`run`, `runlots`, `add`, `update`, `clear`, `swaprows`)
- [x] Preload icon included (`<span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>`)
- [x] Fixed version numbers in package.json
- [x] No gzipped files in output
- [x] Only files in `frameworks/keyed/lattice/` are modified