### PR TITLE
Add keyed Micra implementation

### DIFF
--- a/frameworks/keyed/micra/index.html
+++ b/frameworks/keyed/micra/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Micra-keyed</title>
+    <link href="/css/currentStyle.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div class="container" id="main" data-component="main">
+      <div class="jumbotron">
+        <div class="row">
+          <div class="col-md-6">
+            <h1>Micra-keyed</h1>
+          </div>
+          <div class="col-md-6">
+            <div class="row">
+              <div class="col-sm-6 smallpad">
+                <button
+                  type="button"
+                  class="btn btn-primary btn-block"
+                  id="run"
+                  @click="run"
+                >
+                  Create 1,000 rows
+                </button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button
+                  type="button"
+                  class="btn btn-primary btn-block"
+                  id="runlots"
+                  @click="runLots"
+                >
+                  Create 10,000 rows
+                </button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button
+                  type="button"
+                  class="btn btn-primary btn-block"
+                  id="add"
+                  @click="add"
+                >
+                  Append 1,000 rows
+                </button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button
+                  type="button"
+                  class="btn btn-primary btn-block"
+                  id="update"
+                  @click="update"
+                >
+                  Update every 10th row
+                </button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button
+                  type="button"
+                  class="btn btn-primary btn-block"
+                  id="clear"
+                  @click="clear"
+                >
+                  Clear
+                </button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button
+                  type="button"
+                  class="btn btn-primary btn-block"
+                  id="swaprows"
+                  @click="swapRows"
+                >
+                  Swap Rows
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <table class="table table-hover table-striped test-data">
+        <tbody>
+          <template data-each="data" data-key="id">
+            <tr data-class="danger:item.id === selected">
+              <td class="col-md-1" data-text="item.id"></td>
+              <td class="col-md-4">
+                <a @click="select" data-bind="data-id:item.id" data-text="item.label"></a>
+              </td>
+              <td class="col-md-1">
+                <a @click="remove" data-bind="data-id:item.id"
+                  ><span
+                    class="glyphicon glyphicon-remove"
+                    aria-hidden="true"
+                  ></span
+                ></a>
+              </td>
+              <td class="col-md-6"></td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+
+      <span
+        class="preloadicon glyphicon glyphicon-remove"
+        aria-hidden="true"
+      ></span>
+    </div>
+
+    <script src="node_modules/micra.js/dist/micra.min.js"></script>
+    <script src="src/main.js"></script>
+  </body>
+</html>

--- a/frameworks/keyed/micra/package-lock.json
+++ b/frameworks/keyed/micra/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "js-framework-benchmark-micra",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "js-framework-benchmark-micra",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micra.js": "2.3.2"
+      }
+    },
+    "node_modules/micra.js": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/micra.js/-/micra.js-2.3.2.tgz",
+      "integrity": "sha512-uag6XySAWp6xSaDGwsFapTXdcvrAfxHCPgksVQb6NBgcdrkyuJTNGw2A8xLOMlfNUU5MjOUHH2l2K8XQZ5SuNw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/frameworks/keyed/micra/package.json
+++ b/frameworks/keyed/micra/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "js-framework-benchmark-micra",
+  "version": "1.0.0",
+  "description": "Micra.js keyed implementation",
+  "js-framework-benchmark": {
+    "frameworkVersionFromPackage": "micra.js",
+    "frameworkHomeURL": "https://denisfl.github.io/micra.js/",
+    "language": "JavaScript"
+  },
+  "scripts": {
+    "dev": "exit 0",
+    "build-prod": "exit 0"
+  },
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "dependencies": {
+    "micra.js": "2.3.2"
+  }
+}

--- a/frameworks/keyed/micra/src/main.js
+++ b/frameworks/keyed/micra/src/main.js
@@ -1,0 +1,66 @@
+let idCounter = 1;
+const adjectives = ["pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy"],
+  colours = ["red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange"],
+  nouns = ["table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza", "mouse", "keyboard"];
+
+function _random(max) { return Math.round(Math.random() * 1000) % max; }
+
+function buildData(count) {
+  const data = new Array(count);
+  for (let i = 0; i < count; i++) {
+    data[i] = {
+      id: idCounter++,
+      label: `${adjectives[_random(adjectives.length)]} ${colours[_random(colours.length)]} ${nouns[_random(nouns.length)]}`,
+    };
+  }
+  return data;
+}
+
+Micra.define("main", {
+  // Micra's proxy is shallow by design: every action REPLACES state.data with
+  // a new array (and new objects only for changed rows), which is what drives
+  // the keyed diff. `selected` starts at 0 — row ids start at 1.
+  state: { data: [], selected: 0 },
+
+  run() {
+    this.state.data = buildData(1000);
+    this.state.selected = 0;
+  },
+  runLots() {
+    this.state.data = buildData(10000);
+    this.state.selected = 0;
+  },
+  add() {
+    this.state.data = this.state.data.concat(buildData(1000));
+  },
+  update() {
+    const d = this.state.data;
+    const next = new Array(d.length);
+    for (let i = 0; i < d.length; i++) {
+      next[i] = i % 10 === 0 ? { id: d[i].id, label: d[i].label + " !!!" } : d[i];
+    }
+    this.state.data = next;
+  },
+  clear() {
+    this.state.data = [];
+    this.state.selected = 0;
+  },
+  select(e) {
+    this.state.selected = Number(e.currentTarget.dataset.id);
+  },
+  remove(e) {
+    const id = Number(e.currentTarget.dataset.id);
+    this.state.data = this.state.data.filter((d) => d.id !== id);
+  },
+  swapRows() {
+    const d = this.state.data;
+    if (d.length > 998) {
+      const next = d.slice();
+      next[1] = d[998];
+      next[998] = d[1];
+      this.state.data = next;
+    }
+  },
+});
+
+Micra.start();


### PR DESCRIPTION
This adds a keyed implementation for [Micra.js](https://github.com/denisfl/micra.js) — a ~5 KB (gzip) reactive library for server-rendered pages: shallow-proxy state, data-* directives, keyed list diffing (LIS-based reordering), no build step.

**Implementation notes**:

- Fully idiomatic, no escape hatches: the table is one <template data-each="data" data-key="id">, all mutations replace state.data with a new array (the library's documented pattern — the proxy is intentionally shallow), selection is data-class="danger:item.id === selected".
- No build: build-prod is a no-op; the page loads node_modules/micra.js/dist/micra.min.js directly (same pattern as vanillajs-lite).
- Event handlers take bare method names (@click="select"); row identity is passed via a bound data-id attribute — Micra deliberately has no call-expression syntax in bindings.

Happy to adjust anything to match current contribution guidelines.