### PR TITLE
fix(svelte): build with the production export condition

### DIFF
--- a/frameworks/keyed/svelte-classic/rollup.config.js
+++ b/frameworks/keyed/svelte-classic/rollup.config.js
@@ -3,7 +3,8 @@ import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 
 const plugins = [
-  resolve({ browser: true }),
+  // without the `production` condition, `esm-env` keeps the whole dev runtime in the bundle
+  resolve({ browser: true, exportConditions: ['production'] }),
   svelte({
     emitCss: false,
   }),

--- a/frameworks/keyed/svelte/rollup.config.js
+++ b/frameworks/keyed/svelte/rollup.config.js
@@ -3,7 +3,8 @@ import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 
 const plugins = [
-  resolve({ browser: true }),
+  // without the `production` condition, `esm-env` keeps the whole dev runtime in the bundle
+  resolve({ browser: true, exportConditions: ['production'] }),
   svelte({
     emitCss: false,
   }),

--- a/frameworks/non-keyed/svelte-classic/rollup.config.js
+++ b/frameworks/non-keyed/svelte-classic/rollup.config.js
@@ -3,7 +3,8 @@ import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 
 const plugins = [
-  resolve({ browser: true }),
+  // without the `production` condition, `esm-env` keeps the whole dev runtime in the bundle
+  resolve({ browser: true, exportConditions: ['production'] }),
   svelte({
     emitCss: false,
   }),


### PR DESCRIPTION
Without `production` in the export conditions, `esm-env` resolves to its dev fallback, which reads `process.env.NODE_ENV` at runtime. `DEV` then stops being a compile-time constant, so terser keeps every `if (DEV)` branch and the whole Svelte development runtime ends up in the production bundle.

Reduces the brotli-compressed bundle by ~18-20% for keyed/svelte, keyed/svelte-classic and non-keyed/svelte-classic.