### PR TITLE
Update pota dependency version to ^0.20.233

### DIFF
--- a/frameworks/keyed/pota/package.json
+++ b/frameworks/keyed/pota/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "pota": "^0.19.206"
+    "pota": "^0.20.233"
   },
   "devDependencies": {
     "@babel/core": "7.26.0",


### PR DESCRIPTION
Just a bump.

On running time it may have got a bit worse, memory probably improved but was already pretty good. 

Thanks!