### PR TITLE
chore: upgrade vue versions

### DIFF
--- a/frameworks/keyed/vue-jsx-compiler/package-lock.json
+++ b/frameworks/keyed/vue-jsx-compiler/package-lock.json
@@ -8,8 +8,8 @@
       "name": "js-framework-benchmark-vue-jsx-compiler",
       "version": "1.0.0",
       "dependencies": {
-        "vue": "^3.6.0-alpha.2",
-        "vue-jsx-vapor": "^3.1.4"
+        "vue": "^3.6.0-beta.17",
+        "vue-jsx-vapor": "^3.2.18"
       },
       "devDependencies": {
         "esbuild": "^0.25.12",
@@ -18,30 +18,30 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -51,33 +51,33 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -582,19 +582,21 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -948,9 +950,9 @@
       ]
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -965,31 +967,31 @@
       "license": "MIT"
     },
     "node_modules/@vue-jsx-vapor/compiler-rs": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs/-/compiler-rs-3.1.22.tgz",
-      "integrity": "sha512-CHKpxYP6XXlo9JL3VaIsGY1Piw/OZ2hDGsTH//gvi0dOKVnOMTRW5A80cHDw1B9sZl2XU9jDTWlGCtTuvxHg4Q==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs/-/compiler-rs-3.2.18.tgz",
+      "integrity": "sha512-CbFqwcYmdOxXSNHlZJMqHYcvgZbDWr9kMpIzXtFNpsW9+D4uJLY72T4MTJ79NG9Gpl33kq3jz7RCnV9GCBxxpA==",
       "license": "MIT",
       "optionalDependencies": {
-        "@vue-jsx-vapor/compiler-rs-android-arm-eabi": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-android-arm64": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-darwin-arm64": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-darwin-x64": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-freebsd-x64": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-linux-arm64-gnu": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-linux-arm64-musl": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-linux-x64-gnu": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-linux-x64-musl": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-wasm32-wasi": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-win32-arm64-msvc": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-win32-ia32-msvc": "3.1.22",
-        "@vue-jsx-vapor/compiler-rs-win32-x64-msvc": "3.1.22"
+        "@vue-jsx-vapor/compiler-rs-android-arm-eabi": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-android-arm64": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-darwin-arm64": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-darwin-x64": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-freebsd-x64": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-arm64-gnu": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-arm64-musl": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-x64-gnu": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-x64-musl": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-wasm32-wasi": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-win32-arm64-msvc": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-win32-ia32-msvc": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-win32-x64-msvc": "3.2.18"
       }
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-android-arm-eabi": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-android-arm-eabi/-/compiler-rs-android-arm-eabi-3.1.22.tgz",
-      "integrity": "sha512-Bu0n/qBxVV/pNGhSsafQWp1bu+EKATZZ4t7yNoJVhExAf0HPBuyBeANSM5825ZnyVgqCymh4OiwZQcXNOCPCqQ==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-android-arm-eabi/-/compiler-rs-android-arm-eabi-3.2.18.tgz",
+      "integrity": "sha512-XZCcernaJOUCPyOaB5BuPgJS06h24HuV4XpM0JMHiC3JKM5JuK39Egy9sEoY2G/HF05+GaHJ9bOThaH29JzABg==",
       "cpu": [
         "arm"
       ],
@@ -1000,9 +1002,9 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-android-arm64": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-android-arm64/-/compiler-rs-android-arm64-3.1.22.tgz",
-      "integrity": "sha512-Q1NW9uj2AY0qpIhBI4XtwF/NdYuSR7ETET+fzCEIVNhsn4OnCEgZDGk40XPluriv9D69iorqKmsQibs9sitZdg==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-android-arm64/-/compiler-rs-android-arm64-3.2.18.tgz",
+      "integrity": "sha512-0JsyjDahmxbjIbNah2v/v6aPeAi4Zua7eSSmn/q5EyqvM8FZ1kcIx53Kg0cqTnYrQWWun0I/o3pPFQezDJiifQ==",
       "cpu": [
         "arm64"
       ],
@@ -1013,9 +1015,9 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-darwin-arm64": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-darwin-arm64/-/compiler-rs-darwin-arm64-3.1.22.tgz",
-      "integrity": "sha512-joAme9BvSGu3M7EkuuvminjQ2e1TIyu7ClDalu9Famd4Sx7mnkvCmHE8bx+3lJ7MUcZ21Ef6z4azF3nTObUuZw==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-darwin-arm64/-/compiler-rs-darwin-arm64-3.2.18.tgz",
+      "integrity": "sha512-9SWROILFTK8XAEHk1iuZBkb3GqIPZ1bONpV4LLsUmBCpfFnmbLCzmrmu7orUVfd63fhXlhhHmtl6Z2A+6ZnE+w==",
       "cpu": [
         "arm64"
       ],
@@ -1026,9 +1028,9 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-darwin-x64": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-darwin-x64/-/compiler-rs-darwin-x64-3.1.22.tgz",
-      "integrity": "sha512-zUaNfMuMtln9deFx7YHWdJ7vCMhIFYaxMwVMOUrLEg9JhEsLgv4E4NMtaBN6R2dzJAIOgeciM+VkGQSwrULWFg==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-darwin-x64/-/compiler-rs-darwin-x64-3.2.18.tgz",
+      "integrity": "sha512-Xr68QpqU98nrpxuOuZrySnQhCV2IoIgow1NzlUDGhjpefKlJqLvR2Pk3rKJRY7y69/0/LgnWe+vZSjlvsN7XlA==",
       "cpu": [
         "x64"
       ],
@@ -1039,9 +1041,9 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-freebsd-x64": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-freebsd-x64/-/compiler-rs-freebsd-x64-3.1.22.tgz",
-      "integrity": "sha512-XOYVaEfa+/2tpM9maJAMcHt2Erggnl9tRTBcl7aWLk/ToPjA+Fd52qN7KCWLFqRnh4UrmyBE+CZccY5Ne0ayyg==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-freebsd-x64/-/compiler-rs-freebsd-x64-3.2.18.tgz",
+      "integrity": "sha512-QI77aoJAIgECyDWf1QPi93qTYDCVHZgkTo3c6fCt0F13ux9uC7fzV3cD5BDhKSogDF5YpFY9buITKT4Vasy7hQ==",
       "cpu": [
         "x64"
       ],
@@ -1052,9 +1054,9 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf/-/compiler-rs-linux-arm-gnueabihf-3.1.22.tgz",
-      "integrity": "sha512-Wv+cpe/OC22q7dokryCOBqlPEq3EvB789gW8joDUW+slVZIg9fbU72++V2VvGVOvgKeW5YeWGrqkRgujnSHcIQ==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf/-/compiler-rs-linux-arm-gnueabihf-3.2.18.tgz",
+      "integrity": "sha512-GCC08O68n2eXPsarmR3ZZ9FMydG+OInhIPTJC9pIA1ndE7+tMxMNEjvMZS1qSIX5qxPriNsB+FWb4pWdWS62Hg==",
       "cpu": [
         "arm"
       ],
@@ -1065,11 +1067,14 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-linux-arm64-gnu": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-arm64-gnu/-/compiler-rs-linux-arm64-gnu-3.1.22.tgz",
-      "integrity": "sha512-0IoFWW13C+pViTl7wX69SBaQ2GZFjOhxZC3IXiDj0yrZyA0Q2zvp5GzE9Y/0sDKTLIp6Da4QVpk/FpX09Mvr7Q==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-arm64-gnu/-/compiler-rs-linux-arm64-gnu-3.2.18.tgz",
+      "integrity": "sha512-mHaQm7PCu3JgDTv8DlLfEk7MigMLr1PgELw5GgE8bCka8ur0Qn1WBpCLlWdg/thnt4fY9/8+IZ5ZgG34z9kLUg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1078,11 +1083,14 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-linux-arm64-musl": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-arm64-musl/-/compiler-rs-linux-arm64-musl-3.1.22.tgz",
-      "integrity": "sha512-z/pOq9/IBGAPT7AvmW0cm1nMTC5+LVjYJf634sd8eaCljeuG+T9o78qLPUa2JJpUxV2m6p6r+VMPzRrhl5EYCw==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-arm64-musl/-/compiler-rs-linux-arm64-musl-3.2.18.tgz",
+      "integrity": "sha512-EaZ60NtNvY9TgHT8aT/rXykPdk8oXiixEsqn6PbJMZixpLGlXgpU0lCn9YwstVRwM3dyPCA4WGJhkBD7vKq2Mw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1091,11 +1099,14 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-linux-x64-gnu": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-x64-gnu/-/compiler-rs-linux-x64-gnu-3.1.22.tgz",
-      "integrity": "sha512-PgQl7XQXqtWCJlctrxMuW+RHAWqZ0XoH4E9HM6OKJTcZR0GvZDRvp1cRYgbB/EseIib/lfMWjlHMiTo3dIqGQw==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-x64-gnu/-/compiler-rs-linux-x64-gnu-3.2.18.tgz",
+      "integrity": "sha512-0EAxA6hzwTE+OD44J8l3n6b/xEgwcmSkp+ITjZ2SGqJgNZH5eq8fvPaxe7xizoEz1M8xQuUd0NYggcUJ1yvsKQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1104,11 +1115,14 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-linux-x64-musl": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-x64-musl/-/compiler-rs-linux-x64-musl-3.1.22.tgz",
-      "integrity": "sha512-dDlXErxtmcF6iG4ITwSQgJiTjKkgf0ftNFcPxI+0LkRsKRxgyhfuvvaTsS8MjfZxUeYDXiNlkkwWwMzhDTzgfQ==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-x64-musl/-/compiler-rs-linux-x64-musl-3.2.18.tgz",
+      "integrity": "sha512-DT5BqrmH7q9Fx9hEZ2PvPV39kNaJf3EKig23JKI1AJT3GOLSB5E1A3Kp+fNf4KTQ4mWgQZ63+Nhk05CirQJ8Ig==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1117,25 +1131,27 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-wasm32-wasi": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-wasm32-wasi/-/compiler-rs-wasm32-wasi-3.1.22.tgz",
-      "integrity": "sha512-GhHvHaHUamEi602N3IOEYf/x+zGv1e+oZlQx0xQM7Hiob4vBumg3jTrGxvXuKxewZh1rcoar+UQXa+L12D8W8w==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-wasm32-wasi/-/compiler-rs-wasm32-wasi-3.2.18.tgz",
+      "integrity": "sha512-Rwjw0lUhaAhEpzzo+7OpeR8Y516p+vP1ka2JAmXxwcsomelvvSn/37CZo2xlfpC/tFtH/L3tI17qZK0SNQccAw==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-win32-arm64-msvc": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-win32-arm64-msvc/-/compiler-rs-win32-arm64-msvc-3.1.22.tgz",
-      "integrity": "sha512-cZMyVd8910MRNBR6trf/h1J/aTpsSADUnW6+otf2IbTZ3J+UZg3G/fY1lr3qQumVYqTMAYfvlQL58Eczy4VXeg==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-win32-arm64-msvc/-/compiler-rs-win32-arm64-msvc-3.2.18.tgz",
+      "integrity": "sha512-NqnAgwQgLwJW+p5cZLIfNHnwUvAXXlJHBImDRkH/Fr0wpZC89S0WSydFieyPSroIU+ax7O7zPY0lrJwppOWaBA==",
       "cpu": [
         "arm64"
       ],
@@ -1146,9 +1162,9 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-win32-ia32-msvc": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-win32-ia32-msvc/-/compiler-rs-win32-ia32-msvc-3.1.22.tgz",
-      "integrity": "sha512-lZFYS6nQbDbbSlgEKl9RE/iSP3o3mzkRS2/TdOdQaEUSG3Qw1nFDd9ZHvU+XaBrpaqMla7ZDm07v4ZingtePVw==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-win32-ia32-msvc/-/compiler-rs-win32-ia32-msvc-3.2.18.tgz",
+      "integrity": "sha512-IYqu//HlI7gZ6dMUZMxpIvCqEsanxBpZ66T2oxE1aVrSgj/CJoSynw0x3KBe8cGYo6CR/9twCz9NRcMCJN417w==",
       "cpu": [
         "ia32"
       ],
@@ -1159,9 +1175,9 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/compiler-rs-win32-x64-msvc": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-win32-x64-msvc/-/compiler-rs-win32-x64-msvc-3.1.22.tgz",
-      "integrity": "sha512-DaRn8TJS81YD5CXqXHLibT4BOcZZbtMuigUdLZJF9urOggE1yg71HQKgv31P7Feln+JkyqAuHEbX+lrWO16NfA==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-win32-x64-msvc/-/compiler-rs-win32-x64-msvc-3.2.18.tgz",
+      "integrity": "sha512-jaYa6XYepMy5oF+/qok8bWYSPvL/giqopsbHJHiQSCTvplctodvBW+VsJCOCCWyadN6c5rXPfLgUmgwPgdbz1w==",
       "cpu": [
         "x64"
       ],
@@ -1172,9 +1188,9 @@
       ]
     },
     "node_modules/@vue-jsx-vapor/macros": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/macros/-/macros-3.1.22.tgz",
-      "integrity": "sha512-m2WM1eu0W7kBcTfdydw8Tpp8i1JFL7Li6QROvDCA37puCq3mgK57PutWA/h/mL6o8MBo9Dgg4Gtwo+zjLn2hQQ==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/macros/-/macros-3.2.18.tgz",
+      "integrity": "sha512-dOUedO348AcrHWkIzvDQd7Re6WkPS3HqjUBFMu+PPb41lHXs+OsDyytGFGqaB9LYOWuCFBY4QLfO/d+ubzudJw==",
       "license": "MIT",
       "dependencies": {
         "hash-sum": "^2.0.0",
@@ -1214,140 +1230,140 @@
       }
     },
     "node_modules/@vue-jsx-vapor/runtime": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/runtime/-/runtime-3.1.22.tgz",
-      "integrity": "sha512-TZhT0db2hlOYxCqPean97jOMaqi3+DvLEiXfHpxDuf22NzG1kyRMC5oqZqMrxz8C6M+l5YZpzrXmBXgk2aUGLQ==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/runtime/-/runtime-3.2.18.tgz",
+      "integrity": "sha512-bB4oYcgAWlA/Lvbvn93Q997PvjEvjMgGSWC2frrhK/bRKQ9QNFBFpNCdJfA7GxCWgGMt0cziUOdwmNJcCtGcQA==",
       "license": "MIT",
       "peerDependencies": {
         "csstype": "^3.2.3",
-        "vue": "3.6.0-beta.6"
+        "vue": "3.6.0-beta.16"
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.6.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-beta.6.tgz",
-      "integrity": "sha512-0/YAWFJKJEpYMiMkNaYgUxbf4TWVrCnZ4Pmp898yQUJgQ3B+E2usG8n4tCytniGIIQ3BoLnkUipTNia8g6vp8A==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-beta.17.tgz",
+      "integrity": "sha512-4xB2W8+00h7bfHbVeHD+zI+bmyF+XgQBKCCWLjFJ/VCJ/1tBjnlzWpX0OqcOE78LktGiCGcKgNk+eZAuav5cqg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@vue/shared": "3.6.0-beta.6",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.6.0-beta.17",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.6.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-beta.6.tgz",
-      "integrity": "sha512-kX9aROGuDCz9YTvPiOltOsZ4lu2lAH9rMc5tFt7zrFs2KNBXON4HDSg5Vnu4kTb5tNhM/8YX1Cv2XjwmaCD6Wg==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-beta.17.tgz",
+      "integrity": "sha512-viCM7YwHK6HuQ9rY8O27ET1xLi9WeJ+EmMWlwvtggpqb2j+l7DZOATkCRXOivjTOqtt8h5MIGnlB7tQlupQgeA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.6.0-beta.6",
-        "@vue/shared": "3.6.0-beta.6"
+        "@vue/compiler-core": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.6.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-beta.6.tgz",
-      "integrity": "sha512-hQL0RqB4jNf9QFUvl8xl7nDHZdsWE3IysbMAbgVUmQvhzmFdnP6Bcp8FnyGBhxwo6IJouQoT0HniKudXP13aGA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-beta.17.tgz",
+      "integrity": "sha512-L3KGWeWDCqm1tL03m09IXKRhIEh0Ij2gEIax9W0smDtlCAQt4gc8dmeTbjTOg4+1N2qAFEaAs+0xVu9y1j7Sng==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@vue/compiler-core": "3.6.0-beta.6",
-        "@vue/compiler-dom": "3.6.0-beta.6",
-        "@vue/compiler-ssr": "3.6.0-beta.6",
-        "@vue/compiler-vapor": "3.6.0-beta.6",
-        "@vue/shared": "3.6.0-beta.6",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.6.0-beta.17",
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/compiler-ssr": "3.6.0-beta.17",
+        "@vue/compiler-vapor": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.14",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.6.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-beta.6.tgz",
-      "integrity": "sha512-UkaN+QhSQh4Nc9BiQZvH7fuL+3RDWOvGc+zuHCwUsR8FLOxNbuUKsDe0FlFk914xDDx4IUYzJKyIeSEzqoxCYA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-beta.17.tgz",
+      "integrity": "sha512-OWBt5fu62UGeGTcl3Ra5ocMZbJ3h8ze862g9GlS72CNsYYZTbh3V9LePoOp6WX73SdsSdbsWLSsZfi5Wgh+ggQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-beta.6",
-        "@vue/shared": "3.6.0-beta.6"
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/compiler-vapor": {
-      "version": "3.6.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-beta.6.tgz",
-      "integrity": "sha512-U04KIqp/YYRVt+GU2pGZhZ+q4GWm/Ii2SFrwZqCjXFghU4f5+21Ba6Sru9FzuaYzRY4ubdUz9bpKE0BVd2d46Q==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-beta.17.tgz",
+      "integrity": "sha512-8qqHnEwQVytCnaF9zSOtcZxnYxz+FJqBNl9zIpSKwKRStl4XqmgcXlHtJYQMCxZS6xa7JfPvutkt5mBneh07Yw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@vue/compiler-dom": "3.6.0-beta.6",
-        "@vue/shared": "3.6.0-beta.6",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.6.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-beta.6.tgz",
-      "integrity": "sha512-DWpq1Qk23XFWZI0dAho9koJNV+fjOJv5YNmLO2yymyjtDpraRaot+gQQlmyut3dEt4gIUKUHF7H/azi7ub5mZQ==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-beta.17.tgz",
+      "integrity": "sha512-oKLiLZRomHyJ++367F286Er49TXazWofj1PbNFUBoRxNNLne8xlDHAypN+C9Yr+JfAIN9cRp8l1PdjwfwMsV8g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.6.0-beta.6"
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.6.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-beta.6.tgz",
-      "integrity": "sha512-whCWAVoBnac1rlLdAu17IrG4E1t05a44VOpvXWo+mYWgq28ukaoQmr3w7LPLyUU7ehWOh+Gp31fxAbKSArherg==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-beta.17.tgz",
+      "integrity": "sha512-JDPvmiyLpXtTnpG6I9URF88bOF+7KVgpDvPvZVl9AMboQj+LW4Pp19QOhGzxGoKES6wBts8c4xM1zjtr0xHcQw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-beta.6",
-        "@vue/shared": "3.6.0-beta.6"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.6.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-beta.6.tgz",
-      "integrity": "sha512-auc/UnNwB+Vcydp+HpV63a0WbDSueteT8OZNhcKicWtvRSVfxPAp83pVNtiY+CvRp4myl28Nxewff19XK+u1kw==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-beta.17.tgz",
+      "integrity": "sha512-7B02MUGEFzuJaMbhxtgNRSMOrbj+AlERBy1EBxrXHplHSwv8xQjJpiBk0Z+5+vQMDVS4zc8VIYgeP7CUyROpUg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-beta.6",
-        "@vue/runtime-core": "3.6.0-beta.6",
-        "@vue/shared": "3.6.0-beta.6",
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/runtime-core": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/runtime-vapor": {
-      "version": "3.6.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-beta.6.tgz",
-      "integrity": "sha512-psN1lh/LJS7FS/KE8+JJYvdFWySq09Ww9xCFnXOaISFwh/2VWs5AvcAAq9dgk6+Z0qMUjrVVbspa6byLVCP/aA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-beta.17.tgz",
+      "integrity": "sha512-nJpdHuMOXMEmVUrRTEo4AEDPreBja9euIXHjvUe4aEk1pmTKs61hQRluAdETRyXZwkyFe6D6+fXxvKf5wPBJBg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-beta.6",
-        "@vue/shared": "3.6.0-beta.6"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
-        "@vue/runtime-dom": "3.6.0-beta.6"
+        "@vue/runtime-dom": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.6.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-beta.6.tgz",
-      "integrity": "sha512-IL8RRjIuNmmh4JZmne48htACrvTAYw+IvvGHezpSmom5uzXUyEW9VJqhda9LBnjEBWFVNImzAJGrQ1IZB9X1vg==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-beta.17.tgz",
+      "integrity": "sha512-C7YpoWxewo01cG+S51MouH1v6taXBU5XvmxPjPAI3E9Zn3gpzb49e/ikShA5ov8ijE9R7tyIOUk4QU2xoDiT+Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.6.0-beta.6",
-        "@vue/shared": "3.6.0-beta.6"
+        "@vue/compiler-ssr": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
-        "vue": "3.6.0-beta.6"
+        "vue": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.6.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-beta.6.tgz",
-      "integrity": "sha512-CR/Df2m47Ou7mzF4IksSqfLpk5KtP1KBssocpoSSUbS/dUXPDRS/gRKT59LA3XHmluvnrMw+PYKuf5mzJPFt1Q==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-beta.17.tgz",
+      "integrity": "sha512-iuDH2UPBc8nzqgL4dcLiqpAJoJfQe70RcPM34+p+dVk0ThJD9jjpLPjzouP+RoRrXkAPOC7jmMncafdv69BGaA==",
       "license": "MIT"
     },
     "node_modules/csstype": {
@@ -1471,9 +1487,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -1501,9 +1517,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1513,9 +1529,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
       "funding": [
         {
           "type": "opencollective",
@@ -1532,7 +1548,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1628,27 +1644,67 @@
       "optional": true
     },
     "node_modules/unplugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
-      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+      "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@farmfe/core": "*",
+        "@rspack/core": "*",
+        "bun-types-no-globals": "*",
+        "esbuild": "*",
+        "rolldown": "*",
+        "rollup": "*",
+        "unloader": "*",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "@farmfe/core": {
+          "optional": true
+        },
+        "@rspack/core": {
+          "optional": true
+        },
+        "bun-types-no-globals": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "unloader": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/unplugin-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
-      "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+      "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -2217,17 +2273,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.6.0-beta.6",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-beta.6.tgz",
-      "integrity": "sha512-xtAUa5mT3x8un9Ck8bkuvZYU9Bx0TTjlsrbJe5p/51zcz00+on3QuL0rODYlp+W7QIpGBgZZo/KFIK8SLZoSIQ==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-beta.17.tgz",
+      "integrity": "sha512-sVvFEriOhBjKIi7Jy+vwnlcBVRKhvxMVG4lh2erX1vrlaNKggURyWttRF+z5Vo+6VYriVsXAUyOgaQZub0W8ug==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-beta.6",
-        "@vue/compiler-sfc": "3.6.0-beta.6",
-        "@vue/runtime-dom": "3.6.0-beta.6",
-        "@vue/runtime-vapor": "3.6.0-beta.6",
-        "@vue/server-renderer": "3.6.0-beta.6",
-        "@vue/shared": "3.6.0-beta.6"
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/compiler-sfc": "3.6.0-beta.17",
+        "@vue/runtime-dom": "3.6.0-beta.17",
+        "@vue/runtime-vapor": "3.6.0-beta.17",
+        "@vue/server-renderer": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -2239,15 +2295,15 @@
       }
     },
     "node_modules/vue-jsx-vapor": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/vue-jsx-vapor/-/vue-jsx-vapor-3.1.22.tgz",
-      "integrity": "sha512-rSmFHDU0PkWXnI8vnMrvxX9sFOI4RmtPnXhjlxo7pMh1bmJt/Z+WcSJj4z/iliEKFjkXVFT2M4Vb7+NJG4rxWw==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/vue-jsx-vapor/-/vue-jsx-vapor-3.2.18.tgz",
+      "integrity": "sha512-aSxXlNHIpv8V6Yg8g4adojeQal+O3s/vijKWdC94dSyfVucMAIJNKKWv1dQtI81aDNYkvtTFw0XHSM69gXsxPA==",
       "license": "MIT",
       "dependencies": {
-        "@vue-jsx-vapor/compiler-rs": "3.1.22",
-        "@vue-jsx-vapor/macros": "3.1.22",
-        "@vue-jsx-vapor/runtime": "3.1.22",
-        "@vue/shared": "3.6.0-beta.6",
+        "@vue-jsx-vapor/compiler-rs": "3.2.18",
+        "@vue-jsx-vapor/macros": "3.2.18",
+        "@vue-jsx-vapor/runtime": "3.2.18",
+        "@vue/shared": "3.6.0-beta.16",
         "pathe": "^2.0.3",
         "ts-macro": "^0.3.7",
         "unplugin": "^3.0.0",
@@ -2282,6 +2338,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vue-jsx-vapor/node_modules/@vue/shared": {
+      "version": "3.6.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-beta.16.tgz",
+      "integrity": "sha512-DyuxocDJp/vbmQKnrVzHEs8QrJv2XFnvgyri0W0Ni8+TmoiDSd86NaDoF32yRcIBstxKKL6X6nia7JPjZHia6w==",
+      "license": "MIT"
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",

--- a/frameworks/keyed/vue-jsx-compiler/package.json
+++ b/frameworks/keyed/vue-jsx-compiler/package.json
@@ -14,8 +14,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.6.0-alpha.2",
-    "vue-jsx-vapor": "^3.1.4"
+    "vue": "^3.6.0-beta.17",
+    "vue-jsx-vapor": "^3.2.18"
   },
   "devDependencies": {
     "esbuild": "^0.25.12",

--- a/frameworks/keyed/vue-jsx-vapor/package-lock.json
+++ b/frameworks/keyed/vue-jsx-vapor/package-lock.json
@@ -8,312 +8,38 @@
       "name": "js-framework-benchmark-vue-jsx-vapor",
       "version": "2.0.1",
       "dependencies": {
-        "vue": "3.6.0-alpha.2"
+        "vue": "^3.6.0-beta.17"
       },
       "devDependencies": {
         "vite": "^7.0.5",
-        "vue-jsx-vapor": "^2.6.0"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
-      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.6",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.0",
-        "@babel/types": "^7.28.0",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.27.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-member-expression-to-functions": "^7.27.1",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
-      "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-      "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.27.1",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
+        "vue-jsx-vapor": "^3.2.18"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
-      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -322,103 +48,51 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
-      "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-create-class-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/plugin-syntax-typescript": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -847,13 +521,24 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -868,15 +553,15 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -884,20 +569,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@quansync/fs": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-0.1.3.tgz",
-      "integrity": "sha512-G0OnZbMWEs5LhDyqy2UL17vGhSVHkQIfVojMtEWVenvj0V5S84VBgy86kJIuNsGDp2p7sTKlpSIpBUWdC35OKg==",
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "quansync": "^0.2.10"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sxzz"
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1180,6 +868,17 @@
         "win32"
       ]
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1187,66 +886,254 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@volar/language-core": {
-      "version": "2.4.20",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.20.tgz",
-      "integrity": "sha512-dRDF1G33xaAIDqR6+mXUIjXYdu9vzSxlMGfMEwBxQsfY/JMUEXSpLTR057oTKlUQ2nIvCmP9k94A8h8z2VrNSA==",
+    "node_modules/@vue-jsx-vapor/compiler-rs": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs/-/compiler-rs-3.2.18.tgz",
+      "integrity": "sha512-CbFqwcYmdOxXSNHlZJMqHYcvgZbDWr9kMpIzXtFNpsW9+D4uJLY72T4MTJ79NG9Gpl33kq3jz7RCnV9GCBxxpA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@volar/source-map": "2.4.20"
+      "optionalDependencies": {
+        "@vue-jsx-vapor/compiler-rs-android-arm-eabi": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-android-arm64": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-darwin-arm64": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-darwin-x64": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-freebsd-x64": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-arm64-gnu": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-arm64-musl": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-x64-gnu": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-x64-musl": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-wasm32-wasi": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-win32-arm64-msvc": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-win32-ia32-msvc": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-win32-x64-msvc": "3.2.18"
       }
     },
-    "node_modules/@volar/source-map": {
-      "version": "2.4.20",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.20.tgz",
-      "integrity": "sha512-mVjmFQH8mC+nUaVwmbxoYUy8cww+abaO8dWzqPUjilsavjxH0jCJ3Mp8HFuHsdewZs2c+SP+EO7hCd8Z92whJg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue-jsx-vapor/babel": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/babel/-/babel-2.6.0.tgz",
-      "integrity": "sha512-ZBo/ocfZim7osl+GAKl9KN9u26T3odnjmE4djlI2f5Uwz1aHkagKeu2Ouq6tRSq/xJQKgp3r6H69tqDY4ICkkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/parser": "^7.28.0",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/types": "^7.28.0",
-        "@vue-jsx-vapor/compiler": "2.6.0",
-        "ast-kit": "^2.1.1",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-jsx-vapor/compiler": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler/-/compiler-2.6.0.tgz",
-      "integrity": "sha512-ANvRnrhz3b3wrUhPj5Q7qzI2OaDpMy4A0WYGNCbQHwFLlbofMuNmordUUi6/1bonqrRDZvN2Yv8OM+h19/XdHQ==",
+    "node_modules/@vue-jsx-vapor/compiler-rs-android-arm-eabi": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-android-arm-eabi/-/compiler-rs-android-arm-eabi-3.2.18.tgz",
+      "integrity": "sha512-XZCcernaJOUCPyOaB5BuPgJS06h24HuV4XpM0JMHiC3JKM5JuK39Egy9sEoY2G/HF05+GaHJ9bOThaH29JzABg==",
+      "cpu": [
+        "arm"
+      ],
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-android-arm64": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-android-arm64/-/compiler-rs-android-arm64-3.2.18.tgz",
+      "integrity": "sha512-0JsyjDahmxbjIbNah2v/v6aPeAi4Zua7eSSmn/q5EyqvM8FZ1kcIx53Kg0cqTnYrQWWun0I/o3pPFQezDJiifQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-darwin-arm64": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-darwin-arm64/-/compiler-rs-darwin-arm64-3.2.18.tgz",
+      "integrity": "sha512-9SWROILFTK8XAEHk1iuZBkb3GqIPZ1bONpV4LLsUmBCpfFnmbLCzmrmu7orUVfd63fhXlhhHmtl6Z2A+6ZnE+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-darwin-x64": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-darwin-x64/-/compiler-rs-darwin-x64-3.2.18.tgz",
+      "integrity": "sha512-Xr68QpqU98nrpxuOuZrySnQhCV2IoIgow1NzlUDGhjpefKlJqLvR2Pk3rKJRY7y69/0/LgnWe+vZSjlvsN7XlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-freebsd-x64": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-freebsd-x64/-/compiler-rs-freebsd-x64-3.2.18.tgz",
+      "integrity": "sha512-QI77aoJAIgECyDWf1QPi93qTYDCVHZgkTo3c6fCt0F13ux9uC7fzV3cD5BDhKSogDF5YpFY9buITKT4Vasy7hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf/-/compiler-rs-linux-arm-gnueabihf-3.2.18.tgz",
+      "integrity": "sha512-GCC08O68n2eXPsarmR3ZZ9FMydG+OInhIPTJC9pIA1ndE7+tMxMNEjvMZS1qSIX5qxPriNsB+FWb4pWdWS62Hg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-linux-arm64-gnu": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-arm64-gnu/-/compiler-rs-linux-arm64-gnu-3.2.18.tgz",
+      "integrity": "sha512-mHaQm7PCu3JgDTv8DlLfEk7MigMLr1PgELw5GgE8bCka8ur0Qn1WBpCLlWdg/thnt4fY9/8+IZ5ZgG34z9kLUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-linux-arm64-musl": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-arm64-musl/-/compiler-rs-linux-arm64-musl-3.2.18.tgz",
+      "integrity": "sha512-EaZ60NtNvY9TgHT8aT/rXykPdk8oXiixEsqn6PbJMZixpLGlXgpU0lCn9YwstVRwM3dyPCA4WGJhkBD7vKq2Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-linux-x64-gnu": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-x64-gnu/-/compiler-rs-linux-x64-gnu-3.2.18.tgz",
+      "integrity": "sha512-0EAxA6hzwTE+OD44J8l3n6b/xEgwcmSkp+ITjZ2SGqJgNZH5eq8fvPaxe7xizoEz1M8xQuUd0NYggcUJ1yvsKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-linux-x64-musl": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-x64-musl/-/compiler-rs-linux-x64-musl-3.2.18.tgz",
+      "integrity": "sha512-DT5BqrmH7q9Fx9hEZ2PvPV39kNaJf3EKig23JKI1AJT3GOLSB5E1A3Kp+fNf4KTQ4mWgQZ63+Nhk05CirQJ8Ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-wasm32-wasi": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-wasm32-wasi/-/compiler-rs-wasm32-wasi-3.2.18.tgz",
+      "integrity": "sha512-Rwjw0lUhaAhEpzzo+7OpeR8Y516p+vP1ka2JAmXxwcsomelvvSn/37CZo2xlfpC/tFtH/L3tI17qZK0SNQccAw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "ast-kit": "^2.1.1",
-        "source-map-js": "^1.2.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-win32-arm64-msvc": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-win32-arm64-msvc/-/compiler-rs-win32-arm64-msvc-3.2.18.tgz",
+      "integrity": "sha512-NqnAgwQgLwJW+p5cZLIfNHnwUvAXXlJHBImDRkH/Fr0wpZC89S0WSydFieyPSroIU+ax7O7zPY0lrJwppOWaBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-win32-ia32-msvc": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-win32-ia32-msvc/-/compiler-rs-win32-ia32-msvc-3.2.18.tgz",
+      "integrity": "sha512-IYqu//HlI7gZ6dMUZMxpIvCqEsanxBpZ66T2oxE1aVrSgj/CJoSynw0x3KBe8cGYo6CR/9twCz9NRcMCJN417w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-win32-x64-msvc": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-win32-x64-msvc/-/compiler-rs-win32-x64-msvc-3.2.18.tgz",
+      "integrity": "sha512-jaYa6XYepMy5oF+/qok8bWYSPvL/giqopsbHJHiQSCTvplctodvBW+VsJCOCCWyadN6c5rXPfLgUmgwPgdbz1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@vue-jsx-vapor/macros": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/macros/-/macros-2.6.0.tgz",
-      "integrity": "sha512-1MQU8a2CUBypdPyDwp7NVF73Eksr1LRKJZGgEgUv4AW0e8YdN0njvM04nY5dAD2eZSwgz+zGvkK8UdgnVpakZw==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/macros/-/macros-3.2.18.tgz",
+      "integrity": "sha512-dOUedO348AcrHWkIzvDQd7Re6WkPS3HqjUBFMu+PPb41lHXs+OsDyytGFGqaB9LYOWuCFBY4QLfO/d+ubzudJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue-macros/common": "^3.0.0-beta.19",
-        "@vue/compiler-sfc": "3.6.0-alpha.2",
         "hash-sum": "^2.0.0",
-        "ts-macro": "^0.3.1",
-        "unplugin": "^2.3.5"
+        "magic-string": "^0.30.21",
+        "ts-macro": "^0.3.7",
+        "unplugin": "^3.0.0",
+        "unplugin-utils": "^0.3.1"
       },
       "peerDependencies": {
         "@nuxt/kit": "^3",
@@ -1254,6 +1141,7 @@
         "esbuild": "*",
         "rollup": "^3",
         "vite": ">=3",
+        "vue": ">=3",
         "webpack": "^4 || ^5"
       },
       "peerDependenciesMeta": {
@@ -1278,914 +1166,153 @@
       }
     },
     "node_modules/@vue-jsx-vapor/runtime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/runtime/-/runtime-2.6.0.tgz",
-      "integrity": "sha512-fNhkTHSwNcM9ikIms94SyJZVDanIiTxt+ecc+lDVfCxjZ9iAtzQa8etYtnXgekqx9GsJ92WSBfeInaYlg8YYFQ==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/runtime/-/runtime-3.2.18.tgz",
+      "integrity": "sha512-bB4oYcgAWlA/Lvbvn93Q997PvjEvjMgGSWC2frrhK/bRKQ9QNFBFpNCdJfA7GxCWgGMt0cziUOdwmNJcCtGcQA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "vue": "^3.6.0-alpha.2"
+        "csstype": "^3.2.3",
+        "vue": "3.6.0-beta.16"
       }
-    },
-    "node_modules/@vue-macros/boolean-prop": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/boolean-prop/-/boolean-prop-3.0.0-beta.20.tgz",
-      "integrity": "sha512-KSC4sR/iVlcx5NuJteiFlppZjL/VexQPFjt/grAatHUdCkFoX+UF+CKw8TyKcf+/4Bx85nbXnYjIn2P8hD2JqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue-macros/common": "3.0.0-beta.20",
-        "@vue/compiler-core": "^3.5.18"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      }
-    },
-    "node_modules/@vue-macros/boolean-prop/node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/boolean-prop/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue-macros/common": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.0.0-beta.20.tgz",
-      "integrity": "sha512-k4ez00bGD4mesrrreJarUj9Wuyqzl8N58+j3hsHkw4F9JSTCPMHVeQ7vHXETgnHtNAyJp2o6KRjTLLyzPc1cuA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-sfc": "^3.5.18",
-        "ast-kit": "^2.1.1",
-        "local-pkg": "^1.1.1",
-        "magic-string-ast": "^1.0.0",
-        "unplugin-utils": "^0.2.4"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      },
-      "peerDependencies": {
-        "vue": "^2.7.0 || ^3.2.25"
-      },
-      "peerDependenciesMeta": {
-        "vue": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue-macros/common/node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/common/node_modules/@vue/compiler-dom": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.18.tgz",
-      "integrity": "sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.18",
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/common/node_modules/@vue/compiler-sfc": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.18.tgz",
-      "integrity": "sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/compiler-core": "3.5.18",
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/compiler-ssr": "3.5.18",
-        "@vue/shared": "3.5.18",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/common/node_modules/@vue/compiler-ssr": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.18.tgz",
-      "integrity": "sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/common/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue-macros/config": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/config/-/config-3.0.0-beta.20.tgz",
-      "integrity": "sha512-Dh1QV3AU4wxUpMu1YMDmx2QszYptues/BhJvnZcK8buMOpDp9DNquc1s7DuG1jDptOqZdSPjx5Kt5LqeVkJOiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue-macros/common": "3.0.0-beta.20",
-        "quansync": "^0.2.10",
-        "unconfig": "^7.3.2"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/jsx-directive/-/jsx-directive-3.0.0-beta.20.tgz",
-      "integrity": "sha512-FuswkOrdAPMe8r8O/qV4EbtAcwQCpvpROQDbZY45ZHBd1Yei1rQhKWdptElHK+IJTcWCE6Wu6YW/aPymDt++/A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue-macros/common": "3.0.0-beta.20",
-        "unplugin": "^2.3.5",
-        "vue": "^3.5.18"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/compiler-dom": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.18.tgz",
-      "integrity": "sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.18",
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/compiler-sfc": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.18.tgz",
-      "integrity": "sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/compiler-core": "3.5.18",
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/compiler-ssr": "3.5.18",
-        "@vue/shared": "3.5.18",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/compiler-ssr": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.18.tgz",
-      "integrity": "sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/reactivity": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.18.tgz",
-      "integrity": "sha512-x0vPO5Imw+3sChLM5Y+B6G1zPjwdOri9e8V21NnTnlEvkxatHEH5B5KEAJcjuzQ7BsjGrKtfzuQ5eQwXh8HXBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/runtime-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.18.tgz",
-      "integrity": "sha512-DUpHa1HpeOQEt6+3nheUfqVXRog2kivkXHUhoqJiKR33SO4x+a5uNOMkV487WPerQkL0vUuRvq/7JhRgLW3S+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.5.18",
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/runtime-dom": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.18.tgz",
-      "integrity": "sha512-YwDj71iV05j4RnzZnZtGaXwPoUWeRsqinblgVJwR8XTXYZ9D5PbahHQgsbmzUvCWNF6x7siQ89HgnX5eWkr3mw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.5.18",
-        "@vue/runtime-core": "3.5.18",
-        "@vue/shared": "3.5.18",
-        "csstype": "^3.1.3"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/server-renderer": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.18.tgz",
-      "integrity": "sha512-PvIHLUoWgSbDG7zLHqSqaCoZvHi6NNmfVFOqO+OnwvqMz/tqQr3FuGWS8ufluNddk7ZLBJYMrjcw1c6XzR12mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-ssr": "3.5.18",
-        "@vue/shared": "3.5.18"
-      },
-      "peerDependencies": {
-        "vue": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/vue": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.18.tgz",
-      "integrity": "sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/compiler-sfc": "3.5.18",
-        "@vue/runtime-dom": "3.5.18",
-        "@vue/server-renderer": "3.5.18",
-        "@vue/shared": "3.5.18"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue-macros/short-bind": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/short-bind/-/short-bind-3.0.0-beta.20.tgz",
-      "integrity": "sha512-JJSyZYBcfvP4YGVZo3Ppv7zSnUzDdoW6tRGuq7dOI8kxF+4HshitckmEO9ehJJEIy7b22EsFZYfrV8crnieslQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue-macros/common": "3.0.0-beta.20",
-        "@vue/compiler-core": "^3.5.18"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      }
-    },
-    "node_modules/@vue-macros/short-bind/node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/short-bind/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue-macros/short-vmodel": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/short-vmodel/-/short-vmodel-3.0.0-beta.20.tgz",
-      "integrity": "sha512-UVmRfz9CDEFbc1UrnjDu9LlGyGh7AWR8kstHUQJ5xP+aq3Y7SQKIgFt6YbubHf0Wka7Aiax+tAGyADUBybSMpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue-macros/common": "3.0.0-beta.20",
-        "@vue/compiler-core": "^3.5.18"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      }
-    },
-    "node_modules/@vue-macros/short-vmodel/node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/short-vmodel/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue-macros/volar": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/volar/-/volar-3.0.0-beta.20.tgz",
-      "integrity": "sha512-+FwD2dMqe+pCcp+3FkTbJXbEZi0/f107gk5LXIzMUIkbNu/i8fMVwRGS+7EPTcS0YghDyDU2U09UtITrKDvIig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue-macros/boolean-prop": "3.0.0-beta.20",
-        "@vue-macros/common": "3.0.0-beta.20",
-        "@vue-macros/config": "3.0.0-beta.20",
-        "@vue-macros/short-bind": "3.0.0-beta.20",
-        "@vue-macros/short-vmodel": "3.0.0-beta.20",
-        "@vue/language-core": "3.0.4",
-        "@vue/shared": "^3.5.18",
-        "muggle-string": "^0.4.1",
-        "ts-macro": "^0.3.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      },
-      "peerDependencies": {
-        "vue-tsc": "3.0.4"
-      },
-      "peerDependenciesMeta": {
-        "vue-tsc": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue-macros/volar/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue/babel-helper-vue-transform-on": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.4.0.tgz",
-      "integrity": "sha512-mCokbouEQ/ocRce/FpKCRItGo+013tHg7tixg3DUNS+6bmIchPt66012kBMm476vyEIJPafrvOf4E5OYj3shSw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue/babel-plugin-jsx": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vue/babel-plugin-jsx/-/babel-plugin-jsx-1.4.0.tgz",
-      "integrity": "sha512-9zAHmwgMWlaN6qRKdrg1uKsBKHvnUU+Py+MOCTuYZBoZsopa90Di10QRjB+YPnVss0BZbG/H5XFwJY1fTxJWhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.26.5",
-        "@babel/plugin-syntax-jsx": "^7.25.9",
-        "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
-        "@vue/babel-helper-vue-transform-on": "1.4.0",
-        "@vue/babel-plugin-resolve-type": "1.4.0",
-        "@vue/shared": "^3.5.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue/babel-plugin-jsx/node_modules/@vue/shared": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
-      "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue/babel-plugin-resolve-type": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vue/babel-plugin-resolve-type/-/babel-plugin-resolve-type-1.4.0.tgz",
-      "integrity": "sha512-4xqDRRbQQEWHQyjlYSgZsWj44KfiF6D+ktCuXyZ8EnVDYV3pztmXJDf1HveAjUAXxAnR8daCQT51RneWWxtTyQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.26.5",
-        "@babel/parser": "^7.26.9",
-        "@vue/compiler-sfc": "^3.5.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/compiler-dom": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.17.tgz",
-      "integrity": "sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.17",
-        "@vue/shared": "3.5.17"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/compiler-sfc": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz",
-      "integrity": "sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-core": "3.5.17",
-        "@vue/compiler-dom": "3.5.17",
-        "@vue/compiler-ssr": "3.5.17",
-        "@vue/shared": "3.5.17",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/compiler-ssr": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.17.tgz",
-      "integrity": "sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.17",
-        "@vue/shared": "3.5.17"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/shared": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
-      "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.17.tgz",
-      "integrity": "sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==",
-      "dev": true,
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-beta.17.tgz",
+      "integrity": "sha512-4xB2W8+00h7bfHbVeHD+zI+bmyF+XgQBKCCWLjFJ/VCJ/1tBjnlzWpX0OqcOE78LktGiCGcKgNk+eZAuav5cqg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.5.17",
-        "entities": "^4.5.0",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.6.0-beta.17",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
-    },
-    "node_modules/@vue/compiler-core/node_modules/@vue/shared": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
-      "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-WHFo0z5QXXkBQk65NPrze1RO4RG6vAHcMudRG604zs2VsMkJPXBL5CAFcae3R6aoU3wwbIYHkklbMOelegS90w==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-beta.17.tgz",
+      "integrity": "sha512-viCM7YwHK6HuQ9rY8O27ET1xLi9WeJ+EmMWlwvtggpqb2j+l7DZOATkCRXOivjTOqtt8h5MIGnlB7tQlupQgeA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
-      }
-    },
-    "node_modules/@vue/compiler-dom/node_modules/@vue/compiler-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-2aPvrCWKKhKKU4TaX6N6+cY4LcLIlIc+tcxJHw029mZr7KGb/w+98UxU9o3mYe/CLo5c5v8ps4IlE/Tm4H/eZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.6.0-alpha.2",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
+        "@vue/compiler-core": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-QFwY1M5lYTo6Qt0rSQKXEp9aZngaKtT4WRlITAuioNeFoK5Y5stElr6sw2dopsaPzjbAJftDbQ7MgtMjOZ9XQg==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-beta.17.tgz",
+      "integrity": "sha512-L3KGWeWDCqm1tL03m09IXKRhIEh0Ij2gEIax9W0smDtlCAQt4gc8dmeTbjTOg4+1N2qAFEaAs+0xVu9y1j7Sng==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/compiler-vapor": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.6.0-beta.17",
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/compiler-ssr": "3.6.0-beta.17",
+        "@vue/compiler-vapor": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-2aPvrCWKKhKKU4TaX6N6+cY4LcLIlIc+tcxJHw029mZr7KGb/w+98UxU9o3mYe/CLo5c5v8ps4IlE/Tm4H/eZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.6.0-alpha.2",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.14",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-BtP+A4xL7QSCf/P1eOvJw9XG1wojK3nqjJXSABcwXeIv0SJgBpi4CZ/obVUPAiUWMmdJDV3bdSwqQtkiXqOmug==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-beta.17.tgz",
+      "integrity": "sha512-OWBt5fu62UGeGTcl3Ra5ocMZbJ3h8ze862g9GlS72CNsYYZTbh3V9LePoOp6WX73SdsSdbsWLSsZfi5Wgh+ggQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/compiler-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/qmhrcOrVmBsZiQEpDMH5coH/hx7v1uflKCXDcvWhl7XaPfNWBeVwIndU/s/8mtOz+5nuCZrGtbqozXc4tfQzw==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-beta.17.tgz",
+      "integrity": "sha512-8qqHnEwQVytCnaF9zSOtcZxnYxz+FJqBNl9zIpSKwKRStl4XqmgcXlHtJYQMCxZS6xa7JfPvutkt5mBneh07Yw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
-    },
-    "node_modules/@vue/compiler-vue2": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
-      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
-      }
-    },
-    "node_modules/@vue/language-core": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.4.tgz",
-      "integrity": "sha512-BvueED4LfBCSNH66eeUQk37MQCb7hjdezzGgxniM0LbriW53AJIyLorgshAtStmjfsAuOCcTl/c1b+nz/ye8xQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@volar/language-core": "2.4.20",
-        "@vue/compiler-dom": "^3.5.0",
-        "@vue/compiler-vue2": "^2.7.16",
-        "@vue/shared": "^3.5.0",
-        "alien-signals": "^2.0.5",
-        "muggle-string": "^0.4.1",
-        "path-browserify": "^1.0.1",
-        "picomatch": "^4.0.2"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue/language-core/node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/language-core/node_modules/@vue/compiler-dom": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.18.tgz",
-      "integrity": "sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.18",
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue/language-core/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-dqCEZHz7dy5u0fZV1ILObnH2YCA+I6UHuOt7PLGb1NBEAAUbO251nOK9OfecZEEPsvMJRl3P9rNqdJmAvIcHTg==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-beta.17.tgz",
+      "integrity": "sha512-oKLiLZRomHyJ++367F286Er49TXazWofj1PbNFUBoRxNNLne8xlDHAypN+C9Yr+JfAIN9cRp8l1PdjwfwMsV8g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-OPEIqs/q2rTZWTJm8VVSsI9B2OgsKdtprKEqzw3L74tBGDwNRleCGxGxu2T3LUpPlOtQFkSCZTIh1M52/6PG0w==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-beta.17.tgz",
+      "integrity": "sha512-JDPvmiyLpXtTnpG6I9URF88bOF+7KVgpDvPvZVl9AMboQj+LW4Pp19QOhGzxGoKES6wBts8c4xM1zjtr0xHcQw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-oYrpDYpbRqv/pgqM1SJEN7w9oahCjj6Txatz7McMJ++CX0WyFqAChi3Zvxr06Vrte+OCWA86t6Ot8K+mKV0QAA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-beta.17.tgz",
+      "integrity": "sha512-7B02MUGEFzuJaMbhxtgNRSMOrbj+AlERBy1EBxrXHplHSwv8xQjJpiBk0Z+5+vQMDVS4zc8VIYgeP7CUyROpUg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/runtime-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "csstype": "^3.1.3"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/runtime-core": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/runtime-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-UdGN6tcXIMTD/OFR7qI8V+ID4lji7K5A90i68OjiCr8nevtGxjfYPB3Lz5Lg7S6sckPCnFTECHExzWOmE7aV0A==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-beta.17.tgz",
+      "integrity": "sha512-nJpdHuMOXMEmVUrRTEo4AEDPreBja9euIXHjvUe4aEk1pmTKs61hQRluAdETRyXZwkyFe6D6+fXxvKf5wPBJBg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
-        "@vue/runtime-dom": "3.6.0-alpha.2"
+        "@vue/runtime-dom": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-Zw+fX/FlRqfwzrv5EmCyLBN5bOZWsRo3SnxQKqPl1yA5xGDe+FIe9cjII/X7hlFdC9Vb4lmQBvOQSnTeTj8ygA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-beta.17.tgz",
+      "integrity": "sha512-C7YpoWxewo01cG+S51MouH1v6taXBU5XvmxPjPAI3E9Zn3gpzb49e/ikShA5ov8ijE9R7tyIOUk4QU2xoDiT+Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-ssr": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
-        "vue": "3.6.0-alpha.2"
+        "vue": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
-      "license": "MIT"
-    },
-    "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/alien-signals": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.6.tgz",
-      "integrity": "sha512-P3TxJSe31bUHBiblg59oU1PpaWPtmxF9GhJ/cB7OkgJ0qN/ifFSKUI25/v8ZhsT+lIG6ac8DpTOplXxORX6F3Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ast-kit": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.1.1.tgz",
-      "integrity": "sha512-mfh6a7gKXE8pDlxTvqIc/syH/P3RkzbOF6LeHdcKztLEzYe6IMsRCL7N8vI7hqTGWNxpkCuuRTpT21xNWqhRtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.7",
-        "pathe": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001726",
-        "electron-to-chromium": "^1.5.173",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001731",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
-    "node_modules/confbox": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-beta.17.tgz",
+      "integrity": "sha512-iuDH2UPBc8nzqgL4dcLiqpAJoJfQe70RcPM34+p+dVk0ThJD9jjpLPjzouP+RoRrXkAPOC7jmMncafdv69BGaA==",
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
-    },
-    "node_modules/de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.194",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.194.tgz",
-      "integrity": "sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2235,27 +1362,10 @@
         "@esbuild/win32-x64": "0.25.1"
       }
     },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT"
-    },
-    "node_modules/exsolve": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
-      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
@@ -2288,16 +1398,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/hash-sum": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
@@ -2305,150 +1405,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
-    "node_modules/jiti": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
-      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/local-pkg": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.1.tgz",
-      "integrity": "sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mlly": "^1.7.4",
-        "pkg-types": "^2.0.1",
-        "quansync": "^0.2.8"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
-    },
-    "node_modules/magic-string-ast": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.0.tgz",
-      "integrity": "sha512-8rbuNizut2gW94kv7pqgt0dvk+AHLPVIm0iJtpSgQJ9dx21eWx5SBel8z3jp1xtC0j6/iyK3AWGhAR1H61s7LA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "magic-string": "^0.30.17"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
-      }
-    },
-    "node_modules/mlly": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.14.0",
-        "pathe": "^2.0.1",
-        "pkg-types": "^1.3.0",
-        "ufo": "^1.5.4"
-      }
-    },
-    "node_modules/mlly/node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mlly/node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
@@ -2458,9 +1422,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -2474,20 +1438,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2503,9 +1453,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2515,22 +1465,10 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pkg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.2.0.tgz",
-      "integrity": "sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
-        "pathe": "^2.0.3"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
       "funding": [
         {
           "type": "opencollective",
@@ -2547,30 +1485,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/quansync": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
-      "integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/antfu"
-        },
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/sxzz"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.45.1",
@@ -2612,16 +1533,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2649,99 +1560,93 @@
       }
     },
     "node_modules/ts-macro": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ts-macro/-/ts-macro-0.3.1.tgz",
-      "integrity": "sha512-Q7fVWKas1W7ZlULXdLgacU92g7WY92YIkVe+lENUINBjRPD/1Gfq0dV9Txr8ZszIpJPRE9vw+Rai95DH3sMUFg==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/ts-macro/-/ts-macro-0.3.7.tgz",
+      "integrity": "sha512-5BinbTKn5WXRslotv5/VWTn3catfK0thWoB4BZI5VNEdxMu6r9AUPFalut4wLEK3nGvxhywA9aAdZnJ+Fnug9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "muggle-string": "^0.4.1"
       }
     },
-    "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unconfig": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-7.3.2.tgz",
-      "integrity": "sha512-nqG5NNL2wFVGZ0NA/aCFw0oJ2pxSf1lwg4Z5ill8wd7K4KX/rQbHlwbh+bjctXL5Ly1xtzHenHGOK0b+lG6JVg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@quansync/fs": "^0.1.1",
-        "defu": "^6.1.4",
-        "jiti": "^2.4.2",
-        "quansync": "^0.2.8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/unplugin": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.5.tgz",
-      "integrity": "sha512-RyWSb5AHmGtjjNQ6gIlA67sHOsWpsbWpwDokLwTcejVdOjEkJZh7QKu14J00gDDVSh8kGH4KYC/TNBceXFZhtw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+      "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.14.1",
-        "picomatch": "^4.0.2",
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.4",
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@farmfe/core": "*",
+        "@rspack/core": "*",
+        "bun-types-no-globals": "*",
+        "esbuild": "*",
+        "rolldown": "*",
+        "rollup": "*",
+        "unloader": "*",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "@farmfe/core": {
+          "optional": true
+        },
+        "@rspack/core": {
+          "optional": true
+        },
+        "bun-types-no-globals": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "unloader": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/unplugin-utils": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.2.4.tgz",
-      "integrity": "sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+      "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "pathe": "^2.0.2",
-        "picomatch": "^4.0.2"
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
-      }
-    },
-    "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/vite": {
@@ -2820,17 +1725,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-xn3jwLo6eMqxEKEAW8TWX+KSm7K2jTrNZ5Q3+H5Bu9P3mkoz8w0lUQHrO5WcnSVZfmR7vvw4/5XSYQe2XeDzdw==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-beta.17.tgz",
+      "integrity": "sha512-sVvFEriOhBjKIi7Jy+vwnlcBVRKhvxMVG4lh2erX1vrlaNKggURyWttRF+z5Vo+6VYriVsXAUyOgaQZub0W8ug==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-sfc": "3.6.0-alpha.2",
-        "@vue/runtime-dom": "3.6.0-alpha.2",
-        "@vue/runtime-vapor": "3.6.0-alpha.2",
-        "@vue/server-renderer": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/compiler-sfc": "3.6.0-beta.17",
+        "@vue/runtime-dom": "3.6.0-beta.17",
+        "@vue/runtime-vapor": "3.6.0-beta.17",
+        "@vue/server-renderer": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -2842,26 +1747,20 @@
       }
     },
     "node_modules/vue-jsx-vapor": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/vue-jsx-vapor/-/vue-jsx-vapor-2.6.0.tgz",
-      "integrity": "sha512-CodJDlxBbbZ4EFDQI8yTBzDw05Nbe+bGBjPT5OJv9plf6n8e3xaXG1UkdNkgWhhqZHQnZIRpWydIh7BggKepnw==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/vue-jsx-vapor/-/vue-jsx-vapor-3.2.18.tgz",
+      "integrity": "sha512-aSxXlNHIpv8V6Yg8g4adojeQal+O3s/vijKWdC94dSyfVucMAIJNKKWv1dQtI81aDNYkvtTFw0XHSM69gXsxPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-typescript": "^7.28.0",
-        "@vue-jsx-vapor/babel": "2.6.0",
-        "@vue-jsx-vapor/compiler": "2.6.0",
-        "@vue-jsx-vapor/macros": "2.6.0",
-        "@vue-jsx-vapor/runtime": "2.6.0",
-        "@vue-macros/jsx-directive": "^3.0.0-beta.19",
-        "@vue-macros/volar": "^3.0.0-beta.19",
-        "@vue/babel-plugin-jsx": "^1.4.0",
-        "hash-sum": "^2.0.0",
+        "@vue-jsx-vapor/compiler-rs": "3.2.18",
+        "@vue-jsx-vapor/macros": "3.2.18",
+        "@vue-jsx-vapor/runtime": "3.2.18",
+        "@vue/shared": "3.6.0-beta.16",
         "pathe": "^2.0.3",
-        "ts-macro": "^0.3.1",
-        "unplugin": "^2.3.5",
-        "unplugin-utils": "^0.2.4"
+        "ts-macro": "^0.3.7",
+        "unplugin": "^3.0.0",
+        "unplugin-utils": "^0.3.1"
       },
       "peerDependencies": {
         "@nuxt/kit": "^3",
@@ -2869,7 +1768,7 @@
         "esbuild": "*",
         "rollup": "^3",
         "vite": ">=3",
-        "vue": "^3.6.0-alpha.2",
+        "vue": "^3",
         "webpack": "^4 || ^5"
       },
       "peerDependenciesMeta": {
@@ -2893,19 +1792,19 @@
         }
       }
     },
+    "node_modules/vue-jsx-vapor/node_modules/@vue/shared": {
+      "version": "3.6.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-beta.16.tgz",
+      "integrity": "sha512-DyuxocDJp/vbmQKnrVzHEs8QrJv2XFnvgyri0W0Ni8+TmoiDSd86NaDoF32yRcIBstxKKL6X6nia7JPjZHia6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
     }
   }
 }

--- a/frameworks/keyed/vue-jsx-vapor/package.json
+++ b/frameworks/keyed/vue-jsx-vapor/package.json
@@ -14,10 +14,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "3.6.0-alpha.2"
+    "vue": "^3.6.0-beta.17"
   },
   "devDependencies": {
-    "vue-jsx-vapor": "^2.6.0",
+    "vue-jsx-vapor": "^3.2.18",
     "vite": "^7.0.5"
   }
 }

--- a/frameworks/keyed/vue-jsx/package-lock.json
+++ b/frameworks/keyed/vue-jsx/package-lock.json
@@ -8,35 +8,21 @@
       "name": "js-framework-benchmark-vue-jsx",
       "version": "1.0.0",
       "dependencies": {
-        "vue": "^3.6.0-alpha.2"
+        "vue": "^3.5.39"
       },
       "devDependencies": {
-        "@vitejs/plugin-vue-jsx": "^5.0.1",
+        "@vitejs/plugin-vue-jsx": "^5.1.6",
         "vite": "^7.0.5"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -45,9 +31,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -55,22 +41,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
-      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.6",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -86,14 +72,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -103,27 +89,27 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -133,18 +119,18 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-member-expression-to-functions": "^7.27.1",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -155,9 +141,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -165,43 +151,43 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
-      "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -211,22 +197,22 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -234,15 +220,15 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-      "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.27.1",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -252,41 +238,41 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -294,26 +280,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -323,13 +309,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -339,13 +325,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -355,17 +341,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
-      "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-create-class-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/plugin-syntax-typescript": "^7.27.1"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -375,33 +361,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -409,13 +395,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -864,13 +850,24 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -885,21 +882,28 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.45.1",
@@ -1189,55 +1193,49 @@
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue-jsx": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-5.0.1.tgz",
-      "integrity": "sha512-X7qmQMXbdDh+sfHUttXokPD0cjPkMFoae7SgbkF9vi3idGUKmxLcnU2Ug49FHwiKXebfzQRIm5yK3sfCJzNBbg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-5.1.6.tgz",
+      "integrity": "sha512-YXvi4as2clxt6DFw5+a0tTA97ntiQXm/raR8ofNj3aNwwdlVGTiG2gp7EvfZW17P50acL/9bP0ccF4XnqNmlgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.27.7",
-        "@babel/plugin-transform-typescript": "^7.27.1",
-        "@rolldown/pluginutils": "^1.0.0-beta.21",
-        "@vue/babel-plugin-jsx": "^1.4.0"
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-syntax-typescript": "^7.29.7",
+        "@babel/plugin-transform-typescript": "^7.29.7",
+        "@rolldown/pluginutils": "^1.0.1",
+        "@vue/babel-plugin-jsx": "^2.0.1"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.0.0"
       }
     },
-    "node_modules/@vitejs/plugin-vue-jsx/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.29",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.29.tgz",
-      "integrity": "sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@vue/babel-helper-vue-transform-on": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.4.0.tgz",
-      "integrity": "sha512-mCokbouEQ/ocRce/FpKCRItGo+013tHg7tixg3DUNS+6bmIchPt66012kBMm476vyEIJPafrvOf4E5OYj3shSw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-2.0.1.tgz",
+      "integrity": "sha512-uZ66EaFbnnZSYqYEyplWvn46GhZ1KuYSThdT68p+am7MgBNbQ3hphTL9L+xSIsWkdktwhPYLwPgVWqo96jDdRA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vue/babel-plugin-jsx": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vue/babel-plugin-jsx/-/babel-plugin-jsx-1.4.0.tgz",
-      "integrity": "sha512-9zAHmwgMWlaN6qRKdrg1uKsBKHvnUU+Py+MOCTuYZBoZsopa90Di10QRjB+YPnVss0BZbG/H5XFwJY1fTxJWhA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vue/babel-plugin-jsx/-/babel-plugin-jsx-2.0.1.tgz",
+      "integrity": "sha512-a8CaLQjD/s4PVdhrLD/zT574ZNPnZBOY+IhdtKWRB4HRZ0I2tXBi5ne7d9eCfaYwp5gU5+4KIyFTV1W1YL9xZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.26.5",
-        "@babel/plugin-syntax-jsx": "^7.25.9",
-        "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
-        "@vue/babel-helper-vue-transform-on": "1.4.0",
-        "@vue/babel-plugin-resolve-type": "1.4.0",
-        "@vue/shared": "^3.5.13"
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@vue/babel-helper-vue-transform-on": "2.0.1",
+        "@vue/babel-plugin-resolve-type": "2.0.1",
+        "@vue/shared": "^3.5.22"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -1249,17 +1247,17 @@
       }
     },
     "node_modules/@vue/babel-plugin-resolve-type": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vue/babel-plugin-resolve-type/-/babel-plugin-resolve-type-1.4.0.tgz",
-      "integrity": "sha512-4xqDRRbQQEWHQyjlYSgZsWj44KfiF6D+ktCuXyZ8EnVDYV3pztmXJDf1HveAjUAXxAnR8daCQT51RneWWxtTyQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vue/babel-plugin-resolve-type/-/babel-plugin-resolve-type-2.0.1.tgz",
+      "integrity": "sha512-ybwgIuRGRRBhOU37GImDoWQoz+TlSqap65qVI6iwg/J7FfLTLmMf97TS7xQH9I7Qtr/gp161kYVdhr1ZMraSYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.26.5",
-        "@babel/parser": "^7.26.9",
-        "@vue/compiler-sfc": "^3.5.13"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/parser": "^7.28.4",
+        "@vue/compiler-sfc": "^3.5.22"
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
@@ -1269,232 +1267,122 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.17.tgz",
-      "integrity": "sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==",
-      "dev": true,
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.5.17",
-        "entities": "^4.5.0",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.17.tgz",
-      "integrity": "sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==",
-      "dev": true,
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.17",
-        "@vue/shared": "3.5.17"
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz",
-      "integrity": "sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==",
-      "dev": true,
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-core": "3.5.17",
-        "@vue/compiler-dom": "3.5.17",
-        "@vue/compiler-ssr": "3.5.17",
-        "@vue/shared": "3.5.17",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.17.tgz",
-      "integrity": "sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==",
-      "dev": true,
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.17",
-        "@vue/shared": "3.5.17"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
-    },
-    "node_modules/@vue/compiler-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/qmhrcOrVmBsZiQEpDMH5coH/hx7v1uflKCXDcvWhl7XaPfNWBeVwIndU/s/8mtOz+5nuCZrGtbqozXc4tfQzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/compiler-vapor/node_modules/@vue/compiler-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-2aPvrCWKKhKKU4TaX6N6+cY4LcLIlIc+tcxJHw029mZr7KGb/w+98UxU9o3mYe/CLo5c5v8ps4IlE/Tm4H/eZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.6.0-alpha.2",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/compiler-vapor/node_modules/@vue/compiler-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-WHFo0z5QXXkBQk65NPrze1RO4RG6vAHcMudRG604zs2VsMkJPXBL5CAFcae3R6aoU3wwbIYHkklbMOelegS90w==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
-      }
-    },
-    "node_modules/@vue/compiler-vapor/node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
-      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-dqCEZHz7dy5u0fZV1ILObnH2YCA+I6UHuOt7PLGb1NBEAAUbO251nOK9OfecZEEPsvMJRl3P9rNqdJmAvIcHTg==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/shared": "3.5.39"
       }
-    },
-    "node_modules/@vue/reactivity/node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
-      "license": "MIT"
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-OPEIqs/q2rTZWTJm8VVSsI9B2OgsKdtprKEqzw3L74tBGDwNRleCGxGxu2T3LUpPlOtQFkSCZTIh1M52/6PG0w==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
-    },
-    "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
-      "license": "MIT"
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-oYrpDYpbRqv/pgqM1SJEN7w9oahCjj6Txatz7McMJ++CX0WyFqAChi3Zvxr06Vrte+OCWA86t6Ot8K+mKV0QAA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/runtime-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "csstype": "^3.1.3"
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "csstype": "^3.2.3"
       }
-    },
-    "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
-      "license": "MIT"
-    },
-    "node_modules/@vue/runtime-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-UdGN6tcXIMTD/OFR7qI8V+ID4lji7K5A90i68OjiCr8nevtGxjfYPB3Lz5Lg7S6sckPCnFTECHExzWOmE7aV0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
-      },
-      "peerDependencies": {
-        "@vue/runtime-dom": "3.6.0-alpha.2"
-      }
-    },
-    "node_modules/@vue/runtime-vapor/node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
-      "license": "MIT"
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-Zw+fX/FlRqfwzrv5EmCyLBN5bOZWsRo3SnxQKqPl1yA5xGDe+FIe9cjII/X7hlFdC9Vb4lmQBvOQSnTeTj8ygA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
-        "vue": "3.6.0-alpha.2"
+        "vue": "3.5.39"
       }
-    },
-    "node_modules/@vue/server-renderer/node_modules/@vue/compiler-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-2aPvrCWKKhKKU4TaX6N6+cY4LcLIlIc+tcxJHw029mZr7KGb/w+98UxU9o3mYe/CLo5c5v8ps4IlE/Tm4H/eZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.6.0-alpha.2",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/server-renderer/node_modules/@vue/compiler-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-WHFo0z5QXXkBQk65NPrze1RO4RG6vAHcMudRG604zs2VsMkJPXBL5CAFcae3R6aoU3wwbIYHkklbMOelegS90w==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
-      }
-    },
-    "node_modules/@vue/server-renderer/node_modules/@vue/compiler-ssr": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-BtP+A4xL7QSCf/P1eOvJw9XG1wojK3nqjJXSABcwXeIv0SJgBpi4CZ/obVUPAiUWMmdJDV3bdSwqQtkiXqOmug==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
-      }
-    },
-    "node_modules/@vue/server-renderer/node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
-      "license": "MIT"
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
-      "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
-      "dev": true,
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/browserslist": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "funding": [
         {
@@ -1512,10 +1400,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001726",
-        "electron-to-chromium": "^1.5.173",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1525,9 +1414,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
       "dev": true,
       "funding": [
         {
@@ -1553,15 +1442,15 @@
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1577,16 +1466,16 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.189",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.189.tgz",
-      "integrity": "sha512-y9D1ntS1ruO/pZ/V2FtLE+JXLQe28XoRpZ7QCCo0T8LdQladzdcOVQZH/IWLVJvCw12OGMb6hYOeOAjntCmJRQ==",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -1737,12 +1626,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {
@@ -1753,9 +1642,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -1771,11 +1660,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1797,9 +1689,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
       "funding": [
         {
           "type": "opencollective",
@@ -1816,7 +1708,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1901,9 +1793,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -2007,17 +1899,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-xn3jwLo6eMqxEKEAW8TWX+KSm7K2jTrNZ5Q3+H5Bu9P3mkoz8w0lUQHrO5WcnSVZfmR7vvw4/5XSYQe2XeDzdw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-sfc": "3.6.0-alpha.2",
-        "@vue/runtime-dom": "3.6.0-alpha.2",
-        "@vue/runtime-vapor": "3.6.0-alpha.2",
-        "@vue/server-renderer": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -2027,63 +1918,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/vue/node_modules/@vue/compiler-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-2aPvrCWKKhKKU4TaX6N6+cY4LcLIlIc+tcxJHw029mZr7KGb/w+98UxU9o3mYe/CLo5c5v8ps4IlE/Tm4H/eZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.6.0-alpha.2",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/compiler-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-WHFo0z5QXXkBQk65NPrze1RO4RG6vAHcMudRG604zs2VsMkJPXBL5CAFcae3R6aoU3wwbIYHkklbMOelegS90w==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/compiler-sfc": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-QFwY1M5lYTo6Qt0rSQKXEp9aZngaKtT4WRlITAuioNeFoK5Y5stElr6sw2dopsaPzjbAJftDbQ7MgtMjOZ9XQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/compiler-vapor": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/compiler-ssr": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-BtP+A4xL7QSCf/P1eOvJw9XG1wojK3nqjJXSABcwXeIv0SJgBpi4CZ/obVUPAiUWMmdJDV3bdSwqQtkiXqOmug==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
-      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frameworks/keyed/vue-jsx/package.json
+++ b/frameworks/keyed/vue-jsx/package.json
@@ -14,10 +14,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.6.0-alpha.2"
+    "vue": "^3.5.39"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue-jsx": "^5.0.1",
+    "@vitejs/plugin-vue-jsx": "^5.1.6",
     "vite": "^7.0.5"
   }
 }

--- a/frameworks/keyed/vue-pinia/package-lock.json
+++ b/frameworks/keyed/vue-pinia/package-lock.json
@@ -8,8 +8,8 @@
       "name": "js-framework-benchmark-vue-pinia",
       "version": "0.0.0",
       "dependencies": {
-        "pinia": "^2.3.0",
-        "vue": "^3.5.13"
+        "pinia": "^3.0.4",
+        "vue": "^3.5.39"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.1",
@@ -17,30 +17,30 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.3"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -50,13 +50,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -471,9 +471,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -764,121 +764,172 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
-      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.25.3",
-        "@vue/shared": "3.5.13",
-        "entities": "^4.5.0",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.0"
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
-      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
-      "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.25.3",
-        "@vue/compiler-core": "3.5.13",
-        "@vue/compiler-dom": "3.5.13",
-        "@vue/compiler-ssr": "3.5.13",
-        "@vue/shared": "3.5.13",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.11",
-        "postcss": "^8.4.48",
-        "source-map-js": "^1.2.0"
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
-      "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
-      "license": "MIT"
-    },
-    "node_modules/@vue/reactivity": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
-      "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.13"
+        "@vue/devtools-kit": "^7.7.10"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.10",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
-      "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
-      "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.13",
-        "@vue/runtime-core": "3.5.13",
-        "@vue/shared": "3.5.13",
-        "csstype": "^3.1.3"
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
-      "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
-        "vue": "3.5.13"
+        "vue": "3.5.39"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
       "license": "MIT"
     },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -948,19 +999,43 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/magic-string": {
-      "version": "0.30.15",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.15.tgz",
-      "integrity": "sha512-zXeaYRgZ6ldS1RJJUrMrYgNJ4fdwnyI6tVqoiIhyCyv5IVTK9BU8Ic2l253GGETQHxI4HNUwhJ3fjDhKqEoaAw==",
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
       "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -975,6 +1050,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -982,20 +1063,19 @@
       "license": "ISC"
     },
     "node_modules/pinia": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.0.tgz",
-      "integrity": "sha512-ohZj3jla0LL0OH5PlLTDMzqKiVw2XARmC1XYLdLWIPBMdhDW/123ZWr4zVAhtJm+aoSkFa13pYXskAvAscIkhQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-api": "^6.6.3",
-        "vue-demi": "^0.14.10"
+        "@vue/devtools-api": "^7.7.7"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
-        "typescript": ">=4.4.4",
-        "vue": "^2.7.0 || ^3.5.11"
+        "typescript": ">=4.5.0",
+        "vue": "^3.5.11"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1004,9 +1084,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
       "funding": [
         {
           "type": "opencollective",
@@ -1023,13 +1103,19 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.28.1",
@@ -1077,6 +1163,27 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/vite": {
@@ -1152,48 +1259,22 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
-      "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.13",
-        "@vue/compiler-sfc": "3.5.13",
-        "@vue/runtime-dom": "3.5.13",
-        "@vue/server-renderer": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
         "typescript": "*"
       },
       "peerDependenciesMeta": {
         "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
           "optional": true
         }
       }

--- a/frameworks/keyed/vue-pinia/package.json
+++ b/frameworks/keyed/vue-pinia/package.json
@@ -15,8 +15,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "pinia": "^2.3.0",
-    "vue": "^3.5.13"
+    "pinia": "^3.0.4",
+    "vue": "^3.5.39"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",

--- a/frameworks/keyed/vue-pinia/src/store.js
+++ b/frameworks/keyed/vue-pinia/src/store.js
@@ -1,8 +1,7 @@
 import { defineStore } from 'pinia'
 import { buildData } from './data'
 
-export const useStore = defineStore({
-  id: 'main',
+export const useStore = defineStore('main',{
   state: () => ({
     selected: undefined,
     rows: [],

--- a/frameworks/keyed/vue-vapor/package-lock.json
+++ b/frameworks/keyed/vue-vapor/package-lock.json
@@ -8,7 +8,7 @@
       "name": "js-framework-benchmark-vue-vapor",
       "version": "1.0.0",
       "dependencies": {
-        "vue": "3.6.0-alpha.2"
+        "vue": "^3.6.0-beta.17"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.0",
@@ -16,30 +16,30 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -49,13 +49,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
@@ -804,142 +804,142 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-2aPvrCWKKhKKU4TaX6N6+cY4LcLIlIc+tcxJHw029mZr7KGb/w+98UxU9o3mYe/CLo5c5v8ps4IlE/Tm4H/eZA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-beta.17.tgz",
+      "integrity": "sha512-4xB2W8+00h7bfHbVeHD+zI+bmyF+XgQBKCCWLjFJ/VCJ/1tBjnlzWpX0OqcOE78LktGiCGcKgNk+eZAuav5cqg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.6.0-alpha.2",
-        "entities": "^4.5.0",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.6.0-beta.17",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-WHFo0z5QXXkBQk65NPrze1RO4RG6vAHcMudRG604zs2VsMkJPXBL5CAFcae3R6aoU3wwbIYHkklbMOelegS90w==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-beta.17.tgz",
+      "integrity": "sha512-viCM7YwHK6HuQ9rY8O27ET1xLi9WeJ+EmMWlwvtggpqb2j+l7DZOATkCRXOivjTOqtt8h5MIGnlB7tQlupQgeA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-core": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-QFwY1M5lYTo6Qt0rSQKXEp9aZngaKtT4WRlITAuioNeFoK5Y5stElr6sw2dopsaPzjbAJftDbQ7MgtMjOZ9XQg==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-beta.17.tgz",
+      "integrity": "sha512-L3KGWeWDCqm1tL03m09IXKRhIEh0Ij2gEIax9W0smDtlCAQt4gc8dmeTbjTOg4+1N2qAFEaAs+0xVu9y1j7Sng==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/compiler-vapor": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.6.0-beta.17",
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/compiler-ssr": "3.6.0-beta.17",
+        "@vue/compiler-vapor": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.14",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-BtP+A4xL7QSCf/P1eOvJw9XG1wojK3nqjJXSABcwXeIv0SJgBpi4CZ/obVUPAiUWMmdJDV3bdSwqQtkiXqOmug==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-beta.17.tgz",
+      "integrity": "sha512-OWBt5fu62UGeGTcl3Ra5ocMZbJ3h8ze862g9GlS72CNsYYZTbh3V9LePoOp6WX73SdsSdbsWLSsZfi5Wgh+ggQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/compiler-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/qmhrcOrVmBsZiQEpDMH5coH/hx7v1uflKCXDcvWhl7XaPfNWBeVwIndU/s/8mtOz+5nuCZrGtbqozXc4tfQzw==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-beta.17.tgz",
+      "integrity": "sha512-8qqHnEwQVytCnaF9zSOtcZxnYxz+FJqBNl9zIpSKwKRStl4XqmgcXlHtJYQMCxZS6xa7JfPvutkt5mBneh07Yw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-dqCEZHz7dy5u0fZV1ILObnH2YCA+I6UHuOt7PLGb1NBEAAUbO251nOK9OfecZEEPsvMJRl3P9rNqdJmAvIcHTg==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-beta.17.tgz",
+      "integrity": "sha512-oKLiLZRomHyJ++367F286Er49TXazWofj1PbNFUBoRxNNLne8xlDHAypN+C9Yr+JfAIN9cRp8l1PdjwfwMsV8g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-OPEIqs/q2rTZWTJm8VVSsI9B2OgsKdtprKEqzw3L74tBGDwNRleCGxGxu2T3LUpPlOtQFkSCZTIh1M52/6PG0w==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-beta.17.tgz",
+      "integrity": "sha512-JDPvmiyLpXtTnpG6I9URF88bOF+7KVgpDvPvZVl9AMboQj+LW4Pp19QOhGzxGoKES6wBts8c4xM1zjtr0xHcQw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-oYrpDYpbRqv/pgqM1SJEN7w9oahCjj6Txatz7McMJ++CX0WyFqAChi3Zvxr06Vrte+OCWA86t6Ot8K+mKV0QAA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-beta.17.tgz",
+      "integrity": "sha512-7B02MUGEFzuJaMbhxtgNRSMOrbj+AlERBy1EBxrXHplHSwv8xQjJpiBk0Z+5+vQMDVS4zc8VIYgeP7CUyROpUg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/runtime-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "csstype": "^3.1.3"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/runtime-core": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/runtime-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-UdGN6tcXIMTD/OFR7qI8V+ID4lji7K5A90i68OjiCr8nevtGxjfYPB3Lz5Lg7S6sckPCnFTECHExzWOmE7aV0A==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-beta.17.tgz",
+      "integrity": "sha512-nJpdHuMOXMEmVUrRTEo4AEDPreBja9euIXHjvUe4aEk1pmTKs61hQRluAdETRyXZwkyFe6D6+fXxvKf5wPBJBg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
-        "@vue/runtime-dom": "3.6.0-alpha.2"
+        "@vue/runtime-dom": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-Zw+fX/FlRqfwzrv5EmCyLBN5bOZWsRo3SnxQKqPl1yA5xGDe+FIe9cjII/X7hlFdC9Vb4lmQBvOQSnTeTj8ygA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-beta.17.tgz",
+      "integrity": "sha512-C7YpoWxewo01cG+S51MouH1v6taXBU5XvmxPjPAI3E9Zn3gpzb49e/ikShA5ov8ijE9R7tyIOUk4QU2xoDiT+Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-ssr": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
-        "vue": "3.6.0-alpha.2"
+        "vue": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-beta.17.tgz",
+      "integrity": "sha512-iuDH2UPBc8nzqgL4dcLiqpAJoJfQe70RcPM34+p+dVk0ThJD9jjpLPjzouP+RoRrXkAPOC7jmMncafdv69BGaA==",
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -1026,18 +1026,18 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
       "funding": [
         {
           "type": "opencollective",
@@ -1091,7 +1091,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1241,17 +1241,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-xn3jwLo6eMqxEKEAW8TWX+KSm7K2jTrNZ5Q3+H5Bu9P3mkoz8w0lUQHrO5WcnSVZfmR7vvw4/5XSYQe2XeDzdw==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-beta.17.tgz",
+      "integrity": "sha512-sVvFEriOhBjKIi7Jy+vwnlcBVRKhvxMVG4lh2erX1vrlaNKggURyWttRF+z5Vo+6VYriVsXAUyOgaQZub0W8ug==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-sfc": "3.6.0-alpha.2",
-        "@vue/runtime-dom": "3.6.0-alpha.2",
-        "@vue/runtime-vapor": "3.6.0-alpha.2",
-        "@vue/server-renderer": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/compiler-sfc": "3.6.0-beta.17",
+        "@vue/runtime-dom": "3.6.0-beta.17",
+        "@vue/runtime-vapor": "3.6.0-beta.17",
+        "@vue/server-renderer": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/frameworks/keyed/vue-vapor/package.json
+++ b/frameworks/keyed/vue-vapor/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "3.6.0-alpha.2"
+    "vue": "^3.6.0-beta.17"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",

--- a/frameworks/keyed/vue/package-lock.json
+++ b/frameworks/keyed/vue/package-lock.json
@@ -8,7 +8,7 @@
       "name": "js-framework-benchmark-vue",
       "version": "0.0.0",
       "dependencies": {
-        "vue": "^3.6.0-alpha.2"
+        "vue": "^3.5.39"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.0",
@@ -16,30 +16,30 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -49,13 +49,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -504,9 +504,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
@@ -821,142 +821,115 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-2aPvrCWKKhKKU4TaX6N6+cY4LcLIlIc+tcxJHw029mZr7KGb/w+98UxU9o3mYe/CLo5c5v8ps4IlE/Tm4H/eZA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.6.0-alpha.2",
-        "entities": "^4.5.0",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-WHFo0z5QXXkBQk65NPrze1RO4RG6vAHcMudRG604zs2VsMkJPXBL5CAFcae3R6aoU3wwbIYHkklbMOelegS90w==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-QFwY1M5lYTo6Qt0rSQKXEp9aZngaKtT4WRlITAuioNeFoK5Y5stElr6sw2dopsaPzjbAJftDbQ7MgtMjOZ9XQg==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/compiler-vapor": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-BtP+A4xL7QSCf/P1eOvJw9XG1wojK3nqjJXSABcwXeIv0SJgBpi4CZ/obVUPAiUWMmdJDV3bdSwqQtkiXqOmug==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
-      }
-    },
-    "node_modules/@vue/compiler-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/qmhrcOrVmBsZiQEpDMH5coH/hx7v1uflKCXDcvWhl7XaPfNWBeVwIndU/s/8mtOz+5nuCZrGtbqozXc4tfQzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-dqCEZHz7dy5u0fZV1ILObnH2YCA+I6UHuOt7PLGb1NBEAAUbO251nOK9OfecZEEPsvMJRl3P9rNqdJmAvIcHTg==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-OPEIqs/q2rTZWTJm8VVSsI9B2OgsKdtprKEqzw3L74tBGDwNRleCGxGxu2T3LUpPlOtQFkSCZTIh1M52/6PG0w==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-oYrpDYpbRqv/pgqM1SJEN7w9oahCjj6Txatz7McMJ++CX0WyFqAChi3Zvxr06Vrte+OCWA86t6Ot8K+mKV0QAA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/runtime-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "csstype": "^3.1.3"
-      }
-    },
-    "node_modules/@vue/runtime-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-UdGN6tcXIMTD/OFR7qI8V+ID4lji7K5A90i68OjiCr8nevtGxjfYPB3Lz5Lg7S6sckPCnFTECHExzWOmE7aV0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
-      },
-      "peerDependencies": {
-        "@vue/runtime-dom": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-Zw+fX/FlRqfwzrv5EmCyLBN5bOZWsRo3SnxQKqPl1yA5xGDe+FIe9cjII/X7hlFdC9Vb4lmQBvOQSnTeTj8ygA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
-        "vue": "3.6.0-alpha.2"
+        "vue": "3.5.39"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -1044,18 +1017,18 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -1090,9 +1063,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
       "funding": [
         {
           "type": "opencollective",
@@ -1109,7 +1082,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1259,17 +1232,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-xn3jwLo6eMqxEKEAW8TWX+KSm7K2jTrNZ5Q3+H5Bu9P3mkoz8w0lUQHrO5WcnSVZfmR7vvw4/5XSYQe2XeDzdw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-sfc": "3.6.0-alpha.2",
-        "@vue/runtime-dom": "3.6.0-alpha.2",
-        "@vue/runtime-vapor": "3.6.0-alpha.2",
-        "@vue/server-renderer": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/frameworks/keyed/vue/package.json
+++ b/frameworks/keyed/vue/package.json
@@ -15,7 +15,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.6.0-alpha.2"
+    "vue": "^3.5.39"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",

--- a/frameworks/non-keyed/vue-jsx-vapor/package-lock.json
+++ b/frameworks/non-keyed/vue-jsx-vapor/package-lock.json
@@ -8,312 +8,38 @@
       "name": "js-framework-benchmark-vue-jsx-vapor",
       "version": "1.4.4",
       "dependencies": {
-        "vue": "3.6.0-alpha.2"
+        "vue": "^3.6.0-beta.17"
       },
       "devDependencies": {
         "vite": "^7.0.5",
-        "vue-jsx-vapor": "^2.6.0"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
-      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.6",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.0",
-        "@babel/types": "^7.28.0",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.27.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-member-expression-to-functions": "^7.27.1",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
-      "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-      "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.27.1",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
+        "vue-jsx-vapor": "^3.2.18"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
-      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -322,103 +48,51 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
-      "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-create-class-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/plugin-syntax-typescript": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -847,13 +521,24 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -868,15 +553,15 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -884,20 +569,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@quansync/fs": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-0.1.3.tgz",
-      "integrity": "sha512-G0OnZbMWEs5LhDyqy2UL17vGhSVHkQIfVojMtEWVenvj0V5S84VBgy86kJIuNsGDp2p7sTKlpSIpBUWdC35OKg==",
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "quansync": "^0.2.10"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sxzz"
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1180,6 +868,17 @@
         "win32"
       ]
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1187,66 +886,254 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@volar/language-core": {
-      "version": "2.4.20",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.20.tgz",
-      "integrity": "sha512-dRDF1G33xaAIDqR6+mXUIjXYdu9vzSxlMGfMEwBxQsfY/JMUEXSpLTR057oTKlUQ2nIvCmP9k94A8h8z2VrNSA==",
+    "node_modules/@vue-jsx-vapor/compiler-rs": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs/-/compiler-rs-3.2.18.tgz",
+      "integrity": "sha512-CbFqwcYmdOxXSNHlZJMqHYcvgZbDWr9kMpIzXtFNpsW9+D4uJLY72T4MTJ79NG9Gpl33kq3jz7RCnV9GCBxxpA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@volar/source-map": "2.4.20"
+      "optionalDependencies": {
+        "@vue-jsx-vapor/compiler-rs-android-arm-eabi": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-android-arm64": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-darwin-arm64": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-darwin-x64": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-freebsd-x64": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-arm64-gnu": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-arm64-musl": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-x64-gnu": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-linux-x64-musl": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-wasm32-wasi": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-win32-arm64-msvc": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-win32-ia32-msvc": "3.2.18",
+        "@vue-jsx-vapor/compiler-rs-win32-x64-msvc": "3.2.18"
       }
     },
-    "node_modules/@volar/source-map": {
-      "version": "2.4.20",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.20.tgz",
-      "integrity": "sha512-mVjmFQH8mC+nUaVwmbxoYUy8cww+abaO8dWzqPUjilsavjxH0jCJ3Mp8HFuHsdewZs2c+SP+EO7hCd8Z92whJg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue-jsx-vapor/babel": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/babel/-/babel-2.6.0.tgz",
-      "integrity": "sha512-ZBo/ocfZim7osl+GAKl9KN9u26T3odnjmE4djlI2f5Uwz1aHkagKeu2Ouq6tRSq/xJQKgp3r6H69tqDY4ICkkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/parser": "^7.28.0",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/types": "^7.28.0",
-        "@vue-jsx-vapor/compiler": "2.6.0",
-        "ast-kit": "^2.1.1",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-jsx-vapor/compiler": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler/-/compiler-2.6.0.tgz",
-      "integrity": "sha512-ANvRnrhz3b3wrUhPj5Q7qzI2OaDpMy4A0WYGNCbQHwFLlbofMuNmordUUi6/1bonqrRDZvN2Yv8OM+h19/XdHQ==",
+    "node_modules/@vue-jsx-vapor/compiler-rs-android-arm-eabi": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-android-arm-eabi/-/compiler-rs-android-arm-eabi-3.2.18.tgz",
+      "integrity": "sha512-XZCcernaJOUCPyOaB5BuPgJS06h24HuV4XpM0JMHiC3JKM5JuK39Egy9sEoY2G/HF05+GaHJ9bOThaH29JzABg==",
+      "cpu": [
+        "arm"
+      ],
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-android-arm64": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-android-arm64/-/compiler-rs-android-arm64-3.2.18.tgz",
+      "integrity": "sha512-0JsyjDahmxbjIbNah2v/v6aPeAi4Zua7eSSmn/q5EyqvM8FZ1kcIx53Kg0cqTnYrQWWun0I/o3pPFQezDJiifQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-darwin-arm64": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-darwin-arm64/-/compiler-rs-darwin-arm64-3.2.18.tgz",
+      "integrity": "sha512-9SWROILFTK8XAEHk1iuZBkb3GqIPZ1bONpV4LLsUmBCpfFnmbLCzmrmu7orUVfd63fhXlhhHmtl6Z2A+6ZnE+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-darwin-x64": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-darwin-x64/-/compiler-rs-darwin-x64-3.2.18.tgz",
+      "integrity": "sha512-Xr68QpqU98nrpxuOuZrySnQhCV2IoIgow1NzlUDGhjpefKlJqLvR2Pk3rKJRY7y69/0/LgnWe+vZSjlvsN7XlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-freebsd-x64": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-freebsd-x64/-/compiler-rs-freebsd-x64-3.2.18.tgz",
+      "integrity": "sha512-QI77aoJAIgECyDWf1QPi93qTYDCVHZgkTo3c6fCt0F13ux9uC7fzV3cD5BDhKSogDF5YpFY9buITKT4Vasy7hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf/-/compiler-rs-linux-arm-gnueabihf-3.2.18.tgz",
+      "integrity": "sha512-GCC08O68n2eXPsarmR3ZZ9FMydG+OInhIPTJC9pIA1ndE7+tMxMNEjvMZS1qSIX5qxPriNsB+FWb4pWdWS62Hg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-linux-arm64-gnu": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-arm64-gnu/-/compiler-rs-linux-arm64-gnu-3.2.18.tgz",
+      "integrity": "sha512-mHaQm7PCu3JgDTv8DlLfEk7MigMLr1PgELw5GgE8bCka8ur0Qn1WBpCLlWdg/thnt4fY9/8+IZ5ZgG34z9kLUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-linux-arm64-musl": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-arm64-musl/-/compiler-rs-linux-arm64-musl-3.2.18.tgz",
+      "integrity": "sha512-EaZ60NtNvY9TgHT8aT/rXykPdk8oXiixEsqn6PbJMZixpLGlXgpU0lCn9YwstVRwM3dyPCA4WGJhkBD7vKq2Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-linux-x64-gnu": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-x64-gnu/-/compiler-rs-linux-x64-gnu-3.2.18.tgz",
+      "integrity": "sha512-0EAxA6hzwTE+OD44J8l3n6b/xEgwcmSkp+ITjZ2SGqJgNZH5eq8fvPaxe7xizoEz1M8xQuUd0NYggcUJ1yvsKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-linux-x64-musl": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-linux-x64-musl/-/compiler-rs-linux-x64-musl-3.2.18.tgz",
+      "integrity": "sha512-DT5BqrmH7q9Fx9hEZ2PvPV39kNaJf3EKig23JKI1AJT3GOLSB5E1A3Kp+fNf4KTQ4mWgQZ63+Nhk05CirQJ8Ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-wasm32-wasi": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-wasm32-wasi/-/compiler-rs-wasm32-wasi-3.2.18.tgz",
+      "integrity": "sha512-Rwjw0lUhaAhEpzzo+7OpeR8Y516p+vP1ka2JAmXxwcsomelvvSn/37CZo2xlfpC/tFtH/L3tI17qZK0SNQccAw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "ast-kit": "^2.1.1",
-        "source-map-js": "^1.2.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-win32-arm64-msvc": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-win32-arm64-msvc/-/compiler-rs-win32-arm64-msvc-3.2.18.tgz",
+      "integrity": "sha512-NqnAgwQgLwJW+p5cZLIfNHnwUvAXXlJHBImDRkH/Fr0wpZC89S0WSydFieyPSroIU+ax7O7zPY0lrJwppOWaBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-win32-ia32-msvc": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-win32-ia32-msvc/-/compiler-rs-win32-ia32-msvc-3.2.18.tgz",
+      "integrity": "sha512-IYqu//HlI7gZ6dMUZMxpIvCqEsanxBpZ66T2oxE1aVrSgj/CJoSynw0x3KBe8cGYo6CR/9twCz9NRcMCJN417w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vue-jsx-vapor/compiler-rs-win32-x64-msvc": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/compiler-rs-win32-x64-msvc/-/compiler-rs-win32-x64-msvc-3.2.18.tgz",
+      "integrity": "sha512-jaYa6XYepMy5oF+/qok8bWYSPvL/giqopsbHJHiQSCTvplctodvBW+VsJCOCCWyadN6c5rXPfLgUmgwPgdbz1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@vue-jsx-vapor/macros": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/macros/-/macros-2.6.0.tgz",
-      "integrity": "sha512-1MQU8a2CUBypdPyDwp7NVF73Eksr1LRKJZGgEgUv4AW0e8YdN0njvM04nY5dAD2eZSwgz+zGvkK8UdgnVpakZw==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/macros/-/macros-3.2.18.tgz",
+      "integrity": "sha512-dOUedO348AcrHWkIzvDQd7Re6WkPS3HqjUBFMu+PPb41lHXs+OsDyytGFGqaB9LYOWuCFBY4QLfO/d+ubzudJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue-macros/common": "^3.0.0-beta.19",
-        "@vue/compiler-sfc": "3.6.0-alpha.2",
         "hash-sum": "^2.0.0",
-        "ts-macro": "^0.3.1",
-        "unplugin": "^2.3.5"
+        "magic-string": "^0.30.21",
+        "ts-macro": "^0.3.7",
+        "unplugin": "^3.0.0",
+        "unplugin-utils": "^0.3.1"
       },
       "peerDependencies": {
         "@nuxt/kit": "^3",
@@ -1254,6 +1141,7 @@
         "esbuild": "*",
         "rollup": "^3",
         "vite": ">=3",
+        "vue": ">=3",
         "webpack": "^4 || ^5"
       },
       "peerDependenciesMeta": {
@@ -1278,894 +1166,153 @@
       }
     },
     "node_modules/@vue-jsx-vapor/runtime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/runtime/-/runtime-2.6.0.tgz",
-      "integrity": "sha512-fNhkTHSwNcM9ikIms94SyJZVDanIiTxt+ecc+lDVfCxjZ9iAtzQa8etYtnXgekqx9GsJ92WSBfeInaYlg8YYFQ==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@vue-jsx-vapor/runtime/-/runtime-3.2.18.tgz",
+      "integrity": "sha512-bB4oYcgAWlA/Lvbvn93Q997PvjEvjMgGSWC2frrhK/bRKQ9QNFBFpNCdJfA7GxCWgGMt0cziUOdwmNJcCtGcQA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "vue": "^3.6.0-alpha.2"
+        "csstype": "^3.2.3",
+        "vue": "3.6.0-beta.16"
       }
-    },
-    "node_modules/@vue-macros/boolean-prop": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/boolean-prop/-/boolean-prop-3.0.0-beta.20.tgz",
-      "integrity": "sha512-KSC4sR/iVlcx5NuJteiFlppZjL/VexQPFjt/grAatHUdCkFoX+UF+CKw8TyKcf+/4Bx85nbXnYjIn2P8hD2JqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue-macros/common": "3.0.0-beta.20",
-        "@vue/compiler-core": "^3.5.18"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      }
-    },
-    "node_modules/@vue-macros/boolean-prop/node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/boolean-prop/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue-macros/common": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.0.0-beta.20.tgz",
-      "integrity": "sha512-k4ez00bGD4mesrrreJarUj9Wuyqzl8N58+j3hsHkw4F9JSTCPMHVeQ7vHXETgnHtNAyJp2o6KRjTLLyzPc1cuA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-sfc": "^3.5.18",
-        "ast-kit": "^2.1.1",
-        "local-pkg": "^1.1.1",
-        "magic-string-ast": "^1.0.0",
-        "unplugin-utils": "^0.2.4"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      },
-      "peerDependencies": {
-        "vue": "^2.7.0 || ^3.2.25"
-      },
-      "peerDependenciesMeta": {
-        "vue": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue-macros/common/node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/common/node_modules/@vue/compiler-dom": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.18.tgz",
-      "integrity": "sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.18",
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/common/node_modules/@vue/compiler-sfc": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.18.tgz",
-      "integrity": "sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/compiler-core": "3.5.18",
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/compiler-ssr": "3.5.18",
-        "@vue/shared": "3.5.18",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/common/node_modules/@vue/compiler-ssr": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.18.tgz",
-      "integrity": "sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/common/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue-macros/config": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/config/-/config-3.0.0-beta.20.tgz",
-      "integrity": "sha512-Dh1QV3AU4wxUpMu1YMDmx2QszYptues/BhJvnZcK8buMOpDp9DNquc1s7DuG1jDptOqZdSPjx5Kt5LqeVkJOiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue-macros/common": "3.0.0-beta.20",
-        "quansync": "^0.2.10",
-        "unconfig": "^7.3.2"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/jsx-directive/-/jsx-directive-3.0.0-beta.20.tgz",
-      "integrity": "sha512-FuswkOrdAPMe8r8O/qV4EbtAcwQCpvpROQDbZY45ZHBd1Yei1rQhKWdptElHK+IJTcWCE6Wu6YW/aPymDt++/A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue-macros/common": "3.0.0-beta.20",
-        "unplugin": "^2.3.5",
-        "vue": "^3.5.18"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/compiler-dom": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.18.tgz",
-      "integrity": "sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.18",
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/compiler-sfc": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.18.tgz",
-      "integrity": "sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/compiler-core": "3.5.18",
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/compiler-ssr": "3.5.18",
-        "@vue/shared": "3.5.18",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/compiler-ssr": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.18.tgz",
-      "integrity": "sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/reactivity": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.18.tgz",
-      "integrity": "sha512-x0vPO5Imw+3sChLM5Y+B6G1zPjwdOri9e8V21NnTnlEvkxatHEH5B5KEAJcjuzQ7BsjGrKtfzuQ5eQwXh8HXBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/runtime-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.18.tgz",
-      "integrity": "sha512-DUpHa1HpeOQEt6+3nheUfqVXRog2kivkXHUhoqJiKR33SO4x+a5uNOMkV487WPerQkL0vUuRvq/7JhRgLW3S+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.5.18",
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/runtime-dom": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.18.tgz",
-      "integrity": "sha512-YwDj71iV05j4RnzZnZtGaXwPoUWeRsqinblgVJwR8XTXYZ9D5PbahHQgsbmzUvCWNF6x7siQ89HgnX5eWkr3mw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.5.18",
-        "@vue/runtime-core": "3.5.18",
-        "@vue/shared": "3.5.18",
-        "csstype": "^3.1.3"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/server-renderer": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.18.tgz",
-      "integrity": "sha512-PvIHLUoWgSbDG7zLHqSqaCoZvHi6NNmfVFOqO+OnwvqMz/tqQr3FuGWS8ufluNddk7ZLBJYMrjcw1c6XzR12mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-ssr": "3.5.18",
-        "@vue/shared": "3.5.18"
-      },
-      "peerDependencies": {
-        "vue": "3.5.18"
-      }
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue-macros/jsx-directive/node_modules/vue": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.18.tgz",
-      "integrity": "sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/compiler-sfc": "3.5.18",
-        "@vue/runtime-dom": "3.5.18",
-        "@vue/server-renderer": "3.5.18",
-        "@vue/shared": "3.5.18"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue-macros/short-bind": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/short-bind/-/short-bind-3.0.0-beta.20.tgz",
-      "integrity": "sha512-JJSyZYBcfvP4YGVZo3Ppv7zSnUzDdoW6tRGuq7dOI8kxF+4HshitckmEO9ehJJEIy7b22EsFZYfrV8crnieslQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue-macros/common": "3.0.0-beta.20",
-        "@vue/compiler-core": "^3.5.18"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      }
-    },
-    "node_modules/@vue-macros/short-bind/node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/short-bind/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue-macros/short-vmodel": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/short-vmodel/-/short-vmodel-3.0.0-beta.20.tgz",
-      "integrity": "sha512-UVmRfz9CDEFbc1UrnjDu9LlGyGh7AWR8kstHUQJ5xP+aq3Y7SQKIgFt6YbubHf0Wka7Aiax+tAGyADUBybSMpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue-macros/common": "3.0.0-beta.20",
-        "@vue/compiler-core": "^3.5.18"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      }
-    },
-    "node_modules/@vue-macros/short-vmodel/node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue-macros/short-vmodel/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue-macros/volar": {
-      "version": "3.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue-macros/volar/-/volar-3.0.0-beta.20.tgz",
-      "integrity": "sha512-+FwD2dMqe+pCcp+3FkTbJXbEZi0/f107gk5LXIzMUIkbNu/i8fMVwRGS+7EPTcS0YghDyDU2U09UtITrKDvIig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue-macros/boolean-prop": "3.0.0-beta.20",
-        "@vue-macros/common": "3.0.0-beta.20",
-        "@vue-macros/config": "3.0.0-beta.20",
-        "@vue-macros/short-bind": "3.0.0-beta.20",
-        "@vue-macros/short-vmodel": "3.0.0-beta.20",
-        "@vue/language-core": "3.0.4",
-        "@vue/shared": "^3.5.18",
-        "muggle-string": "^0.4.1",
-        "ts-macro": "^0.3.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/vue-macros"
-      },
-      "peerDependencies": {
-        "vue-tsc": "3.0.4"
-      },
-      "peerDependenciesMeta": {
-        "vue-tsc": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue-macros/volar/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue/babel-helper-vue-transform-on": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.4.0.tgz",
-      "integrity": "sha512-mCokbouEQ/ocRce/FpKCRItGo+013tHg7tixg3DUNS+6bmIchPt66012kBMm476vyEIJPafrvOf4E5OYj3shSw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue/babel-plugin-jsx": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vue/babel-plugin-jsx/-/babel-plugin-jsx-1.4.0.tgz",
-      "integrity": "sha512-9zAHmwgMWlaN6qRKdrg1uKsBKHvnUU+Py+MOCTuYZBoZsopa90Di10QRjB+YPnVss0BZbG/H5XFwJY1fTxJWhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.26.5",
-        "@babel/plugin-syntax-jsx": "^7.25.9",
-        "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
-        "@vue/babel-helper-vue-transform-on": "1.4.0",
-        "@vue/babel-plugin-resolve-type": "1.4.0",
-        "@vue/shared": "^3.5.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue/babel-plugin-jsx/node_modules/@vue/shared": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
-      "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue/babel-plugin-resolve-type": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vue/babel-plugin-resolve-type/-/babel-plugin-resolve-type-1.4.0.tgz",
-      "integrity": "sha512-4xqDRRbQQEWHQyjlYSgZsWj44KfiF6D+ktCuXyZ8EnVDYV3pztmXJDf1HveAjUAXxAnR8daCQT51RneWWxtTyQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.26.5",
-        "@babel/parser": "^7.26.9",
-        "@vue/compiler-sfc": "^3.5.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/compiler-core": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.17.tgz",
-      "integrity": "sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.5.17",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/compiler-dom": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.17.tgz",
-      "integrity": "sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.17",
-        "@vue/shared": "3.5.17"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/compiler-sfc": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz",
-      "integrity": "sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-core": "3.5.17",
-        "@vue/compiler-dom": "3.5.17",
-        "@vue/compiler-ssr": "3.5.17",
-        "@vue/shared": "3.5.17",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/compiler-ssr": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.17.tgz",
-      "integrity": "sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.17",
-        "@vue/shared": "3.5.17"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/shared": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
-      "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-2aPvrCWKKhKKU4TaX6N6+cY4LcLIlIc+tcxJHw029mZr7KGb/w+98UxU9o3mYe/CLo5c5v8ps4IlE/Tm4H/eZA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-beta.17.tgz",
+      "integrity": "sha512-4xB2W8+00h7bfHbVeHD+zI+bmyF+XgQBKCCWLjFJ/VCJ/1tBjnlzWpX0OqcOE78LktGiCGcKgNk+eZAuav5cqg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.6.0-alpha.2",
-        "entities": "^4.5.0",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.6.0-beta.17",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-WHFo0z5QXXkBQk65NPrze1RO4RG6vAHcMudRG604zs2VsMkJPXBL5CAFcae3R6aoU3wwbIYHkklbMOelegS90w==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-beta.17.tgz",
+      "integrity": "sha512-viCM7YwHK6HuQ9rY8O27ET1xLi9WeJ+EmMWlwvtggpqb2j+l7DZOATkCRXOivjTOqtt8h5MIGnlB7tQlupQgeA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-core": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-QFwY1M5lYTo6Qt0rSQKXEp9aZngaKtT4WRlITAuioNeFoK5Y5stElr6sw2dopsaPzjbAJftDbQ7MgtMjOZ9XQg==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-beta.17.tgz",
+      "integrity": "sha512-L3KGWeWDCqm1tL03m09IXKRhIEh0Ij2gEIax9W0smDtlCAQt4gc8dmeTbjTOg4+1N2qAFEaAs+0xVu9y1j7Sng==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/compiler-vapor": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.6.0-beta.17",
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/compiler-ssr": "3.6.0-beta.17",
+        "@vue/compiler-vapor": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.14",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-BtP+A4xL7QSCf/P1eOvJw9XG1wojK3nqjJXSABcwXeIv0SJgBpi4CZ/obVUPAiUWMmdJDV3bdSwqQtkiXqOmug==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-beta.17.tgz",
+      "integrity": "sha512-OWBt5fu62UGeGTcl3Ra5ocMZbJ3h8ze862g9GlS72CNsYYZTbh3V9LePoOp6WX73SdsSdbsWLSsZfi5Wgh+ggQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/compiler-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/qmhrcOrVmBsZiQEpDMH5coH/hx7v1uflKCXDcvWhl7XaPfNWBeVwIndU/s/8mtOz+5nuCZrGtbqozXc4tfQzw==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-beta.17.tgz",
+      "integrity": "sha512-8qqHnEwQVytCnaF9zSOtcZxnYxz+FJqBNl9zIpSKwKRStl4XqmgcXlHtJYQMCxZS6xa7JfPvutkt5mBneh07Yw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
-    },
-    "node_modules/@vue/compiler-vue2": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
-      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
-      }
-    },
-    "node_modules/@vue/language-core": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.4.tgz",
-      "integrity": "sha512-BvueED4LfBCSNH66eeUQk37MQCb7hjdezzGgxniM0LbriW53AJIyLorgshAtStmjfsAuOCcTl/c1b+nz/ye8xQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@volar/language-core": "2.4.20",
-        "@vue/compiler-dom": "^3.5.0",
-        "@vue/compiler-vue2": "^2.7.16",
-        "@vue/shared": "^3.5.0",
-        "alien-signals": "^2.0.5",
-        "muggle-string": "^0.4.1",
-        "path-browserify": "^1.0.1",
-        "picomatch": "^4.0.2"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue/language-core/node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/language-core/node_modules/@vue/compiler-dom": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.18.tgz",
-      "integrity": "sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.18",
-        "@vue/shared": "3.5.18"
-      }
-    },
-    "node_modules/@vue/language-core/node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-dqCEZHz7dy5u0fZV1ILObnH2YCA+I6UHuOt7PLGb1NBEAAUbO251nOK9OfecZEEPsvMJRl3P9rNqdJmAvIcHTg==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-beta.17.tgz",
+      "integrity": "sha512-oKLiLZRomHyJ++367F286Er49TXazWofj1PbNFUBoRxNNLne8xlDHAypN+C9Yr+JfAIN9cRp8l1PdjwfwMsV8g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-OPEIqs/q2rTZWTJm8VVSsI9B2OgsKdtprKEqzw3L74tBGDwNRleCGxGxu2T3LUpPlOtQFkSCZTIh1M52/6PG0w==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-beta.17.tgz",
+      "integrity": "sha512-JDPvmiyLpXtTnpG6I9URF88bOF+7KVgpDvPvZVl9AMboQj+LW4Pp19QOhGzxGoKES6wBts8c4xM1zjtr0xHcQw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-oYrpDYpbRqv/pgqM1SJEN7w9oahCjj6Txatz7McMJ++CX0WyFqAChi3Zvxr06Vrte+OCWA86t6Ot8K+mKV0QAA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-beta.17.tgz",
+      "integrity": "sha512-7B02MUGEFzuJaMbhxtgNRSMOrbj+AlERBy1EBxrXHplHSwv8xQjJpiBk0Z+5+vQMDVS4zc8VIYgeP7CUyROpUg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/runtime-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "csstype": "^3.1.3"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/runtime-core": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/runtime-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-UdGN6tcXIMTD/OFR7qI8V+ID4lji7K5A90i68OjiCr8nevtGxjfYPB3Lz5Lg7S6sckPCnFTECHExzWOmE7aV0A==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-beta.17.tgz",
+      "integrity": "sha512-nJpdHuMOXMEmVUrRTEo4AEDPreBja9euIXHjvUe4aEk1pmTKs61hQRluAdETRyXZwkyFe6D6+fXxvKf5wPBJBg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
-        "@vue/runtime-dom": "3.6.0-alpha.2"
+        "@vue/runtime-dom": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-Zw+fX/FlRqfwzrv5EmCyLBN5bOZWsRo3SnxQKqPl1yA5xGDe+FIe9cjII/X7hlFdC9Vb4lmQBvOQSnTeTj8ygA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-beta.17.tgz",
+      "integrity": "sha512-C7YpoWxewo01cG+S51MouH1v6taXBU5XvmxPjPAI3E9Zn3gpzb49e/ikShA5ov8ijE9R7tyIOUk4QU2xoDiT+Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-ssr": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
-        "vue": "3.6.0-alpha.2"
+        "vue": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
-      "license": "MIT"
-    },
-    "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/alien-signals": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.6.tgz",
-      "integrity": "sha512-P3TxJSe31bUHBiblg59oU1PpaWPtmxF9GhJ/cB7OkgJ0qN/ifFSKUI25/v8ZhsT+lIG6ac8DpTOplXxORX6F3Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ast-kit": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.1.1.tgz",
-      "integrity": "sha512-mfh6a7gKXE8pDlxTvqIc/syH/P3RkzbOF6LeHdcKztLEzYe6IMsRCL7N8vI7hqTGWNxpkCuuRTpT21xNWqhRtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.7",
-        "pathe": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001726",
-        "electron-to-chromium": "^1.5.173",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001731",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
-    "node_modules/confbox": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-beta.17.tgz",
+      "integrity": "sha512-iuDH2UPBc8nzqgL4dcLiqpAJoJfQe70RcPM34+p+dVk0ThJD9jjpLPjzouP+RoRrXkAPOC7jmMncafdv69BGaA==",
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
-    },
-    "node_modules/de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.194",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.194.tgz",
-      "integrity": "sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2215,27 +1362,10 @@
         "@esbuild/win32-x64": "0.25.1"
       }
     },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT"
-    },
-    "node_modules/exsolve": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
-      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
@@ -2268,16 +1398,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/hash-sum": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
@@ -2285,150 +1405,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
-    "node_modules/jiti": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
-      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/local-pkg": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.1.tgz",
-      "integrity": "sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mlly": "^1.7.4",
-        "pkg-types": "^2.0.1",
-        "quansync": "^0.2.8"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
-    },
-    "node_modules/magic-string-ast": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.0.tgz",
-      "integrity": "sha512-8rbuNizut2gW94kv7pqgt0dvk+AHLPVIm0iJtpSgQJ9dx21eWx5SBel8z3jp1xtC0j6/iyK3AWGhAR1H61s7LA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "magic-string": "^0.30.17"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
-      }
-    },
-    "node_modules/mlly": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.14.0",
-        "pathe": "^2.0.1",
-        "pkg-types": "^1.3.0",
-        "ufo": "^1.5.4"
-      }
-    },
-    "node_modules/mlly/node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mlly/node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
@@ -2438,9 +1422,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -2454,20 +1438,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2483,9 +1453,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2495,22 +1465,10 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pkg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.2.0.tgz",
-      "integrity": "sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
-        "pathe": "^2.0.3"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
       "funding": [
         {
           "type": "opencollective",
@@ -2527,30 +1485,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/quansync": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
-      "integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/antfu"
-        },
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/sxzz"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.45.1",
@@ -2592,16 +1533,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2629,99 +1560,93 @@
       }
     },
     "node_modules/ts-macro": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ts-macro/-/ts-macro-0.3.1.tgz",
-      "integrity": "sha512-Q7fVWKas1W7ZlULXdLgacU92g7WY92YIkVe+lENUINBjRPD/1Gfq0dV9Txr8ZszIpJPRE9vw+Rai95DH3sMUFg==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/ts-macro/-/ts-macro-0.3.7.tgz",
+      "integrity": "sha512-5BinbTKn5WXRslotv5/VWTn3catfK0thWoB4BZI5VNEdxMu6r9AUPFalut4wLEK3nGvxhywA9aAdZnJ+Fnug9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "muggle-string": "^0.4.1"
       }
     },
-    "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unconfig": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-7.3.2.tgz",
-      "integrity": "sha512-nqG5NNL2wFVGZ0NA/aCFw0oJ2pxSf1lwg4Z5ill8wd7K4KX/rQbHlwbh+bjctXL5Ly1xtzHenHGOK0b+lG6JVg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@quansync/fs": "^0.1.1",
-        "defu": "^6.1.4",
-        "jiti": "^2.4.2",
-        "quansync": "^0.2.8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/unplugin": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.5.tgz",
-      "integrity": "sha512-RyWSb5AHmGtjjNQ6gIlA67sHOsWpsbWpwDokLwTcejVdOjEkJZh7QKu14J00gDDVSh8kGH4KYC/TNBceXFZhtw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+      "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.14.1",
-        "picomatch": "^4.0.2",
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.4",
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@farmfe/core": "*",
+        "@rspack/core": "*",
+        "bun-types-no-globals": "*",
+        "esbuild": "*",
+        "rolldown": "*",
+        "rollup": "*",
+        "unloader": "*",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "@farmfe/core": {
+          "optional": true
+        },
+        "@rspack/core": {
+          "optional": true
+        },
+        "bun-types-no-globals": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "unloader": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/unplugin-utils": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.2.4.tgz",
-      "integrity": "sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+      "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "pathe": "^2.0.2",
-        "picomatch": "^4.0.2"
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
-      }
-    },
-    "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/vite": {
@@ -2800,17 +1725,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-xn3jwLo6eMqxEKEAW8TWX+KSm7K2jTrNZ5Q3+H5Bu9P3mkoz8w0lUQHrO5WcnSVZfmR7vvw4/5XSYQe2XeDzdw==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-beta.17.tgz",
+      "integrity": "sha512-sVvFEriOhBjKIi7Jy+vwnlcBVRKhvxMVG4lh2erX1vrlaNKggURyWttRF+z5Vo+6VYriVsXAUyOgaQZub0W8ug==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-sfc": "3.6.0-alpha.2",
-        "@vue/runtime-dom": "3.6.0-alpha.2",
-        "@vue/runtime-vapor": "3.6.0-alpha.2",
-        "@vue/server-renderer": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/compiler-sfc": "3.6.0-beta.17",
+        "@vue/runtime-dom": "3.6.0-beta.17",
+        "@vue/runtime-vapor": "3.6.0-beta.17",
+        "@vue/server-renderer": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -2822,26 +1747,20 @@
       }
     },
     "node_modules/vue-jsx-vapor": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/vue-jsx-vapor/-/vue-jsx-vapor-2.6.0.tgz",
-      "integrity": "sha512-CodJDlxBbbZ4EFDQI8yTBzDw05Nbe+bGBjPT5OJv9plf6n8e3xaXG1UkdNkgWhhqZHQnZIRpWydIh7BggKepnw==",
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/vue-jsx-vapor/-/vue-jsx-vapor-3.2.18.tgz",
+      "integrity": "sha512-aSxXlNHIpv8V6Yg8g4adojeQal+O3s/vijKWdC94dSyfVucMAIJNKKWv1dQtI81aDNYkvtTFw0XHSM69gXsxPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-typescript": "^7.28.0",
-        "@vue-jsx-vapor/babel": "2.6.0",
-        "@vue-jsx-vapor/compiler": "2.6.0",
-        "@vue-jsx-vapor/macros": "2.6.0",
-        "@vue-jsx-vapor/runtime": "2.6.0",
-        "@vue-macros/jsx-directive": "^3.0.0-beta.19",
-        "@vue-macros/volar": "^3.0.0-beta.19",
-        "@vue/babel-plugin-jsx": "^1.4.0",
-        "hash-sum": "^2.0.0",
+        "@vue-jsx-vapor/compiler-rs": "3.2.18",
+        "@vue-jsx-vapor/macros": "3.2.18",
+        "@vue-jsx-vapor/runtime": "3.2.18",
+        "@vue/shared": "3.6.0-beta.16",
         "pathe": "^2.0.3",
-        "ts-macro": "^0.3.1",
-        "unplugin": "^2.3.5",
-        "unplugin-utils": "^0.2.4"
+        "ts-macro": "^0.3.7",
+        "unplugin": "^3.0.0",
+        "unplugin-utils": "^0.3.1"
       },
       "peerDependencies": {
         "@nuxt/kit": "^3",
@@ -2849,7 +1768,7 @@
         "esbuild": "*",
         "rollup": "^3",
         "vite": ">=3",
-        "vue": "^3.6.0-alpha.2",
+        "vue": "^3",
         "webpack": "^4 || ^5"
       },
       "peerDependenciesMeta": {
@@ -2873,19 +1792,19 @@
         }
       }
     },
+    "node_modules/vue-jsx-vapor/node_modules/@vue/shared": {
+      "version": "3.6.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-beta.16.tgz",
+      "integrity": "sha512-DyuxocDJp/vbmQKnrVzHEs8QrJv2XFnvgyri0W0Ni8+TmoiDSd86NaDoF32yRcIBstxKKL6X6nia7JPjZHia6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
     }
   }
 }

--- a/frameworks/non-keyed/vue-jsx-vapor/package.json
+++ b/frameworks/non-keyed/vue-jsx-vapor/package.json
@@ -14,10 +14,10 @@
     "preview": "vite preview --port 4711"
   },
   "dependencies": {
-    "vue": "3.6.0-alpha.2"
+    "vue": "^3.6.0-beta.17"
   },
   "devDependencies": {
-    "vue-jsx-vapor": "^2.6.0",
+    "vue-jsx-vapor": "^3.2.18",
     "vite": "^7.0.5"
   }
 }

--- a/frameworks/non-keyed/vue-vapor/package-lock.json
+++ b/frameworks/non-keyed/vue-vapor/package-lock.json
@@ -8,7 +8,7 @@
       "name": "js-framework-benchmark-vue-vapor",
       "version": "1.0.0",
       "dependencies": {
-        "vue": "3.6.0-alpha.2"
+        "vue": "^3.6.0-beta.17"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.0",
@@ -16,30 +16,30 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -49,13 +49,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
@@ -804,142 +804,142 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-2aPvrCWKKhKKU4TaX6N6+cY4LcLIlIc+tcxJHw029mZr7KGb/w+98UxU9o3mYe/CLo5c5v8ps4IlE/Tm4H/eZA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-beta.17.tgz",
+      "integrity": "sha512-4xB2W8+00h7bfHbVeHD+zI+bmyF+XgQBKCCWLjFJ/VCJ/1tBjnlzWpX0OqcOE78LktGiCGcKgNk+eZAuav5cqg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.6.0-alpha.2",
-        "entities": "^4.5.0",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.6.0-beta.17",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-WHFo0z5QXXkBQk65NPrze1RO4RG6vAHcMudRG604zs2VsMkJPXBL5CAFcae3R6aoU3wwbIYHkklbMOelegS90w==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-beta.17.tgz",
+      "integrity": "sha512-viCM7YwHK6HuQ9rY8O27ET1xLi9WeJ+EmMWlwvtggpqb2j+l7DZOATkCRXOivjTOqtt8h5MIGnlB7tQlupQgeA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-core": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-QFwY1M5lYTo6Qt0rSQKXEp9aZngaKtT4WRlITAuioNeFoK5Y5stElr6sw2dopsaPzjbAJftDbQ7MgtMjOZ9XQg==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-beta.17.tgz",
+      "integrity": "sha512-L3KGWeWDCqm1tL03m09IXKRhIEh0Ij2gEIax9W0smDtlCAQt4gc8dmeTbjTOg4+1N2qAFEaAs+0xVu9y1j7Sng==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/compiler-vapor": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.6.0-beta.17",
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/compiler-ssr": "3.6.0-beta.17",
+        "@vue/compiler-vapor": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.14",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-BtP+A4xL7QSCf/P1eOvJw9XG1wojK3nqjJXSABcwXeIv0SJgBpi4CZ/obVUPAiUWMmdJDV3bdSwqQtkiXqOmug==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-beta.17.tgz",
+      "integrity": "sha512-OWBt5fu62UGeGTcl3Ra5ocMZbJ3h8ze862g9GlS72CNsYYZTbh3V9LePoOp6WX73SdsSdbsWLSsZfi5Wgh+ggQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/compiler-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/qmhrcOrVmBsZiQEpDMH5coH/hx7v1uflKCXDcvWhl7XaPfNWBeVwIndU/s/8mtOz+5nuCZrGtbqozXc4tfQzw==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-beta.17.tgz",
+      "integrity": "sha512-8qqHnEwQVytCnaF9zSOtcZxnYxz+FJqBNl9zIpSKwKRStl4XqmgcXlHtJYQMCxZS6xa7JfPvutkt5mBneh07Yw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-dqCEZHz7dy5u0fZV1ILObnH2YCA+I6UHuOt7PLGb1NBEAAUbO251nOK9OfecZEEPsvMJRl3P9rNqdJmAvIcHTg==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-beta.17.tgz",
+      "integrity": "sha512-oKLiLZRomHyJ++367F286Er49TXazWofj1PbNFUBoRxNNLne8xlDHAypN+C9Yr+JfAIN9cRp8l1PdjwfwMsV8g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-OPEIqs/q2rTZWTJm8VVSsI9B2OgsKdtprKEqzw3L74tBGDwNRleCGxGxu2T3LUpPlOtQFkSCZTIh1M52/6PG0w==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-beta.17.tgz",
+      "integrity": "sha512-JDPvmiyLpXtTnpG6I9URF88bOF+7KVgpDvPvZVl9AMboQj+LW4Pp19QOhGzxGoKES6wBts8c4xM1zjtr0xHcQw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-oYrpDYpbRqv/pgqM1SJEN7w9oahCjj6Txatz7McMJ++CX0WyFqAChi3Zvxr06Vrte+OCWA86t6Ot8K+mKV0QAA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-beta.17.tgz",
+      "integrity": "sha512-7B02MUGEFzuJaMbhxtgNRSMOrbj+AlERBy1EBxrXHplHSwv8xQjJpiBk0Z+5+vQMDVS4zc8VIYgeP7CUyROpUg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/runtime-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "csstype": "^3.1.3"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/runtime-core": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/runtime-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-UdGN6tcXIMTD/OFR7qI8V+ID4lji7K5A90i68OjiCr8nevtGxjfYPB3Lz5Lg7S6sckPCnFTECHExzWOmE7aV0A==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-beta.17.tgz",
+      "integrity": "sha512-nJpdHuMOXMEmVUrRTEo4AEDPreBja9euIXHjvUe4aEk1pmTKs61hQRluAdETRyXZwkyFe6D6+fXxvKf5wPBJBg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
-        "@vue/runtime-dom": "3.6.0-alpha.2"
+        "@vue/runtime-dom": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-Zw+fX/FlRqfwzrv5EmCyLBN5bOZWsRo3SnxQKqPl1yA5xGDe+FIe9cjII/X7hlFdC9Vb4lmQBvOQSnTeTj8ygA==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-beta.17.tgz",
+      "integrity": "sha512-C7YpoWxewo01cG+S51MouH1v6taXBU5XvmxPjPAI3E9Zn3gpzb49e/ikShA5ov8ijE9R7tyIOUk4QU2xoDiT+Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-ssr": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
-        "vue": "3.6.0-alpha.2"
+        "vue": "3.6.0-beta.17"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-beta.17.tgz",
+      "integrity": "sha512-iuDH2UPBc8nzqgL4dcLiqpAJoJfQe70RcPM34+p+dVk0ThJD9jjpLPjzouP+RoRrXkAPOC7jmMncafdv69BGaA==",
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -1026,18 +1026,18 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
       "funding": [
         {
           "type": "opencollective",
@@ -1091,7 +1091,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1241,17 +1241,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-xn3jwLo6eMqxEKEAW8TWX+KSm7K2jTrNZ5Q3+H5Bu9P3mkoz8w0lUQHrO5WcnSVZfmR7vvw4/5XSYQe2XeDzdw==",
+      "version": "3.6.0-beta.17",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-beta.17.tgz",
+      "integrity": "sha512-sVvFEriOhBjKIi7Jy+vwnlcBVRKhvxMVG4lh2erX1vrlaNKggURyWttRF+z5Vo+6VYriVsXAUyOgaQZub0W8ug==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-sfc": "3.6.0-alpha.2",
-        "@vue/runtime-dom": "3.6.0-alpha.2",
-        "@vue/runtime-vapor": "3.6.0-alpha.2",
-        "@vue/server-renderer": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-dom": "3.6.0-beta.17",
+        "@vue/compiler-sfc": "3.6.0-beta.17",
+        "@vue/runtime-dom": "3.6.0-beta.17",
+        "@vue/runtime-vapor": "3.6.0-beta.17",
+        "@vue/server-renderer": "3.6.0-beta.17",
+        "@vue/shared": "3.6.0-beta.17"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/frameworks/non-keyed/vue-vapor/package.json
+++ b/frameworks/non-keyed/vue-vapor/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "3.6.0-alpha.2"
+    "vue": "^3.6.0-beta.17"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",

--- a/frameworks/non-keyed/vue/package-lock.json
+++ b/frameworks/non-keyed/vue/package-lock.json
@@ -8,7 +8,7 @@
       "name": "js-framework-benchmark-vue",
       "version": "0.0.0",
       "dependencies": {
-        "vue": "^3.6.0-alpha.2"
+        "vue": "^3.5.39"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.0",
@@ -16,30 +16,30 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -49,13 +49,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -504,9 +504,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
@@ -821,142 +821,115 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-2aPvrCWKKhKKU4TaX6N6+cY4LcLIlIc+tcxJHw029mZr7KGb/w+98UxU9o3mYe/CLo5c5v8ps4IlE/Tm4H/eZA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.6.0-alpha.2",
-        "entities": "^4.5.0",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-WHFo0z5QXXkBQk65NPrze1RO4RG6vAHcMudRG604zs2VsMkJPXBL5CAFcae3R6aoU3wwbIYHkklbMOelegS90w==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-QFwY1M5lYTo6Qt0rSQKXEp9aZngaKtT4WRlITAuioNeFoK5Y5stElr6sw2dopsaPzjbAJftDbQ7MgtMjOZ9XQg==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-core": "3.6.0-alpha.2",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/compiler-vapor": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-BtP+A4xL7QSCf/P1eOvJw9XG1wojK3nqjJXSABcwXeIv0SJgBpi4CZ/obVUPAiUWMmdJDV3bdSwqQtkiXqOmug==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
-      }
-    },
-    "node_modules/@vue/compiler-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/qmhrcOrVmBsZiQEpDMH5coH/hx7v1uflKCXDcvWhl7XaPfNWBeVwIndU/s/8mtOz+5nuCZrGtbqozXc4tfQzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-dqCEZHz7dy5u0fZV1ILObnH2YCA+I6UHuOt7PLGb1NBEAAUbO251nOK9OfecZEEPsvMJRl3P9rNqdJmAvIcHTg==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-OPEIqs/q2rTZWTJm8VVSsI9B2OgsKdtprKEqzw3L74tBGDwNRleCGxGxu2T3LUpPlOtQFkSCZTIh1M52/6PG0w==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-oYrpDYpbRqv/pgqM1SJEN7w9oahCjj6Txatz7McMJ++CX0WyFqAChi3Zvxr06Vrte+OCWA86t6Ot8K+mKV0QAA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/runtime-core": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2",
-        "csstype": "^3.1.3"
-      }
-    },
-    "node_modules/@vue/runtime-vapor": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-UdGN6tcXIMTD/OFR7qI8V+ID4lji7K5A90i68OjiCr8nevtGxjfYPB3Lz5Lg7S6sckPCnFTECHExzWOmE7aV0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
-      },
-      "peerDependencies": {
-        "@vue/runtime-dom": "3.6.0-alpha.2"
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-Zw+fX/FlRqfwzrv5EmCyLBN5bOZWsRo3SnxQKqPl1yA5xGDe+FIe9cjII/X7hlFdC9Vb4lmQBvOQSnTeTj8ygA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
-        "vue": "3.6.0-alpha.2"
+        "vue": "3.5.39"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -1044,18 +1017,18 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -1090,9 +1063,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
       "funding": [
         {
           "type": "opencollective",
@@ -1109,7 +1082,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1259,17 +1232,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-alpha.2.tgz",
-      "integrity": "sha512-xn3jwLo6eMqxEKEAW8TWX+KSm7K2jTrNZ5Q3+H5Bu9P3mkoz8w0lUQHrO5WcnSVZfmR7vvw4/5XSYQe2XeDzdw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-alpha.2",
-        "@vue/compiler-sfc": "3.6.0-alpha.2",
-        "@vue/runtime-dom": "3.6.0-alpha.2",
-        "@vue/runtime-vapor": "3.6.0-alpha.2",
-        "@vue/server-renderer": "3.6.0-alpha.2",
-        "@vue/shared": "3.6.0-alpha.2"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/frameworks/non-keyed/vue/package.json
+++ b/frameworks/non-keyed/vue/package.json
@@ -15,7 +15,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.6.0-alpha.2"
+    "vue": "^3.5.39"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",


### PR DESCRIPTION
Use version 3.5.39  for standard Vue mode.
Use version 3.6.0-beta.17 for Vapor mode.