### PR TITLE
Bumps the pinned micra.js dependency 2.3.2 → 2.5.0

### DIFF
--- a/frameworks/keyed/micra/package-lock.json
+++ b/frameworks/keyed/micra/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "micra.js": "2.3.2"
+        "micra.js": "2.5.0"
       }
     },
     "node_modules/micra.js": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/micra.js/-/micra.js-2.3.2.tgz",
-      "integrity": "sha512-uag6XySAWp6xSaDGwsFapTXdcvrAfxHCPgksVQb6NBgcdrkyuJTNGw2A8xLOMlfNUU5MjOUHH2l2K8XQZ5SuNw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/micra.js/-/micra.js-2.5.0.tgz",
+      "integrity": "sha512-E30fPd1tMetsuPifKBSAoeBodtr2pUapo64h/eE9HPL/kW26Z1s5pzB6yb+shzgWs2/1rEmu5nRjeceUXs3YaQ==",
       "license": "MIT"
     }
   }

--- a/frameworks/keyed/micra/package.json
+++ b/frameworks/keyed/micra/package.json
@@ -19,6 +19,6 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "micra.js": "2.3.2"
+    "micra.js": "2.5.0"
   }
 }


### PR DESCRIPTION
The #1139 strict-CSP note — Micra 2.5.0 replaced its new Function-based directive-expression compiler with a tokenizer + Pratt parser + AST interpreter, so 2.5.0 needs no unsafe-eval. 

I verified the keyed entry locally under the exact policy staticRouter applies (default-src 'self'; report-uri /csp), exercising create/update/swap/append/clear/select — zero CSP violations. Happy for you to drop #1139 if you agree.