### PR TITLE
spark-html (keyed): bump to 1.8.1

### DIFF
--- a/frameworks/keyed/spark-html/package-lock.json
+++ b/frameworks/keyed/spark-html/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "js-framework-benchmark-spark-html",
-  "version": "1.7.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-framework-benchmark-spark-html",
-      "version": "1.7.0",
+      "version": "1.8.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "spark-html": "^1.7.0"
+        "spark-html": "^1.8.1"
       },
       "devDependencies": {
         "spark-html-bun": "^1.0.0"
       }
     },
     "node_modules/spark-html": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/spark-html/-/spark-html-1.7.0.tgz",
-      "integrity": "sha512-RFteeQQl1CxGwcQEFQmm6e3kqrm7q/8G1jSKcvEBxdt7ExXNPDNcUAmMA9FZQlJfOb0XroZZidr1xdwXchPRUQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/spark-html/-/spark-html-1.8.1.tgz",
+      "integrity": "sha512-N4DE14/QWFEEhCSMGwoK4kdcx/hPswemgGL4Wmk2WHuvKbaLepHKFstJEXB+PkC9EZT8g9HTfRgPP4B26GSBjA==",
       "license": "MIT",
       "bin": {
         "spark-html": "bin/cli.js"

--- a/frameworks/keyed/spark-html/package.json
+++ b/frameworks/keyed/spark-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-framework-benchmark-spark-html",
-  "version": "1.7.0",
+  "version": "1.8.1",
   "description": "spark-html keyed benchmark",
   "js-framework-benchmark": {
     "frameworkVersionFromPackage": "spark-html",
@@ -14,7 +14,7 @@
     "build-prod": "spark build --out-dir dist --base /frameworks/keyed/spark-html/dist/"
   },
   "dependencies": {
-    "spark-html": "^1.7.0"
+    "spark-html": "^1.8.1"
   },
   "devDependencies": {
     "spark-html-bun": "^1.0.0"
@@ -22,4 +22,3 @@
   "author": "",
   "license": "Apache-2.0"
 }
-


### PR DESCRIPTION
Bumps the spark-html keyed implementation from 1.7.0 → 1.8.1 (dependency + lockfile). No implementation-code changes — the app builds unchanged (`build-prod` verified locally with 1.8.1).

Thanks again for running #2048! The results you posted were for v1.7.0 (geomean 1.32). The releases since then target exactly the ops that were spark-html’s weakest there:

- **1.8.0** — in-place array/object mutation of a top-level state value now rides a narrow dirty-key update lane instead of a full component pass. This directly improves **partial update** (the "every 10th row" op, spark-html’s worst relative factor at 1.57 in the v1.7.0 run) and helps **swap rows**.
- **1.8.1** — a correctness fix (same-event `bind:` + `onXXX` handler ordering); no perf change.

The runtime is still the same single no-build 18 KB-gzip artifact, API-frozen for 1.x — so this is a safe drop-in re-benchmark. Would appreciate a re-run when convenient. 🙏