### PR TITLE
AkashJS: bump packages with perf fixes

### DIFF
--- a/frameworks/keyed/akashjs/package.json
+++ b/frameworks/keyed/akashjs/package.json
@@ -7,12 +7,12 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@akashjs/runtime": "0.2.7",
-    "@akashjs/compiler": "0.1.59",
-    "@akashjs/vite-plugin": "0.2.3"
+    "@akashjs/compiler": "0.1.60",
+    "@akashjs/runtime": "0.2.8",
+    "@akashjs/vite-plugin": "0.2.4"
   },
   "devDependencies": {
-    "vite": "5.4.21",
-    "typescript": "^5.5.0"
+    "typescript": "^5.9.3",
+    "vite": "^5.4.21"
   }
 }


### PR DESCRIPTION
## Summary

- Bump `@akashjs/runtime` to 0.2.8, `@akashjs/compiler` to 0.1.60, `@akashjs/vite-plugin` to 0.2.4
- LIS-based keyed list reconciler — swap/remove operations now produce minimal DOM moves instead of O(n) iteration
- `class:` directive caches previous boolean value, skips `classList.toggle` when unchanged
- Signal `.set()` uses inline batch instead of closure allocation

## Expected impact

| Benchmark | Before (Chrome 149) | Expected |
|-----------|-------------------|----------|
| swap rows | 82.7ms | ~12ms |
| select row | 6.4ms | ~2.5ms |
| remove row | 41.0ms | ~10ms |