### PR TITLE
Update knno-jsx dependencies to version 2.5.1 and adjust package-lock…

### DIFF
--- a/frameworks/keyed/knno-jsx/package-lock.json
+++ b/frameworks/keyed/knno-jsx/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@knno/jsx": "2.3.0",
-				"@knno/jsx-optimizer": "2.2.0"
+				"@knno/jsx": "2.5.1",
+				"@knno/jsx-optimizer": "2.2.1"
 			},
 			"devDependencies": {
 				"@rollup/plugin-node-resolve": "16.0.3",
@@ -628,9 +628,9 @@
 			}
 		},
 		"node_modules/@knno/jsx": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@knno/jsx/-/jsx-2.3.0.tgz",
-			"integrity": "sha512-cHrXUnL8r1y0JDQYhI5vwMSp40ypLUeFj69BC4DxXosOxxuob1uO2Z/mBRphfUqJTfyNzc/bCkx7PzarVzVgYg==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@knno/jsx/-/jsx-2.5.1.tgz",
+			"integrity": "sha512-nRt4CPuU5xT2N0ffWt4pQ+/ns1U5Q1Crc0qfr6jKPLZzW+0PGZ4QlhCBAIt6wcAhEFBz0DUu7E5qzNWsMgfqig==",
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "3.1.3"
@@ -640,9 +640,9 @@
 			}
 		},
 		"node_modules/@knno/jsx-optimizer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@knno/jsx-optimizer/-/jsx-optimizer-2.2.0.tgz",
-			"integrity": "sha512-7ookgjmt52xeP/QN7X9/vnnLRVLDIYbhenZqRkAnWFOgpgRKXW6akj5Zx9ktWigjCPV7Bh6rgjaV7pHnM47WLA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@knno/jsx-optimizer/-/jsx-optimizer-2.2.1.tgz",
+			"integrity": "sha512-j7eGM3JEMwhLwDHyyPAlnQb8/CWD1wbroGW2dusoqCUMifzr1DbdSstb1kBU3wB5QmkISZhef8PPXbnEXspOuQ==",
 			"dependencies": {
 				"@babel/generator": "^7.27",
 				"@babel/parser": "^7.27",

--- a/frameworks/keyed/knno-jsx/package.json
+++ b/frameworks/keyed/knno-jsx/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "dist/main.js",
 	"js-framework-benchmark": {
-		"frameworkVersion": "2.3.0",
+		"frameworkVersion": "2.5.1",
 		"frameworkHomeURL": "https://gitee.com/thor.qin/knno-jsx",
 		"language": "TypeScript"
 	},
@@ -19,8 +19,8 @@
 		"url": "https://github.com/krausest/js-framework-benchmark.git"
 	},
 	"dependencies": {
-		"@knno/jsx": "2.3.0",
-		"@knno/jsx-optimizer": "2.2.0"
+		"@knno/jsx": "2.5.1",
+		"@knno/jsx-optimizer": "2.2.1"
 	},
 	"devDependencies": {
 		"@rollup/plugin-node-resolve": "16.0.3",

--- a/frameworks/non-keyed/knno-jsx/package-lock.json
+++ b/frameworks/non-keyed/knno-jsx/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@knno/jsx": "2.3.0",
-				"@knno/jsx-optimizer": "2.2.0"
+				"@knno/jsx": "2.5.1",
+				"@knno/jsx-optimizer": "2.2.1"
 			},
 			"devDependencies": {
 				"@rollup/plugin-node-resolve": "16.0.3",
@@ -628,9 +628,9 @@
 			}
 		},
 		"node_modules/@knno/jsx": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@knno/jsx/-/jsx-2.3.0.tgz",
-			"integrity": "sha512-cHrXUnL8r1y0JDQYhI5vwMSp40ypLUeFj69BC4DxXosOxxuob1uO2Z/mBRphfUqJTfyNzc/bCkx7PzarVzVgYg==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@knno/jsx/-/jsx-2.5.1.tgz",
+			"integrity": "sha512-nRt4CPuU5xT2N0ffWt4pQ+/ns1U5Q1Crc0qfr6jKPLZzW+0PGZ4QlhCBAIt6wcAhEFBz0DUu7E5qzNWsMgfqig==",
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "3.1.3"
@@ -640,9 +640,9 @@
 			}
 		},
 		"node_modules/@knno/jsx-optimizer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@knno/jsx-optimizer/-/jsx-optimizer-2.2.0.tgz",
-			"integrity": "sha512-7ookgjmt52xeP/QN7X9/vnnLRVLDIYbhenZqRkAnWFOgpgRKXW6akj5Zx9ktWigjCPV7Bh6rgjaV7pHnM47WLA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@knno/jsx-optimizer/-/jsx-optimizer-2.2.1.tgz",
+			"integrity": "sha512-j7eGM3JEMwhLwDHyyPAlnQb8/CWD1wbroGW2dusoqCUMifzr1DbdSstb1kBU3wB5QmkISZhef8PPXbnEXspOuQ==",
 			"dependencies": {
 				"@babel/generator": "^7.27",
 				"@babel/parser": "^7.27",

--- a/frameworks/non-keyed/knno-jsx/package.json
+++ b/frameworks/non-keyed/knno-jsx/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "dist/main.js",
 	"js-framework-benchmark": {
-		"frameworkVersion": "2.3.0",
+		"frameworkVersion": "2.5.1",
 		"frameworkHomeURL": "https://gitee.com/thor.qin/knno-jsx",
 		"language": "TypeScript"
 	},
@@ -19,8 +19,8 @@
 		"url": "https://github.com/krausest/js-framework-benchmark.git"
 	},
 	"dependencies": {
-		"@knno/jsx": "2.3.0",
-		"@knno/jsx-optimizer": "2.2.0"
+		"@knno/jsx": "2.5.1",
+		"@knno/jsx-optimizer": "2.2.1"
 	},
 	"devDependencies": {
 		"@rollup/plugin-node-resolve": "16.0.3",


### PR DESCRIPTION
### Changes
1. Upgrade all knno-jsx dependencies from previous version to 2.5.1
2. Regenerate package-lock.json to lock the new dependency versions

### Reason
Apply latest bug fixes & minor performance improvements.
