### PR TITLE
Update Ripple to 0.3.112

### DIFF
--- a/frameworks/keyed/ripple/package-lock.json
+++ b/frameworks/keyed/ripple/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "ripple": "0.3.65"
+        "ripple": "0.3.112"
       },
       "devDependencies": {
-        "@ripple-ts/vite-plugin": "0.3.65",
+        "@ripple-ts/vite-plugin": "0.3.112",
         "terser": "^5.46.1",
         "vite": "^8.0.14"
       }
@@ -142,21 +142,21 @@
       }
     },
     "node_modules/@ripple-ts/adapter": {
-      "version": "0.3.65",
-      "resolved": "https://registry.npmjs.org/@ripple-ts/adapter/-/adapter-0.3.65.tgz",
-      "integrity": "sha512-E9XQvj94K0ym+6zY3vc1JMouxznwELu6L36gXXrBZP1ZHIZ8SpWTm4sDiQKCRxNA2hxPpodyDLX7NjNRnjePfQ==",
+      "version": "0.3.112",
+      "resolved": "https://registry.npmjs.org/@ripple-ts/adapter/-/adapter-0.3.112.tgz",
+      "integrity": "sha512-Yt7rO48zmy2HTnxRevS19MuJbOLkPlcS6RqnBaVrOA43lrgU4EY4+rWcFkjCvIEINEhWSM8R9gu6xkpWK8a5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@ripple-ts/vite-plugin": {
-      "version": "0.3.65",
-      "resolved": "https://registry.npmjs.org/@ripple-ts/vite-plugin/-/vite-plugin-0.3.65.tgz",
-      "integrity": "sha512-hFR+gg+lW0a5k5h5EN5CQJhlKWyxFv/50Ie6W3DEUweHG/Kphezb6UPRuj3CJVGZiN4rlOIpVJyJea08wqFgkQ==",
+      "version": "0.3.112",
+      "resolved": "https://registry.npmjs.org/@ripple-ts/vite-plugin/-/vite-plugin-0.3.112.tgz",
+      "integrity": "sha512-W0CS7k1jRk7P4X3ku5tnDV6m341Qc1X/7mXkLoogktrTQEWRXMCbn0i1u/IDcDnHK2uEKP6Iv8U6u36jVCZoFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ripple-ts/adapter": "0.3.65",
-        "@tsrx/ripple": "0.1.13"
+        "@ripple-ts/adapter": "0.3.112",
+        "@tsrx/ripple": "0.1.51"
       },
       "bin": {
         "ripple-preview": "src/bin/preview.js"
@@ -427,40 +427,40 @@
       "license": "MIT"
     },
     "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
-      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
+      "integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
       }
     },
     "node_modules/@tsrx/core": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@tsrx/core/-/core-0.1.13.tgz",
-      "integrity": "sha512-CpachOxyUIbf+0q6zWJfI1RFpHdo6ZIy0v62qzW72WfW+tPtg8w0f9wFrA0AwhgpO8AFJtT5oNerXpScVMagOQ==",
+      "version": "0.1.50",
+      "resolved": "https://registry.npmjs.org/@tsrx/core/-/core-0.1.50.tgz",
+      "integrity": "sha512-s5oZWG9FQpyMGbnoM5or9/OBb0etUDzkVQuq4lIPFp8aYAb/mEA2m9GYRGq8nlsyAztVvqku3huQXwlXZT0m7g==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5",
         "@noble/hashes": "^2.2.0",
-        "@sveltejs/acorn-typescript": "^1.0.9",
+        "@sveltejs/acorn-typescript": "^1.0.11",
         "@types/estree": "^1.0.8",
         "@types/estree-jsx": "^1.0.5",
-        "acorn": "^8.15.0",
-        "esrap": "^2.2.8",
+        "acorn": "^8.17.0",
+        "esrap": "^2.3.0",
         "is-reference": "^3.0.3",
         "magic-string": "^0.30.18",
         "zimmerframe": "^1.1.2"
       }
     },
     "node_modules/@tsrx/ripple": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@tsrx/ripple/-/ripple-0.1.13.tgz",
-      "integrity": "sha512-HzqqFdN9PiWbXe7f/UV6c1Vz5/I/b2ypokpcK1VAO9c1xwy0aHham73Gunr3AumUU0RCfHq6/KTfkCmiM/jaUQ==",
+      "version": "0.1.51",
+      "resolved": "https://registry.npmjs.org/@tsrx/ripple/-/ripple-0.1.51.tgz",
+      "integrity": "sha512-nKpvC3GoMDH28Du+TxKf+h8ojlcvSw6CgYENj351viYwxC/CG0yYl6m68Hz8Q40Rw80phK8ikLNC9eMQX22j2g==",
       "license": "MIT",
       "dependencies": {
-        "@tsrx/core": "0.1.13",
-        "esrap": "^2.2.8",
+        "@tsrx/core": "0.1.50",
+        "esrap": "^2.3.0",
         "is-reference": "^3.0.3",
         "zimmerframe": "^1.1.2"
       }
@@ -492,9 +492,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -549,9 +549,9 @@
       "license": "MIT"
     },
     "node_modules/esrap": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
-      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.0.tgz",
+      "integrity": "sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -946,13 +946,13 @@
       }
     },
     "node_modules/ripple": {
-      "version": "0.3.65",
-      "resolved": "https://registry.npmjs.org/ripple/-/ripple-0.3.65.tgz",
-      "integrity": "sha512-8pP4CBomj/LWvg6pufL5AnqTYW53bsXm76qA81ft7byXRFvqccsM7F7wuDNSFCvJmb7Tt/HT9ZnVCX3EQ9C3/A==",
+      "version": "0.3.112",
+      "resolved": "https://registry.npmjs.org/ripple/-/ripple-0.3.112.tgz",
+      "integrity": "sha512-Yfy/Waag7wkWe4wKBO9rGe8zD7Ktmx+vVQx+zcG1gum0KcT04FUxJ1eZPYT95RfRacN/Au6Dmkyv8Y6AQa8NUQ==",
       "license": "MIT",
       "dependencies": {
-        "@tsrx/core": "0.1.13",
-        "@tsrx/ripple": "0.1.13",
+        "@tsrx/core": "0.1.50",
+        "@tsrx/ripple": "0.1.51",
         "clsx": "^2.1.1",
         "devalue": "^5.8.1",
         "esm-env": "^1.2.2"

--- a/frameworks/keyed/ripple/package.json
+++ b/frameworks/keyed/ripple/package.json
@@ -24,10 +24,10 @@
     "url": "https://github.com/krausest/js-framework-benchmark.git"
   },
   "dependencies": {
-    "ripple": "0.3.65"
+    "ripple": "0.3.112"
   },
   "devDependencies": {
-    "@ripple-ts/vite-plugin": "0.3.65",
+    "@ripple-ts/vite-plugin": "0.3.112",
     "terser": "^5.46.1",
     "vite": "^8.0.14"
   }

--- a/frameworks/keyed/ripple/src/Main.tsrx
+++ b/frameworks/keyed/ripple/src/Main.tsrx
@@ -65,7 +65,7 @@ interface Row {
   label: Tracked<string>;
 }
 
-export default component App() {
+export default function App() @{
   let rowId = 1;
   const items = track<Row[]>([]);
   const selected = track<number | undefined>(undefined);
@@ -123,38 +123,38 @@ export default component App() {
     <div class="jumbotron">
       <div class="row">
         <div class="col-md-6">
-          <h1>{"Ripple"}</h1>
+          <h1>Ripple</h1>
         </div>
         <div class="col-md-6">
           <div class="row">
             <div class="col-sm-6 smallpad">
               <button type="button" class="btn btn-primary btn-block" id="run" onClick={run}>
-                {"Create 1,000 rows"}
+                Create 1,000 rows
               </button>
             </div>
             <div class="col-sm-6 smallpad">
               <button type="button" class="btn btn-primary btn-block" id="runlots" onClick={runLots}>
-                {"Create 10,000 rows"}
+                Create 10,000 rows
               </button>
             </div>
             <div class="col-sm-6 smallpad">
               <button type="button" class="btn btn-primary btn-block" id="add" onClick={add}>
-                {"Append 1,000 rows"}
+                Append 1,000 rows
               </button>
             </div>
             <div class="col-sm-6 smallpad">
               <button type="button" class="btn btn-primary btn-block" id="update" onClick={partialUpdate}>
-                {"Update every 10th row"}
+                Update every 10th row
               </button>
             </div>
             <div class="col-sm-6 smallpad">
               <button type="button" class="btn btn-primary btn-block" id="clear" onClick={clear}>
-                {"Clear"}
+                Clear
               </button>
             </div>
             <div class="col-sm-6 smallpad">
               <button type="button" class="btn btn-primary btn-block" id="swaprows" onClick={swapRows}>
-                {"Swap Rows"}
+                Swap Rows
               </button>
             </div>
           </div>
@@ -163,13 +163,13 @@ export default component App() {
     </div>
     <table class="table table-hover table-striped test-data">
       <tbody>
-        for (const row of items.value) {
+        @for (const row of items.value) {
           const id = row.id;
 
           <tr class={selected.value === id ? 'danger' : ''}>
-            <td class="col-md-1">{text id}</td>
+            <td class="col-md-1">{id}</td>
             <td class="col-md-4">
-              <a onClick={() => { selected.value = id; }}>{text row.label.value}</a>
+              <a onClick={() => { selected.value = id; }}>{row.label.value}</a>
             </td>
             <td class="col-md-1">
               <a onClick={() => remove(row)}>

--- a/frameworks/keyed/ripple/src/Main.tsrx
+++ b/frameworks/keyed/ripple/src/Main.tsrx
@@ -167,9 +167,9 @@ export default function App() @{
           const id = row.id;
 
           <tr class={selected.value === id ? 'danger' : ''}>
-            <td class="col-md-1">{id}</td>
+            <td class="col-md-1">{id as string}</td>
             <td class="col-md-4">
-              <a onClick={() => { selected.value = id; }}>{row.label.value}</a>
+              <a onClick={() => { selected.value = id; }}>{row.label.value as string}</a>
             </td>
             <td class="col-md-1">
               <a onClick={() => remove(row)}>


### PR DESCRIPTION
- update `ripple` and `@ripple-ts/vite-plugin` from 0.3.65 to 0.3.112
- migrate the benchmark component to the current TSRX function, statement-container, `@for`, text, and expression syntax