### PR TITLE
Add keyed domphy implementation

### DIFF
--- a/frameworks/keyed/domphy/README.md
+++ b/frameworks/keyed/domphy/README.md
@@ -1,0 +1,25 @@
+# Domphy — keyed implementation
+
+[Domphy](https://domphy.com/) is a patch-based, framework-agnostic UI runtime.
+No JSX, no virtual DOM: UIs are plain objects keyed by HTML tag and reactivity
+is listener-based (`toState`).
+
+This implementation uses the framework's idiomatic fine-grained style:
+
+- one keyed `State<Row[]>` for the row list (`_key` per row drives the keyed
+  reconciler),
+- per-row `label` states, so "update every 10th row" re-renders only those
+  rows' text,
+- one table-level `selected` id state; each row derives its `danger` class
+  from it,
+- row element descriptors are created once per row and reused across list
+  re-renders, so unchanged rows skip patching on reorder/remove.
+
+## Build
+
+```
+npm install
+npm run build-prod
+```
+
+This bundles `src/main.ts` with esbuild into `dist/main.js`.

--- a/frameworks/keyed/domphy/index.html
+++ b/frameworks/keyed/domphy/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>Domphy-keyed</title>
+    <link href="/css/currentStyle.css" rel="stylesheet"/>
+</head>
+<body>
+<div id='main'></div>
+<script src='dist/main.js'></script>
+</body>
+</html>

--- a/frameworks/keyed/domphy/package-lock.json
+++ b/frameworks/keyed/domphy/package-lock.json
@@ -1,0 +1,518 @@
+{
+  "name": "js-framework-benchmark-domphy",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "js-framework-benchmark-domphy",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@domphy/core": "^0.21.1"
+      },
+      "devDependencies": {
+        "esbuild": "0.25.12"
+      }
+    },
+    "node_modules/@domphy/core": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@domphy/core/-/core-0.21.1.tgz",
+      "integrity": "sha512-hxBV66cbD37QI6lUrQhaBggnK6LIHue68sL53g6VK1guLB7jTCxhi57OlQsgDLx3oZ23Bykb4B1vm73oEfjQuA==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    }
+  }
+}

--- a/frameworks/keyed/domphy/package.json
+++ b/frameworks/keyed/domphy/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "js-framework-benchmark-domphy",
+  "version": "1.0.0",
+  "description": "Domphy keyed demo",
+  "type": "module",
+  "main": "dist/main.js",
+  "js-framework-benchmark": {
+    "frameworkVersionFromPackage": "@domphy/core",
+    "frameworkHomeURL": "https://domphy.com/",
+    "language": "TypeScript"
+  },
+  "scripts": {
+    "dev": "esbuild src/main.ts --bundle --format=iife --outfile=dist/main.js",
+    "build-prod": "esbuild src/main.ts --bundle --minify --format=iife --outfile=dist/main.js"
+  },
+  "author": "Huu Khanh Nguyen",
+  "license": "MIT",
+  "homepage": "https://github.com/krausest/js-framework-benchmark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krausest/js-framework-benchmark.git"
+  },
+  "dependencies": {
+    "@domphy/core": "^0.21.1"
+  },
+  "devDependencies": {
+    "esbuild": "0.25.12"
+  }
+}

--- a/frameworks/keyed/domphy/src/main.ts
+++ b/frameworks/keyed/domphy/src/main.ts
@@ -1,0 +1,270 @@
+// js-framework-benchmark keyed implementation for Domphy (@domphy/core).
+//
+// Idiomatic fine-grained Domphy style:
+//   - one keyed `State<Row[]>` for the row list (rows carry `_key`),
+//   - per-row `label` states so "update every 10th row" touches only those
+//     rows' text (no list re-render, like solid's per-row signals),
+//   - one table-level `selected` id state (per benchmark rules); each row
+//     derives its `danger` class from it,
+//   - each row's element descriptor is created once per row and reused
+//     across list re-renders, so unchanged rows skip patching entirely.
+//
+// DOM structure mirrors frameworks/keyed/vanillajs:
+//   tr > td.col-md-1 (id) + td.col-md-4 > a (label)
+//      + td.col-md-1 > a > span.glyphicon-remove + td.col-md-6
+// Selected row: tr.danger.
+
+import type { DomphyElement } from "@domphy/core";
+import { ElementNode, toState } from "@domphy/core";
+
+// ---------------------------------------------------------------------------
+// Data generation (verbatim from the krausest reference implementations)
+// ---------------------------------------------------------------------------
+
+function _random(max: number): number {
+  return Math.round(Math.random() * 1000) % max;
+}
+
+const ADJECTIVES = [
+  "pretty",
+  "large",
+  "big",
+  "small",
+  "tall",
+  "short",
+  "long",
+  "handsome",
+  "plain",
+  "quaint",
+  "clean",
+  "elegant",
+  "easy",
+  "angry",
+  "crazy",
+  "helpful",
+  "mushy",
+  "odd",
+  "unsightly",
+  "adorable",
+  "important",
+  "inexpensive",
+  "cheap",
+  "expensive",
+  "fancy",
+];
+const COLOURS = [
+  "red",
+  "yellow",
+  "blue",
+  "green",
+  "pink",
+  "brown",
+  "purple",
+  "brown",
+  "white",
+  "black",
+  "orange",
+];
+const NOUNS = [
+  "table",
+  "chair",
+  "house",
+  "bbq",
+  "desk",
+  "car",
+  "pony",
+  "cookie",
+  "sandwich",
+  "burger",
+  "pizza",
+  "mouse",
+  "keyboard",
+];
+
+let nextId = 1;
+
+interface Row {
+  id: number;
+  label: ReturnType<typeof toState<string>>;
+}
+
+function buildData(count: number): Row[] {
+  const data: Row[] = [];
+  for (let i = 0; i < count; i++) {
+    data.push({
+      id: nextId++,
+      label: toState(
+        ADJECTIVES[_random(ADJECTIVES.length)] +
+          " " +
+          COLOURS[_random(COLOURS.length)] +
+          " " +
+          NOUNS[_random(NOUNS.length)],
+      ),
+    });
+  }
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Store: one keyed list state + one selected-id state
+// ---------------------------------------------------------------------------
+
+const data = toState<Row[]>([]);
+const selected = toState<number | null>(null);
+
+function run(count: number): void {
+  selected.set(null);
+  data.set(buildData(count));
+}
+
+function add(count: number): void {
+  data.set(data.get().concat(buildData(count)));
+}
+
+function update(): void {
+  const rows = data.get();
+  for (let i = 0; i < rows.length; i += 10) {
+    const label = rows[i].label;
+    label.set(label.get() + " !!!");
+  }
+}
+
+function clear(): void {
+  selected.set(null);
+  data.set([]);
+}
+
+function remove(row: Row): void {
+  if (selected.get() === row.id) selected.set(null);
+  data.set(data.get().filter((r) => r !== row));
+}
+
+function swapRows(): void {
+  const rows = data.get();
+  if (rows.length < 999) return;
+  const next = rows.slice();
+  const tmp = next[1];
+  next[1] = next[998];
+  next[998] = tmp;
+  data.set(next);
+}
+
+// ---------------------------------------------------------------------------
+// Row rendering — one stable descriptor per row (created once, reused across
+// list re-renders so unchanged rows are skipped by the keyed reconciler)
+// ---------------------------------------------------------------------------
+
+const REMOVE_ICON: DomphyElement = {
+  span: null,
+  class: "glyphicon glyphicon-remove",
+  "aria-hidden": "true",
+} as DomphyElement;
+
+const elementCache = new WeakMap<Row, DomphyElement>();
+
+function elementFor(row: Row): DomphyElement {
+  let element = elementCache.get(row);
+  if (element) return element;
+  element = {
+    tr: [
+      { td: row.id, class: "col-md-1" },
+      {
+        td: [
+          {
+            a: (l: any) => row.label.get(l),
+            onClick: () => selected.set(row.id),
+          },
+        ],
+        class: "col-md-4",
+      },
+      {
+        td: [
+          {
+            a: [REMOVE_ICON],
+            onClick: () => remove(row),
+          },
+        ],
+        class: "col-md-1",
+      },
+      { td: null, class: "col-md-6" },
+    ],
+    _key: row.id,
+    class: (l: any) => (selected.get(l) === row.id ? "danger" : ""),
+  } as DomphyElement;
+  elementCache.set(row, element);
+  return element;
+}
+
+// ---------------------------------------------------------------------------
+// Page scaffold (mirrors the krausest index.html structure) + mount
+// ---------------------------------------------------------------------------
+
+function actionButton(
+  id: string,
+  label: string,
+  onClick: () => void,
+): DomphyElement {
+  return {
+    div: [
+      {
+        button: label,
+        type: "button",
+        class: "btn btn-primary btn-block",
+        id,
+        onClick,
+      },
+    ],
+    class: "col-sm-6 smallpad",
+  } as DomphyElement;
+}
+
+const App: DomphyElement = {
+  div: [
+    {
+      div: [
+        {
+          div: [
+            { div: [{ h1: 'Domphy-"keyed"' }], class: "col-md-6" },
+            {
+              div: [
+                {
+                  div: [
+                    actionButton("run", "Create 1,000 rows", () => run(1000)),
+                    actionButton("runlots", "Create 10,000 rows", () =>
+                      run(10000),
+                    ),
+                    actionButton("add", "Append 1,000 rows", () => add(1000)),
+                    actionButton("update", "Update every 10th row", update),
+                    actionButton("clear", "Clear", clear),
+                    actionButton("swaprows", "Swap Rows", swapRows),
+                  ],
+                  class: "row",
+                },
+              ],
+              class: "col-md-6",
+            },
+          ],
+          class: "row",
+        },
+      ],
+      class: "jumbotron",
+    },
+    {
+      table: [
+        {
+          tbody: (l: any) => data.get(l).map(elementFor),
+          id: "tbody",
+        },
+      ],
+      class: "table table-hover table-striped test-data",
+    },
+    {
+      span: null,
+      class: "preloadicon glyphicon glyphicon-remove",
+      "aria-hidden": "true",
+    },
+  ],
+  class: "container",
+} as DomphyElement;
+
+new ElementNode(App).render(document.getElementById("main")!);


### PR DESCRIPTION
## Summary

Adds a keyed implementation for **Domphy** (`@domphy/core` 0.21.1, published on npm) — a patch-based, framework-agnostic UI runtime: plain-object element trees keyed by HTML tag, listener-based fine-grained reactivity, no JSX, no virtual DOM.

- Implementation notes: one keyed `State<Row[]>` list with `_key` per row; per-row `label` states so `update every 10th` touches only those rows; a single table-level `selected` id state (per the contribution notes on selection style); per-row descriptors cached so unchanged rows skip patching. Markup mirrors `frameworks/keyed/vanillajs` including the `aria-hidden` / glyphicon preload span.
- `npm install && npm run build-prod` installs purely from npm (lockfile included, `@domphy/core` 0.21.1 from the registry).
- `isKeyed` check passes (keyed for run / remove row / swap rows); official webdriver-ts playwright runner completed with a successful plausibility check.

Local measurement (official runner, headless Chrome on Windows, no throttling — indicative only): select/swap/remove/update land within ~0.95–1.6× of vanillajs-keyed; create/clear ops at ~2–3.4×. Full numbers available on request; a re-run on the reference hardware will be more meaningful.

Project: https://github.com/domphy/domphy · https://domphy.com
