### PR TITLE
Update Qingkuai implementation and dependencies

### DIFF
--- a/frameworks/keyed/qingkuai/package-lock.json
+++ b/frameworks/keyed/qingkuai/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "name": "js-framework-benchmark-qingkuai",
             "dependencies": {
-                "qingkuai": "^1.0.55",
+                "qingkuai": "^1.0.60",
                 "vite": "^8.0.3",
                 "vite-plugin-qingkuai": "^1.0.14"
             },
@@ -841,9 +841,9 @@
             }
         },
         "node_modules/qingkuai": {
-            "version": "1.0.56",
-            "resolved": "https://registry.npmjs.org/qingkuai/-/qingkuai-1.0.56.tgz",
-            "integrity": "sha512-G6vAm7IOJ/0sa7V91XIuLOeybIKYaulZ8SOaWgcwmqwXJ7JrOdm7c3OELSgguvXk8PhDnBTplv8vhODGGgIQQw==",
+            "version": "1.0.60",
+            "resolved": "https://registry.npmjs.org/qingkuai/-/qingkuai-1.0.60.tgz",
+            "integrity": "sha512-iZJgc7cAQwDE5kw2XJAskuN++MErFEmGf2siwK1vjzwzT9bSa/QOlwlGshDTtTCxpsFNkcHCT6BJ4WuMi9io7w==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.28.0",

--- a/frameworks/keyed/qingkuai/package.json
+++ b/frameworks/keyed/qingkuai/package.json
@@ -5,15 +5,14 @@
     "js-framework-benchmark": {
         "frameworkVersionFromPackage": "qingkuai",
         "frameworkHomeURL": "https://qingkuai.dev",
-        "language": "JavaScript",
-        "issues": [801]
+        "language": "JavaScript"
     },
     "scripts": {
         "dev": "vite",
         "build-prod": "vite build"
     },
     "dependencies": {
-        "qingkuai": "^1.0.55",
+        "qingkuai": "^1.0.61",
         "vite": "^8.0.3",
         "vite-plugin-qingkuai": "^1.0.14"
     },

--- a/frameworks/keyed/qingkuai/src/data.js
+++ b/frameworks/keyed/qingkuai/src/data.js
@@ -57,20 +57,28 @@ const nouns = [
 ]
 
 function random(max) {
-    return Math.round(Math.random() * 100) % max
+    return (Math.random() * max) | 0
 }
 
 export function buildData(count) {
-    const data = []
-    for (let i = 0; i < count; i++)
-        data.push({
-            id: id++,
+    const data = new Array(count)
+    const adjectiveCount = adjectives.length
+    const colourCount = colours.length
+    const nounCount = nouns.length
+    let nextId = id
+
+    for (let i = 0; i < count; i++) {
+        data[i] = {
+            id: nextId++,
             label:
-                adjectives[random(adjectives.length)] +
+                adjectives[random(adjectiveCount)] +
                 " " +
-                colours[random(colours.length)] +
+                colours[random(colourCount)] +
                 " " +
-                nouns[random(nouns.length)]
-        })
+                nouns[random(nounCount)]
+        }
+    }
+
+    id = nextId
     return data
 }

--- a/frameworks/keyed/qingkuai/src/pages/App.qk
+++ b/frameworks/keyed/qingkuai/src/pages/App.qk
@@ -2,10 +2,14 @@
     import { buildData } from "../data"
 
     let rows = []
-    let selected = null
+    let selected
 
     const clear = () => {
         rows = []
+    }
+
+    const select = id => {
+        selected = id
     }
 
     const run = () => {
@@ -17,17 +21,23 @@
     }
 
     const add = () => {
-        rows = [...rows, ...buildData(1000)]
+        rows = rows.concat(buildData(1000))
     }
 
     const remove = id => {
-        rows = rows.filter(item => id !== item.id)
+        for (let i = 0; i < rows.length; i++) {
+            if (rows[i].id === id) {
+                rows.splice(i, 1)
+                break
+            }
+        }
+        rows = rows.slice()
     }
 
     const update = () => {
         for (let i = 0; i < rows.length; i += 10) {
             rows[i] = {
-                ...rows[i],
+                id: rows[i].id,
                 label: rows[i].label + " !!!"
             }
         }
@@ -43,20 +53,12 @@
             rows = clone
         }
     }
-
-    function select() {
-        const node = this.parentNode.parentNode
-        if (selected) {
-            selected.removeAttribute("class")
-        }
-        ;(selected = node).className = "danger"
-    }
 </lang-js>
 
 <div class="jumbotron">
     <div class="row">
         <div class="col-md-6">
-            <h1>QingKuai (Keyed)</h1>
+            <h1>Qingkuai (Keyed)</h1>
         </div>
         <div class="col-md-6">
             <div class="row">
@@ -129,10 +131,11 @@
         <tr
             #key={item.id}
             #for={item of rows}
+            !class={selected === item.id ? "danger" : ""}
         >
             <td class="col-md-1">{item.id}</td>
             <td class="col-md-4">
-                <a @click={select}>{item.label}</a>
+                <a @click={select(item.id)}>{item.label}</a>
             </td>
             <td class="col-md-1">
                 <a @click={remove(item.id)}>

--- a/frameworks/non-keyed/qingkuai/package-lock.json
+++ b/frameworks/non-keyed/qingkuai/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "name": "js-framework-benchmark-qingkuai",
             "dependencies": {
-                "qingkuai": "^1.0.55",
+                "qingkuai": "^1.0.60",
                 "vite": "^8.0.3",
                 "vite-plugin-qingkuai": "^1.0.14"
             },
@@ -841,9 +841,9 @@
             }
         },
         "node_modules/qingkuai": {
-            "version": "1.0.56",
-            "resolved": "https://registry.npmjs.org/qingkuai/-/qingkuai-1.0.56.tgz",
-            "integrity": "sha512-G6vAm7IOJ/0sa7V91XIuLOeybIKYaulZ8SOaWgcwmqwXJ7JrOdm7c3OELSgguvXk8PhDnBTplv8vhODGGgIQQw==",
+            "version": "1.0.60",
+            "resolved": "https://registry.npmjs.org/qingkuai/-/qingkuai-1.0.60.tgz",
+            "integrity": "sha512-iZJgc7cAQwDE5kw2XJAskuN++MErFEmGf2siwK1vjzwzT9bSa/QOlwlGshDTtTCxpsFNkcHCT6BJ4WuMi9io7w==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.28.0",

--- a/frameworks/non-keyed/qingkuai/package.json
+++ b/frameworks/non-keyed/qingkuai/package.json
@@ -11,7 +11,7 @@
         "build-prod": "vite build"
     },
     "dependencies": {
-        "qingkuai": "^1.0.55",
+        "qingkuai": "^1.0.61",
         "vite": "^8.0.3",
         "vite-plugin-qingkuai": "^1.0.14"
     },

--- a/frameworks/non-keyed/qingkuai/src/data.js
+++ b/frameworks/non-keyed/qingkuai/src/data.js
@@ -57,20 +57,28 @@ const nouns = [
 ]
 
 function random(max) {
-    return Math.round(Math.random() * 100) % max
+    return (Math.random() * max) | 0
 }
 
 export function buildData(count) {
-    const data = []
-    for (let i = 0; i < count; i++)
-        data.push({
-            id: id++,
+    const data = new Array(count)
+    const adjectiveCount = adjectives.length
+    const colourCount = colours.length
+    const nounCount = nouns.length
+    let nextId = id
+
+    for (let i = 0; i < count; i++) {
+        data[i] = {
+            id: nextId++,
             label:
-                adjectives[random(adjectives.length)] +
+                adjectives[random(adjectiveCount)] +
                 " " +
-                colours[random(colours.length)] +
+                colours[random(colourCount)] +
                 " " +
-                nouns[random(nouns.length)]
-        })
+                nouns[random(nounCount)]
+        }
+    }
+
+    id = nextId
     return data
 }

--- a/frameworks/non-keyed/qingkuai/src/pages/App.qk
+++ b/frameworks/non-keyed/qingkuai/src/pages/App.qk
@@ -2,10 +2,14 @@
     import { buildData } from "../data"
 
     let rows = []
-    let selected = null
+    let selected
 
     const clear = () => {
         rows = []
+    }
+
+    const select = id => {
+        selected = id
     }
 
     const run = () => {
@@ -17,17 +21,23 @@
     }
 
     const add = () => {
-        rows = [...rows, ...buildData(1000)]
+        rows = rows.concat(buildData(1000))
     }
 
     const remove = id => {
-        rows = rows.filter(item => id !== item.id)
+        for (let i = 0; i < rows.length; i++) {
+            if (rows[i].id === id) {
+                rows.splice(i, 1)
+                break
+            }
+        }
+        rows = rows.slice()
     }
 
     const update = () => {
         for (let i = 0; i < rows.length; i += 10) {
             rows[i] = {
-                ...rows[i],
+                id: rows[i].id,
                 label: rows[i].label + " !!!"
             }
         }
@@ -43,20 +53,12 @@
             rows = clone
         }
     }
-
-    function select() {
-        const node = this.parentNode.parentNode
-        if (selected) {
-            selected.removeAttribute("class")
-        }
-        ;(selected = node).className = "danger"
-    }
 </lang-js>
 
 <div class="jumbotron">
     <div class="row">
         <div class="col-md-6">
-            <h1>QingKuai (Keyed)</h1>
+            <h1>Qingkuai (Non-Keyed)</h1>
         </div>
         <div class="col-md-6">
             <div class="row">
@@ -126,10 +128,13 @@
 </div>
 <table class="table table-hover table-striped test-data">
     <tbody>
-        <tr #for={item of rows}>
+        <tr
+            #for={item of rows}
+            !class={selected === item.id ? "danger" : ""}
+        >
             <td class="col-md-1">{item.id}</td>
             <td class="col-md-4">
-                <a @click={select}>{item.label}</a>
+                <a @click={select(item.id)}>{item.label}</a>
             </td>
             <td class="col-md-1">
                 <a @click={remove(item.id)}>


### PR DESCRIPTION
This PR updates the Qingkuai keyed and non-keyed implementations with the following changes:
- Bump `qingkuai` from `^1.0.55` to `^1.0.61`
- General performance optimizations:
  - Optimize data generation to reduce unnecessary allocations and per-iteration overhead
  - Simplify row append, remove, update, and selection logic
  - Switch selection handling to state-driven updates instead of imperative DOM mutations
- Remove note `#772` (previously mislabeled as `#801`) by eliminating manual DOM manipulation from the implementation:
  - Row selection is now handled declaratively through framework state and template bindings
  - This better reflects how the framework works rather than relying on custom DOM patching