### PR TITLE
Add spark-html (keyed) implementation

### DIFF
--- a/frameworks/keyed/spark-html/index.html
+++ b/frameworks/keyed/spark-html/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>spark-html-keyed</title>
+    <link href="/css/currentStyle.css" rel="stylesheet"/>
+</head>
+<body>
+<div id='main' import="components/app"></div>
+<script type="module" src="/src/main.js"></script>
+</body>
+</html>

--- a/frameworks/keyed/spark-html/package-lock.json
+++ b/frameworks/keyed/spark-html/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "js-framework-benchmark-spark-html",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-spark-html",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "spark-html": "^1.1.0"
+        "spark-html": "^1.2.0"
       },
       "devDependencies": {
         "spark-html-bun": "^1.0.0"
       }
     },
     "node_modules/spark-html": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/spark-html/-/spark-html-1.1.0.tgz",
-      "integrity": "sha512-SqOzOE+zwCVAcV392CyVkgJcSKAushJNGM1QJh6E9/PkTxh3Tvqfg/bblfMRhGy5Bl5xKbauuXt8yzf6OtkTlA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/spark-html/-/spark-html-1.2.0.tgz",
+      "integrity": "sha512-CI8CeHxSYIaa7NKxR7VwmSfmOBayinEkECoYGMHa29cIW9qn0RiNI7sywJCscSi8bukBwguXcXI0WXQaXAXCPQ==",
       "license": "MIT",
       "bin": {
         "spark-html": "bin/cli.js"

--- a/frameworks/keyed/spark-html/package-lock.json
+++ b/frameworks/keyed/spark-html/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "js-framework-benchmark-spark-html",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "js-framework-benchmark-spark-html",
+      "version": "1.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spark-html": "^1.1.0"
+      },
+      "devDependencies": {
+        "spark-html-bun": "^1.0.0"
+      }
+    },
+    "node_modules/spark-html": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/spark-html/-/spark-html-1.1.0.tgz",
+      "integrity": "sha512-SqOzOE+zwCVAcV392CyVkgJcSKAushJNGM1QJh6E9/PkTxh3Tvqfg/bblfMRhGy5Bl5xKbauuXt8yzf6OtkTlA==",
+      "license": "MIT",
+      "bin": {
+        "spark-html": "bin/cli.js"
+      }
+    },
+    "node_modules/spark-html-bun": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spark-html-bun/-/spark-html-bun-1.0.0.tgz",
+      "integrity": "sha512-fybZ2Vk0G026jJNyRovSr9egLzshMvIe7t+bEDr/EgW5c25rNUdrhxfoi2weIP+qONl6ywdRJW3bLZgra7CDtw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "spark": "bin/cli.js"
+      },
+      "engines": {
+        "bun": ">=1.2.0"
+      }
+    }
+  }
+}

--- a/frameworks/keyed/spark-html/package.json
+++ b/frameworks/keyed/spark-html/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "js-framework-benchmark-spark-html",
+  "version": "1.1.0",
+  "description": "spark-html keyed benchmark",
+  "js-framework-benchmark": {
+    "frameworkVersionFromPackage": "spark-html",
+    "frameworkHomeURL": "https://spark-html.dev",
+    "issues": [],
+    "language": "JavaScript",
+    "customURL": "/dist"
+  },
+  "scripts": {
+    "dev": "spark dev",
+    "build-prod": "spark build --out-dir dist --base /frameworks/keyed/spark-html/dist/"
+  },
+  "dependencies": {
+    "spark-html": "^1.1.0"
+  },
+  "devDependencies": {
+    "spark-html-bun": "^1.0.0"
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}

--- a/frameworks/keyed/spark-html/package.json
+++ b/frameworks/keyed/spark-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-spark-html",
-  "version": "1.2.0",
+  "version": "1.5.0",
   "description": "spark-html keyed benchmark",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "spark-html",
@@ -14,7 +14,7 @@
     "build-prod": "spark build --out-dir dist --base /frameworks/keyed/spark-html/dist/"
   },
   "dependencies": {
-    "spark-html": "^1.2.0"
+    "spark-html": "^1.5.0"
   },
   "devDependencies": {
     "spark-html-bun": "^1.0.0"

--- a/frameworks/keyed/spark-html/package.json
+++ b/frameworks/keyed/spark-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-spark-html",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "spark-html keyed benchmark",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "spark-html",
@@ -14,7 +14,7 @@
     "build-prod": "spark build --out-dir dist --base /frameworks/keyed/spark-html/dist/"
   },
   "dependencies": {
-    "spark-html": "^1.5.0"
+    "spark-html": "^1.6.0"
   },
   "devDependencies": {
     "spark-html-bun": "^1.0.0"

--- a/frameworks/keyed/spark-html/package.json
+++ b/frameworks/keyed/spark-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-spark-html",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "spark-html keyed benchmark",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "spark-html",
@@ -14,7 +14,7 @@
     "build-prod": "spark build --out-dir dist --base /frameworks/keyed/spark-html/dist/"
   },
   "dependencies": {
-    "spark-html": "^1.1.0"
+    "spark-html": "^1.2.0"
   },
   "devDependencies": {
     "spark-html-bun": "^1.0.0"

--- a/frameworks/keyed/spark-html/package.json
+++ b/frameworks/keyed/spark-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-spark-html",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "spark-html keyed benchmark",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "spark-html",
@@ -14,7 +14,7 @@
     "build-prod": "spark build --out-dir dist --base /frameworks/keyed/spark-html/dist/"
   },
   "dependencies": {
-    "spark-html": "^1.6.0"
+    "spark-html": "^1.7.0"
   },
   "devDependencies": {
     "spark-html-bun": "^1.0.0"
@@ -22,3 +22,4 @@
   "author": "",
   "license": "Apache-2.0"
 }
+

--- a/frameworks/keyed/spark-html/public/components/app.html
+++ b/frameworks/keyed/spark-html/public/components/app.html
@@ -1,0 +1,114 @@
+<div class="container">
+  <div class="jumbotron">
+    <div class="row">
+      <div class="col-md-6">
+        <h1>spark-html-keyed</h1>
+      </div>
+      <div class="col-md-6">
+        <div class="row">
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block" id="run" onclick="{run}">Create 1,000 rows</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block" id="runlots" onclick="{runLots}">Create 10,000 rows</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block" id="add" onclick="{add}">Append 1,000 rows</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block" id="update" onclick="{update}">Update every 10th row</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block" id="clear" onclick="{clear}">Clear</button>
+          </div>
+          <div class="col-sm-6 smallpad">
+            <button type="button" class="btn btn-primary btn-block" id="swaprows" onclick="{swapRows}">Swap Rows</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <table class="table table-hover table-striped test-data">
+    <tbody id="tbody">
+      <template each="row in rows" key="row.id">
+        <tr :class="row.id === selected ? 'danger' : ''">
+          <td class="col-md-1">{row.id}</td>
+          <td class="col-md-4"><a onclick="{select(row.id)}">{row.label}</a></td>
+          <td class="col-md-1"><a onclick="{remove(row.id)}"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td>
+          <td class="col-md-6"></td>
+        </tr>
+      </template>
+    </tbody>
+  </table>
+  <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
+</div>
+
+<script>
+  let rows = [];
+  let selected = null;
+  let nextId = 1;
+
+  const adjectives = ["pretty","large","big","small","tall","short","long","handsome","plain","quaint","clean","elegant","easy","angry","crazy","helpful","mushy","odd","unsightly","adorable","important","inexpensive","cheap","expensive","fancy"];
+  const colours = ["red","yellow","blue","green","pink","brown","purple","brown","white","black","orange"];
+  const nouns = ["table","chair","house","bbq","desk","car","pony","cookie","sandwich","burger","pizza","mouse","keyboard"];
+
+  function random(max) {
+    return Math.round(Math.random() * 1000) % max;
+  }
+
+  function buildData(count) {
+    const data = [];
+    for (let i = 0; i < count; i++) {
+      data.push({
+        id: nextId++,
+        label: adjectives[random(adjectives.length)] + ' ' + colours[random(colours.length)] + ' ' + nouns[random(nouns.length)],
+      });
+    }
+    return data;
+  }
+
+  function run() {
+    rows = buildData(1000);
+    selected = null;
+  }
+
+  function runLots() {
+    rows = buildData(10000);
+    selected = null;
+  }
+
+  function add() {
+    rows = rows.concat(buildData(1000));
+  }
+
+  function update() {
+    const next = rows.slice();
+    for (let i = 0; i < next.length; i += 10) {
+      next[i] = { id: next[i].id, label: next[i].label + ' !!!' };
+    }
+    rows = next;
+  }
+
+  function select(id) {
+    selected = id;
+  }
+
+  function remove(id) {
+    rows = rows.filter((r) => r.id !== id);
+  }
+
+  function clear() {
+    rows = [];
+    selected = null;
+  }
+
+  function swapRows() {
+    if (rows.length > 998) {
+      const next = rows.slice();
+      const tmp = next[1];
+      next[1] = next[998];
+      next[998] = tmp;
+      rows = next;
+    }
+  }
+</script>

--- a/frameworks/keyed/spark-html/src/main.js
+++ b/frameworks/keyed/spark-html/src/main.js
@@ -1,0 +1,3 @@
+import { mount } from 'spark-html';
+
+mount();


### PR DESCRIPTION
Adds a keyed implementation for **spark-html** ([spark-html.dev](https://spark-html.dev), [npm](https://www.npmjs.com/package/spark-html)) — a no-build reactive HTML framework: the `.html` file the author writes is what runs in the browser (no compiler, no virtual DOM, single-file components). This implementation uses spark-html 1.1.0 from npm.

**Implementation notes**
- Keyed via `<template each="row in rows" key="row.id">` — the framework's standard keyed-list syntax (LIS-based reconciliation internally; a swap is 2 DOM moves).
- Row markup matches the vanillajs reference byte-for-byte, including `aria-hidden="true"`.
- State updates are the idiomatic immutable style (`rows = next`); `select` is plain state (`selected = id`) read by a per-row `:class` binding — no per-row selected flags (#800), no client-code event delegation (#801; handlers are per-row `onclick` attributes in the template), no direct DOM manipulation in app code (#772).
- Built with the framework's own tool (`spark-html-bun`) via `npm run build-prod`; `customURL` points at `dist`. Framework version resolves from npm via `frameworkVersionFromPackage`.
- `isKeyed` passes for run/remove/swap locally.

Happy to adjust anything that doesn't match current conventions.