### PR TITLE
Upgrade native document to 1.0.172

### DIFF
--- a/frameworks/keyed/native-document/package-lock.json
+++ b/frameworks/keyed/native-document/package-lock.json
@@ -8,7 +8,7 @@
       "name": "native-document",
       "version": "1.0.13",
       "dependencies": {
-        "native-document": "1.0.158",
+        "native-document": "1.0.171.10",
         "vite": "^8.0.5"
       },
       "devDependencies": {
@@ -908,13 +908,16 @@
       }
     },
     "node_modules/native-document": {
-      "version": "1.0.158",
-      "resolved": "https://registry.npmjs.org/native-document/-/native-document-1.0.158.tgz",
-      "integrity": "sha512-LqwFpcI31L+xCcIunV1fr8Ka9mAqMFmjKjab0p753iMPzdpXYVgr8uZcQZz41rxpbvlS8YLoEOXyX7JKWM4z8Q==",
-      "license": "ISC",
+      "version": "1.0.17-1.10",
+      "resolved": "https://registry.npmjs.org/native-document/-/native-document-1.0.17-1.10.tgz",
+      "integrity": "sha512-G7MxxNqjQAsSHEAecCzSjh37xtANFnsHayD8fEbljqyOVyCsEWBGsxT/IrMf9KCWASSEN8rPw6Ft36OCwBqBQg==",
+      "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
         "i18next": "^25.8.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/open": {

--- a/frameworks/keyed/native-document/package.json
+++ b/frameworks/keyed/native-document/package.json
@@ -12,7 +12,7 @@
     "dev": "vite"
   },
   "dependencies": {
-    "native-document": "1.0.158",
+    "native-document": "1.0.172",
     "vite": "^8.0.5"
   },
   "devDependencies": {

--- a/frameworks/keyed/native-document/src/main.js
+++ b/frameworks/keyed/native-document/src/main.js
@@ -9,24 +9,22 @@ const RemoveIcon = useCache(() => {
   return Link(Span({ class: 'glyphicon glyphicon-remove', 'aria-hidden': true }));
 });
 
+const EmptyCell = useCache(() => Td({ class: 'col-md-6'}));
 
-const TableRowBuilder = useCache(($binder) => {
-  const $isSelected = $binder.class((item) => AppService.selected.when(item.id));
+const TableRowBuilder = (item) => {
 
-  return Tr( { class: { 'danger': $isSelected } }, [
-    Td({ class: 'col-md-1' }, $binder.id),
-    Td({ class: 'col-md-4' }, Link($binder.label)).nd.attach('onClick', AppService.select),
-    Td({ class: 'col-md-1' },
-      RemoveIcon().nd.attach('onClick', AppService.remove)
-    ),
-    Td({ class: 'col-md-6'})
+  return Tr( { class: { 'danger': AppService.selected.when(item.id) } }, [
+    Td({ class: 'col-md-1' }, item.id),
+    Td({ class: 'col-md-4' }, Link(item.label)).nd.onClick(() => AppService.select(item)),
+    Td({ class: 'col-md-1' }, RemoveIcon().nd.onClick(() => AppService.remove(item)),),
+    EmptyCell
   ]);
-});
+};
 
 const App = Div({ class: 'container' }, [
   Jumbotron(),
   Table({ class: 'table table-hover table-striped test-data' },
-    TBody(ForEachArray(AppService.data, TableRowBuilder, { isParentUniqueChild: true}))
+    TBody(ForEachArray(AppService.data, TableRowBuilder, { isParentUniqueChild: true }))
   ),
   Span({ class: 'preloadicon glyphicon glyphicon-remove', 'aria-hidden': true })
 ]);


### PR DESCRIPTION
Upgrade native document 1.0.172

ElementCreator.processChildren and getChild - refactored for better performance
nd-element-extensions - all prototype extensions converted to non-enumerable defineProperty
NDElement events - inline handler (on*) used when no existing handler and no options; falls back to addEventListener for subsequent handlers or when options are provided