### PR TITLE
chore(vue): drop data-label and delegate the per-row click handlers

### DIFF
--- a/frameworks/keyed/vue-jsx-vapor/src/App.jsx
+++ b/frameworks/keyed/vue-jsx-vapor/src/App.jsx
@@ -106,7 +106,7 @@ export default defineComponent({
 
         <table class="table table-hover table-striped test-data">
           <tbody>
-            <tr v-for={ctx in rows.value} key={ctx.id} class={{ danger: ctx.id === selected.value }} data-label={ctx.label.value}>
+            <tr v-for={ctx in rows.value} key={ctx.id} class={{ danger: ctx.id === selected.value }}>
               <td class="col-md-1" v-text={ctx.id} />
               <td class="col-md-4">
                 <a onClick={() => select(ctx.id)} v-text={ctx.label.value} />

--- a/frameworks/keyed/vue-vapor/package-lock.json
+++ b/frameworks/keyed/vue-vapor/package-lock.json
@@ -8,7 +8,7 @@
       "name": "js-framework-benchmark-vue-vapor",
       "version": "1.0.0",
       "dependencies": {
-        "vue": "^3.6.0-beta.17"
+        "vue": "^3.6.0-rc.5"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.0",
@@ -34,12 +34,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -804,130 +804,128 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-beta.17.tgz",
-      "integrity": "sha512-4xB2W8+00h7bfHbVeHD+zI+bmyF+XgQBKCCWLjFJ/VCJ/1tBjnlzWpX0OqcOE78LktGiCGcKgNk+eZAuav5cqg==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-rc.5.tgz",
+      "integrity": "sha512-OSOzR/4Mk8TMStNxFLFwcVjgFvvMGvlKEpboxv9W4ikQhsVLKEMTtzBVY5A11qwb6zGuwWJdCOeME5npmpURiQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@vue/shared": "3.6.0-beta.17",
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.6.0-rc.5",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-beta.17.tgz",
-      "integrity": "sha512-viCM7YwHK6HuQ9rY8O27ET1xLi9WeJ+EmMWlwvtggpqb2j+l7DZOATkCRXOivjTOqtt8h5MIGnlB7tQlupQgeA==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-rc.5.tgz",
+      "integrity": "sha512-QBONzGYH7o448rwz+8FUWW4Gm4Zw0EtNhtRooOw/KDFF+/hWz1VlGIpvU9Hjv5MXDMMCu+UsLXEYFtXTSHgIwg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17"
+        "@vue/compiler-core": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-beta.17.tgz",
-      "integrity": "sha512-L3KGWeWDCqm1tL03m09IXKRhIEh0Ij2gEIax9W0smDtlCAQt4gc8dmeTbjTOg4+1N2qAFEaAs+0xVu9y1j7Sng==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-rc.5.tgz",
+      "integrity": "sha512-o/IH60kRS8C06ek3tullJhm4sK3T6aDXQa8Dgq7qLxRCa5gXrIZMDO9+mZYy0THxAiTZs2tc/XwnKu0JqmSKRw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@vue/compiler-core": "3.6.0-beta.17",
-        "@vue/compiler-dom": "3.6.0-beta.17",
-        "@vue/compiler-ssr": "3.6.0-beta.17",
-        "@vue/compiler-vapor": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17",
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.6.0-rc.5",
+        "@vue/compiler-dom": "3.6.0-rc.5",
+        "@vue/compiler-ssr": "3.6.0-rc.5",
+        "@vue/compiler-vapor": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.14",
+        "postcss": "^8.5.19",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-beta.17.tgz",
-      "integrity": "sha512-OWBt5fu62UGeGTcl3Ra5ocMZbJ3h8ze862g9GlS72CNsYYZTbh3V9LePoOp6WX73SdsSdbsWLSsZfi5Wgh+ggQ==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-rc.5.tgz",
+      "integrity": "sha512-KBsxaO538LZeNARcaYeEwOE0Fl/gw2mEYB9+hK/Hrk7yUCq4WeS9V32HL84SiTY4S6WXrcKP0pXB6zW6zvjB6w==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17"
+        "@vue/compiler-dom": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5"
       }
     },
     "node_modules/@vue/compiler-vapor": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-beta.17.tgz",
-      "integrity": "sha512-8qqHnEwQVytCnaF9zSOtcZxnYxz+FJqBNl9zIpSKwKRStl4XqmgcXlHtJYQMCxZS6xa7JfPvutkt5mBneh07Yw==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-rc.5.tgz",
+      "integrity": "sha512-UXnYH+4NhPmEmlWcHuiR+KjfpZCuG1CBkWXTSH5720p2jRGzuEGiMUAx7CtMXyIJ0QZwdzDV09xFs35zsgJeYA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@vue/compiler-dom": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17",
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-dom": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-beta.17.tgz",
-      "integrity": "sha512-oKLiLZRomHyJ++367F286Er49TXazWofj1PbNFUBoRxNNLne8xlDHAypN+C9Yr+JfAIN9cRp8l1PdjwfwMsV8g==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-rc.5.tgz",
+      "integrity": "sha512-FcTNjZwCU4VPAv7W/EJD/ckatgxFJ20jU6S2dGmJC9RS08HAvKB/IjtCQaE7HBuIC4oXQnnahkNuilrDFt0BWA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.6.0-beta.17"
+        "@vue/shared": "3.6.0-rc.5"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-beta.17.tgz",
-      "integrity": "sha512-JDPvmiyLpXtTnpG6I9URF88bOF+7KVgpDvPvZVl9AMboQj+LW4Pp19QOhGzxGoKES6wBts8c4xM1zjtr0xHcQw==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-rc.5.tgz",
+      "integrity": "sha512-NiT9xl/ndkTHASfQ9AjxDjTiClIZRmsIWb0orlKNnjHn6C09PNZX4V/c0Aewtlg8bouarpnV6JLbpg16gYMBJA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17"
+        "@vue/reactivity": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-beta.17.tgz",
-      "integrity": "sha512-7B02MUGEFzuJaMbhxtgNRSMOrbj+AlERBy1EBxrXHplHSwv8xQjJpiBk0Z+5+vQMDVS4zc8VIYgeP7CUyROpUg==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-rc.5.tgz",
+      "integrity": "sha512-E5A1z7UEoPvAmIpZopSJ5ji8A1wuP2cFHVc41ZN2w32FWV3CxFQVJG3VNSHwFs8lBQ8Ji5SDnkMCfJXHVzt0iQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-beta.17",
-        "@vue/runtime-core": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17",
+        "@vue/reactivity": "3.6.0-rc.5",
+        "@vue/runtime-core": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/runtime-vapor": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-beta.17.tgz",
-      "integrity": "sha512-nJpdHuMOXMEmVUrRTEo4AEDPreBja9euIXHjvUe4aEk1pmTKs61hQRluAdETRyXZwkyFe6D6+fXxvKf5wPBJBg==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-rc.5.tgz",
+      "integrity": "sha512-OmBf4R/SJ11h9ZXrpPThddh2SqTmyc9eCBLFSmH1rhfr/sVFMrrcxMXjFOX1Rn+Nlqiuf9pUx/hYwG2gY2uJHA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17"
+        "@vue/reactivity": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5"
       },
       "peerDependencies": {
-        "@vue/runtime-dom": "3.6.0-beta.17"
+        "@vue/runtime-dom": "3.6.0-rc.5"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-beta.17.tgz",
-      "integrity": "sha512-C7YpoWxewo01cG+S51MouH1v6taXBU5XvmxPjPAI3E9Zn3gpzb49e/ikShA5ov8ijE9R7tyIOUk4QU2xoDiT+Q==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-rc.5.tgz",
+      "integrity": "sha512-esb8yrZjymuMO7Wqjp62B2cFCGvL1AkmlIp8KBsKowG+BOqzemOJHz1yhK7Tf3KE0LIEatDP/Gb4FZo+S/LwyQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17"
-      },
-      "peerDependencies": {
-        "vue": "3.6.0-beta.17"
+        "@vue/compiler-ssr": "3.6.0-rc.5",
+        "@vue/runtime-dom": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-beta.17.tgz",
-      "integrity": "sha512-iuDH2UPBc8nzqgL4dcLiqpAJoJfQe70RcPM34+p+dVk0ThJD9jjpLPjzouP+RoRrXkAPOC7jmMncafdv69BGaA==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-rc.5.tgz",
+      "integrity": "sha512-2dQ2+xAv7USEKgM5ckB2PrNc4pBcqYNCmkk8/RQtbpxpNDK0RvH0c9vG4rgqsvFS4wy3RXyj2ZfoAhldkgZ2dw==",
       "license": "MIT"
     },
     "node_modules/csstype": {
@@ -1035,9 +1033,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -1072,9 +1070,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
-      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1091,7 +1089,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1241,17 +1239,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-beta.17.tgz",
-      "integrity": "sha512-sVvFEriOhBjKIi7Jy+vwnlcBVRKhvxMVG4lh2erX1vrlaNKggURyWttRF+z5Vo+6VYriVsXAUyOgaQZub0W8ug==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-rc.5.tgz",
+      "integrity": "sha512-yM+CHEWSTc9FjJGIeViI86VVheHvJ3YaZrrXqlD7wX3S+8tNPR/vDMviGOv4ULIMTkzWWKWVRvylsytXbHBbNA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-beta.17",
-        "@vue/compiler-sfc": "3.6.0-beta.17",
-        "@vue/runtime-dom": "3.6.0-beta.17",
-        "@vue/runtime-vapor": "3.6.0-beta.17",
-        "@vue/server-renderer": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17"
+        "@vue/compiler-dom": "3.6.0-rc.5",
+        "@vue/compiler-sfc": "3.6.0-rc.5",
+        "@vue/runtime-dom": "3.6.0-rc.5",
+        "@vue/runtime-vapor": "3.6.0-rc.5",
+        "@vue/server-renderer": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/frameworks/keyed/vue-vapor/package.json
+++ b/frameworks/keyed/vue-vapor/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.6.0-beta.17"
+    "vue": "^3.6.0-rc.5"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",

--- a/frameworks/keyed/vue-vapor/src/App.vue
+++ b/frameworks/keyed/vue-vapor/src/App.vue
@@ -96,14 +96,13 @@ function swapRows() {
         v-for="row of rows"
         :key="row.id"
         :class="{ danger: row.id === selected }"
-        :data-label="row.label.value"
       >
         <td class="col-md-1">{{ row.id }}</td>
         <td class="col-md-4">
-          <a @click="select(row.id)">{{ row.label.value }}</a>
+          <a @click.delegate="select(row.id)">{{ row.label.value }}</a>
         </td>
         <td class="col-md-1">
-          <a @click="remove(row.id)">
+          <a @click.delegate="remove(row.id)">
             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
           </a>
         </td>

--- a/frameworks/keyed/vue/src/App.vue
+++ b/frameworks/keyed/vue/src/App.vue
@@ -138,7 +138,6 @@ function swapRows() {
         v-for="{ id, label } of rows"
         :key="id"
         :class="{ danger: id === selected }"
-        :data-label="label"
         v-memo="[label, id === selected]"
       >
         <td class="col-md-1">{{ id }}</td>

--- a/frameworks/non-keyed/vue-jsx-vapor/src/App.jsx
+++ b/frameworks/non-keyed/vue-jsx-vapor/src/App.jsx
@@ -106,7 +106,7 @@ export default defineComponent({
 
         <table class="table table-hover table-striped test-data">
           <tbody>
-            <tr v-for={ctx in rows.value} class={{ danger: ctx.id === selected.value }} data-label={ctx.label.value}>
+            <tr v-for={ctx in rows.value} class={{ danger: ctx.id === selected.value }}>
               <td class="col-md-1" v-text={ctx.id} />
               <td class="col-md-4">
                 <a onClick={() => select(ctx.id)} v-text={ctx.label.value} />

--- a/frameworks/non-keyed/vue-vapor/package-lock.json
+++ b/frameworks/non-keyed/vue-vapor/package-lock.json
@@ -8,7 +8,7 @@
       "name": "js-framework-benchmark-vue-vapor",
       "version": "1.0.0",
       "dependencies": {
-        "vue": "^3.6.0-beta.17"
+        "vue": "^3.6.0-rc.5"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.0",
@@ -34,12 +34,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -804,130 +804,128 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-beta.17.tgz",
-      "integrity": "sha512-4xB2W8+00h7bfHbVeHD+zI+bmyF+XgQBKCCWLjFJ/VCJ/1tBjnlzWpX0OqcOE78LktGiCGcKgNk+eZAuav5cqg==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-rc.5.tgz",
+      "integrity": "sha512-OSOzR/4Mk8TMStNxFLFwcVjgFvvMGvlKEpboxv9W4ikQhsVLKEMTtzBVY5A11qwb6zGuwWJdCOeME5npmpURiQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@vue/shared": "3.6.0-beta.17",
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.6.0-rc.5",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-beta.17.tgz",
-      "integrity": "sha512-viCM7YwHK6HuQ9rY8O27ET1xLi9WeJ+EmMWlwvtggpqb2j+l7DZOATkCRXOivjTOqtt8h5MIGnlB7tQlupQgeA==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-rc.5.tgz",
+      "integrity": "sha512-QBONzGYH7o448rwz+8FUWW4Gm4Zw0EtNhtRooOw/KDFF+/hWz1VlGIpvU9Hjv5MXDMMCu+UsLXEYFtXTSHgIwg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17"
+        "@vue/compiler-core": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-beta.17.tgz",
-      "integrity": "sha512-L3KGWeWDCqm1tL03m09IXKRhIEh0Ij2gEIax9W0smDtlCAQt4gc8dmeTbjTOg4+1N2qAFEaAs+0xVu9y1j7Sng==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-rc.5.tgz",
+      "integrity": "sha512-o/IH60kRS8C06ek3tullJhm4sK3T6aDXQa8Dgq7qLxRCa5gXrIZMDO9+mZYy0THxAiTZs2tc/XwnKu0JqmSKRw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@vue/compiler-core": "3.6.0-beta.17",
-        "@vue/compiler-dom": "3.6.0-beta.17",
-        "@vue/compiler-ssr": "3.6.0-beta.17",
-        "@vue/compiler-vapor": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17",
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.6.0-rc.5",
+        "@vue/compiler-dom": "3.6.0-rc.5",
+        "@vue/compiler-ssr": "3.6.0-rc.5",
+        "@vue/compiler-vapor": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.14",
+        "postcss": "^8.5.19",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-beta.17.tgz",
-      "integrity": "sha512-OWBt5fu62UGeGTcl3Ra5ocMZbJ3h8ze862g9GlS72CNsYYZTbh3V9LePoOp6WX73SdsSdbsWLSsZfi5Wgh+ggQ==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-rc.5.tgz",
+      "integrity": "sha512-KBsxaO538LZeNARcaYeEwOE0Fl/gw2mEYB9+hK/Hrk7yUCq4WeS9V32HL84SiTY4S6WXrcKP0pXB6zW6zvjB6w==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17"
+        "@vue/compiler-dom": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5"
       }
     },
     "node_modules/@vue/compiler-vapor": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-beta.17.tgz",
-      "integrity": "sha512-8qqHnEwQVytCnaF9zSOtcZxnYxz+FJqBNl9zIpSKwKRStl4XqmgcXlHtJYQMCxZS6xa7JfPvutkt5mBneh07Yw==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-rc.5.tgz",
+      "integrity": "sha512-UXnYH+4NhPmEmlWcHuiR+KjfpZCuG1CBkWXTSH5720p2jRGzuEGiMUAx7CtMXyIJ0QZwdzDV09xFs35zsgJeYA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@vue/compiler-dom": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17",
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-dom": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-beta.17.tgz",
-      "integrity": "sha512-oKLiLZRomHyJ++367F286Er49TXazWofj1PbNFUBoRxNNLne8xlDHAypN+C9Yr+JfAIN9cRp8l1PdjwfwMsV8g==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-rc.5.tgz",
+      "integrity": "sha512-FcTNjZwCU4VPAv7W/EJD/ckatgxFJ20jU6S2dGmJC9RS08HAvKB/IjtCQaE7HBuIC4oXQnnahkNuilrDFt0BWA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.6.0-beta.17"
+        "@vue/shared": "3.6.0-rc.5"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-beta.17.tgz",
-      "integrity": "sha512-JDPvmiyLpXtTnpG6I9URF88bOF+7KVgpDvPvZVl9AMboQj+LW4Pp19QOhGzxGoKES6wBts8c4xM1zjtr0xHcQw==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-rc.5.tgz",
+      "integrity": "sha512-NiT9xl/ndkTHASfQ9AjxDjTiClIZRmsIWb0orlKNnjHn6C09PNZX4V/c0Aewtlg8bouarpnV6JLbpg16gYMBJA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17"
+        "@vue/reactivity": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-beta.17.tgz",
-      "integrity": "sha512-7B02MUGEFzuJaMbhxtgNRSMOrbj+AlERBy1EBxrXHplHSwv8xQjJpiBk0Z+5+vQMDVS4zc8VIYgeP7CUyROpUg==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-rc.5.tgz",
+      "integrity": "sha512-E5A1z7UEoPvAmIpZopSJ5ji8A1wuP2cFHVc41ZN2w32FWV3CxFQVJG3VNSHwFs8lBQ8Ji5SDnkMCfJXHVzt0iQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-beta.17",
-        "@vue/runtime-core": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17",
+        "@vue/reactivity": "3.6.0-rc.5",
+        "@vue/runtime-core": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/runtime-vapor": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-beta.17.tgz",
-      "integrity": "sha512-nJpdHuMOXMEmVUrRTEo4AEDPreBja9euIXHjvUe4aEk1pmTKs61hQRluAdETRyXZwkyFe6D6+fXxvKf5wPBJBg==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-rc.5.tgz",
+      "integrity": "sha512-OmBf4R/SJ11h9ZXrpPThddh2SqTmyc9eCBLFSmH1rhfr/sVFMrrcxMXjFOX1Rn+Nlqiuf9pUx/hYwG2gY2uJHA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17"
+        "@vue/reactivity": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5"
       },
       "peerDependencies": {
-        "@vue/runtime-dom": "3.6.0-beta.17"
+        "@vue/runtime-dom": "3.6.0-rc.5"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-beta.17.tgz",
-      "integrity": "sha512-C7YpoWxewo01cG+S51MouH1v6taXBU5XvmxPjPAI3E9Zn3gpzb49e/ikShA5ov8ijE9R7tyIOUk4QU2xoDiT+Q==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-rc.5.tgz",
+      "integrity": "sha512-esb8yrZjymuMO7Wqjp62B2cFCGvL1AkmlIp8KBsKowG+BOqzemOJHz1yhK7Tf3KE0LIEatDP/Gb4FZo+S/LwyQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17"
-      },
-      "peerDependencies": {
-        "vue": "3.6.0-beta.17"
+        "@vue/compiler-ssr": "3.6.0-rc.5",
+        "@vue/runtime-dom": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-beta.17.tgz",
-      "integrity": "sha512-iuDH2UPBc8nzqgL4dcLiqpAJoJfQe70RcPM34+p+dVk0ThJD9jjpLPjzouP+RoRrXkAPOC7jmMncafdv69BGaA==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-rc.5.tgz",
+      "integrity": "sha512-2dQ2+xAv7USEKgM5ckB2PrNc4pBcqYNCmkk8/RQtbpxpNDK0RvH0c9vG4rgqsvFS4wy3RXyj2ZfoAhldkgZ2dw==",
       "license": "MIT"
     },
     "node_modules/csstype": {
@@ -1035,9 +1033,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -1072,9 +1070,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
-      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1091,7 +1089,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1241,17 +1239,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.6.0-beta.17",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-beta.17.tgz",
-      "integrity": "sha512-sVvFEriOhBjKIi7Jy+vwnlcBVRKhvxMVG4lh2erX1vrlaNKggURyWttRF+z5Vo+6VYriVsXAUyOgaQZub0W8ug==",
+      "version": "3.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.6.0-rc.5.tgz",
+      "integrity": "sha512-yM+CHEWSTc9FjJGIeViI86VVheHvJ3YaZrrXqlD7wX3S+8tNPR/vDMviGOv4ULIMTkzWWKWVRvylsytXbHBbNA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.6.0-beta.17",
-        "@vue/compiler-sfc": "3.6.0-beta.17",
-        "@vue/runtime-dom": "3.6.0-beta.17",
-        "@vue/runtime-vapor": "3.6.0-beta.17",
-        "@vue/server-renderer": "3.6.0-beta.17",
-        "@vue/shared": "3.6.0-beta.17"
+        "@vue/compiler-dom": "3.6.0-rc.5",
+        "@vue/compiler-sfc": "3.6.0-rc.5",
+        "@vue/runtime-dom": "3.6.0-rc.5",
+        "@vue/runtime-vapor": "3.6.0-rc.5",
+        "@vue/server-renderer": "3.6.0-rc.5",
+        "@vue/shared": "3.6.0-rc.5"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/frameworks/non-keyed/vue-vapor/package.json
+++ b/frameworks/non-keyed/vue-vapor/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.6.0-beta.17"
+    "vue": "^3.6.0-rc.5"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",

--- a/frameworks/non-keyed/vue-vapor/src/App.vue
+++ b/frameworks/non-keyed/vue-vapor/src/App.vue
@@ -95,14 +95,13 @@ function swapRows() {
       <tr
         v-for="row of rows"
         :class="{ danger: selected === row.id }"
-        :data-label="row.label.value"
       >
         <td class="col-md-1">{{ row.id }}</td>
         <td class="col-md-4">
-          <a @click="select(row.id)">{{ row.label.value }}</a>
+          <a @click.delegate="select(row.id)">{{ row.label.value }}</a>
         </td>
         <td class="col-md-1">
-          <a @click="remove(row.id)">
+          <a @click.delegate="remove(row.id)">
             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
           </a>
         </td>

--- a/frameworks/non-keyed/vue/src/App.vue
+++ b/frameworks/non-keyed/vue/src/App.vue
@@ -137,7 +137,6 @@ function swapRows() {
       <tr
         v-for="{ id, label } of rows"
         :class="{ danger: id === selected }"
-        :data-label="label"
         v-memo="[label, id === selected]"
       >
         <td class="col-md-1">{{ id }}</td>


### PR DESCRIPTION
### Why `data-label` is removed

The `<tr>` in the Vue implementations carried a `:data-label="label"` binding
that no other implementation has. Out of 253 implementations in this repo, only
the Vue-family entries (and alins) have it — the vanillajs reference row is just
`<td class='col-md-1'>…` with no data attribute, and nothing in the repo reads it:
not the test driver, not the results app, not the CSS.