### PR TITLE
AkashJS: bump runtime to 0.2.9

### DIFF
--- a/frameworks/keyed/akashjs/package.json
+++ b/frameworks/keyed/akashjs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@akashjs/compiler": "0.1.60",
-    "@akashjs/runtime": "0.2.8",
+    "@akashjs/runtime": "0.2.9",
     "@akashjs/vite-plugin": "0.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Bump `@akashjs/runtime` from 0.2.8 to 0.2.9
- Fix memory leak: effects and signal subscriptions in `<For>` are now disposed when rows are removed
- Reduce bundle size: 18.3 KB → 16.0 KB (tree-shaking improvements)

Only `package.json` is changed (runtime version). The `js-framework-benchmark` section and `vite.config.ts` with `base: './'` are preserved.